### PR TITLE
localで立ち上げたアプリを他のデバイスからアクセスできるようにvscodeの設定を修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,5 +32,19 @@
     "source=gemini-cli-config,target=/home/vscode/.gemini,type=volume"
   ],
   "postCreateCommand": [".devcontainer/postCreateCommand.sh"],
-  "forwardPorts": [3000, 8000, 5432]
+  "forwardPorts": [3000, 8000, 5432, 5173],
+  "portsAttributes": {
+    "3000": {
+      "label": "Frontend",
+    },
+    "8000": {
+      "label": "Backend",
+    },
+    "5432": {
+      "label": "PostgreSQL",
+    },
+    "5173": {
+      "label": "Vite",
+    }
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,5 +41,6 @@
     ["cva\\(([^;]*)[\\);]", "[`'\"`]([^'\"`;]*)[`'\"`]"],
     ["(?:twMerge|twJoin)\\(([^;]*)[\\);]", "[`'\"`]([^'\"`;]*)[`'\"`]"]
   ],
-  "cSpell.words": ["shadcn"]
+  "cSpell.words": ["shadcn"],
+  "remote.localPortHost": "allInterfaces",
 }


### PR DESCRIPTION
## 概要
アプリケーションのPWA化に伴って、ローカルPCで立ち上げたアプリケーションをモバイルで表示して、動作確認できるように設定しました。

## 詳細
- vscodeのsettings.jsonを修正
- devcontainer.jsonにportのラベルを追加

## 動作確認
<details><summary>フロントに変更がある場合、画像を添付すること</summary>
<img width="1080" height="2400" alt="Screenshot_20250814-005248" src="https://github.com/user-attachments/assets/d4527340-12e2-439b-a517-f0a4cc487f68" />

</details> 


## 確認項目
- [ ] 動作確認を実施している
  - [ ] devcontainerをbuildする
  - [ ] npm run devを実行する
  - [ ] 自分のルーターから割り当てられたIPを調べる(macの場合は `ifconfig | grep "inet "`を実行すればわかる)
  - [ ] 同じネットワークに繋がっている端末から、`http://${自分のIP}:5173`をブラウザから叩くとアプリケーションが見れる
- [ ] issueはPRページ右下のDevelopmentからissueが紐づいている
