### PR TITLE
mainへのブランチ保護CIを追加　

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,34 @@
+name: Branch Protection
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-branch-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch policy for main
+        run: |
+          # PRのソースブランチを取得
+          SOURCE_BRANCH="${{ github.head_ref }}"
+          echo "ソースブランチ: $SOURCE_BRANCH"
+          
+          # mainブランチへのマージを許可するブランチパターン
+          if [[ "$SOURCE_BRANCH" == "develop" || "$SOURCE_BRANCH" =~ ^hotfix/ ]]; then
+            echo "✅ 許可されたブランチからのマージです"
+            echo "ブランチ: $SOURCE_BRANCH → main"
+          else
+            echo "❌ このブランチからmainへの直接マージは許可されていません"
+            echo "ブランチ: $SOURCE_BRANCH → main"
+            echo ""
+            echo "📋 正しい手順:"
+            echo "1. feature/* や bugfix/* ブランチは、まずdevelopブランチにマージしてください"
+            echo "2. developブランチから安定版をmainにマージしてください"
+            echo "3. 緊急修正の場合は、hotfix/* ブランチからmainに直接マージ可能です"
+            echo ""
+            echo "許可されるブランチパターン:"
+            echo "- develop"
+            echo "- hotfix/*"
+            exit 1
+          fi


### PR DESCRIPTION
## 概要
mainへのブランチ保護CIを追加しました。

## 詳細
`develop`, `hotfix/*`以外のブランチからの`main`へのマージをブロックします。

## 動作確認
内部変数を変更しての確認済み。

## 確認項目
- [x] 動作確認を実施している
- [x] issueはPRページ右下のDevelopmentからissueが紐づいている
