### PR TITLE
refactor: serverコードの品質改善

### DIFF
--- a/server/app/cruds/pages.py
+++ b/server/app/cruds/pages.py
@@ -24,7 +24,7 @@ async def create_page(db: AsyncSession, page: PageCreate, trip_id: int) -> Page:
     return db_page
 
 
-async def get_pages(db: AsyncSession, trip_id: int) -> list[Page]:
+async def find_pages(db: AsyncSession, trip_id: int) -> list[Page]:
     """
     特定の旅行プランに関連するすべてのページを取得する関数
 
@@ -33,7 +33,7 @@ async def get_pages(db: AsyncSession, trip_id: int) -> list[Page]:
         trip_id (int): 旅行プランのID
 
     Returns:
-        List[Page]: ページリスト
+        list[Page]: ページリスト
     """
     result = await db.execute(select(Page).where(Page.trip_id == trip_id))
     return list(result.scalars().all())

--- a/server/app/cruds/trips.py
+++ b/server/app/cruds/trips.py
@@ -24,7 +24,7 @@ async def create_trip(db: AsyncSession, trip: TripCreateIn, url_id: str) -> int:
     return db_trip.id
 
 
-async def list_trips(db: AsyncSession) -> list[Trip]:
+async def find_trips(db: AsyncSession) -> list[Trip]:
     """
     すべての旅行プランを取得する関数
 

--- a/server/app/errors.py
+++ b/server/app/errors.py
@@ -53,7 +53,7 @@ class ErrorResponseException(Exception):
         self,
         message: str,
         code: str,
-        detail: dict[str, Any] | None = {},
+        detail: dict[str, Any] | None = None,
         description: str = "",
     ):
         self.message = message

--- a/server/app/errors.py
+++ b/server/app/errors.py
@@ -75,6 +75,29 @@ class ErrorResponseException(Exception):
         )
 
 
+class NotFound(ErrorResponseException):
+    """
+    リソースが見つからない場合のエラー
+
+    Attributes:
+      response_status (int): HTTP ステータスコード
+    """
+
+    response_status = status.HTTP_404_NOT_FOUND
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "not_found",
+        detail: dict[str, Any] | None = None,
+        description: str = "",
+    ):
+        self.message = message
+        self.code = code
+        self.detail = detail
+        self.description = description
+
+
 class InvalidParam(ErrorResponseException):
     """
     無効なパラメータに対するエラー

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -32,7 +32,9 @@ app = FastAPI(
 _http_basic = HTTPBasic()
 
 
-def _verify_api_docs_auth(credentials: HTTPBasicCredentials = Depends(_http_basic)) -> None:
+def _verify_api_docs_auth(
+    credentials: HTTPBasicCredentials = Depends(_http_basic),
+) -> None:
     """
     説明:
 
@@ -91,6 +93,7 @@ async def openapi_schema(
         get_openapi(title=app.title, version=app.version, routes=app.routes)
     )
 
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
@@ -110,7 +113,9 @@ app.add_exception_handler(RequestValidationError, validation_exception_handler)
 
 
 @app.get("/health", tags=["Health"])
-async def health_check(delay: float = Query(0, ge=0, le=30, description="デバッグ用: レスポンス遅延(秒)")):
+async def health_check(
+    delay: float = Query(0, ge=0, le=30, description="デバッグ用: レスポンス遅延(秒)"),
+):
     """Renderのヘルスチェック用エンドポイント"""
     if delay > 0:
         await asyncio.sleep(delay)

--- a/server/app/routers/blocks.py
+++ b/server/app/routers/blocks.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cruds import blocks as blocks_cruds
 from app.cruds import pages as pages_cruds
@@ -16,7 +16,7 @@ router = APIRouter(tags=["Blocks"])
     response_model=Block,
 )
 async def create_block(
-    page_id: int, block: BlockCreate, db: Session = Depends(get_db_session)
+    page_id: int, block: BlockCreate, db: AsyncSession = Depends(get_db_session)
 ) -> Block:
     """
     説明:
@@ -37,7 +37,7 @@ async def create_block(
     response_model=list[Block],
 )
 async def get_blocks(
-    page_id: int, db: Session = Depends(get_db_session)
+    page_id: int, db: AsyncSession = Depends(get_db_session)
 ) -> list[Block]:
     """
     説明:
@@ -53,7 +53,7 @@ async def get_blocks(
     operation_id="blocks-get",
     response_model=Block,
 )
-async def get_block(block_id: int, db: Session = Depends(get_db_session)) -> Block:
+async def get_block(block_id: int, db: AsyncSession = Depends(get_db_session)) -> Block:
     """
     説明:
 
@@ -73,7 +73,7 @@ async def get_block(block_id: int, db: Session = Depends(get_db_session)) -> Blo
     response_model=Block,
 )
 async def update_block(
-    block_id: int, block: BlockUpdate, db: Session = Depends(get_db_session)
+    block_id: int, block: BlockUpdate, db: AsyncSession = Depends(get_db_session)
 ) -> Block:
     """
     説明:
@@ -93,7 +93,7 @@ async def update_block(
     operation_id="blocks-delete",
     status_code=204,
 )
-async def delete_block(block_id: int, db: Session = Depends(get_db_session)) -> None:
+async def delete_block(block_id: int, db: AsyncSession = Depends(get_db_session)) -> None:
     """
     説明:
 

--- a/server/app/routers/blocks.py
+++ b/server/app/routers/blocks.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cruds import blocks as blocks_cruds
 from app.cruds import pages as pages_cruds
 from app.db_connection import get_db_session
+from app.errors import NotFound
 from app.schemas.block import Block, BlockCreate, BlockUpdate
 
 router = APIRouter(tags=["Blocks"])
@@ -25,7 +26,7 @@ async def create_block(
     """
     db_page = await pages_cruds.get_page(db, page_id=page_id)
     if db_page is None:
-        raise HTTPException(status_code=404, detail="Page not found")
+        raise NotFound(message="Page not found")
 
     return await blocks_cruds.create_block(db=db, block=block, page_id=page_id)
 
@@ -61,7 +62,7 @@ async def get_block(block_id: int, db: AsyncSession = Depends(get_db_session)) -
     """
     db_block = await blocks_cruds.get_block(db, block_id=block_id)
     if db_block is None:
-        raise HTTPException(status_code=404, detail="Block not found")
+        raise NotFound(message="Block not found")
 
     return db_block
 
@@ -82,7 +83,7 @@ async def update_block(
     """
     db_block = await blocks_cruds.update_block(db, block_id=block_id, block=block)
     if db_block is None:
-        raise HTTPException(status_code=404, detail="Block not found")
+        raise NotFound(message="Block not found")
 
     return db_block
 
@@ -100,6 +101,6 @@ async def delete_block(block_id: int, db: AsyncSession = Depends(get_db_session)
     - IDで指定された単一のブロックを削除する
     """
     if not await blocks_cruds.delete_block(db, block_id=block_id):
-        raise HTTPException(status_code=404, detail="Block not found")
+        raise NotFound(message="Block not found")
 
     return

--- a/server/app/routers/blocks.py
+++ b/server/app/routers/blocks.py
@@ -94,7 +94,9 @@ async def update_block(
     operation_id="blocks-delete",
     status_code=204,
 )
-async def delete_block(block_id: int, db: AsyncSession = Depends(get_db_session)) -> None:
+async def delete_block(
+    block_id: int, db: AsyncSession = Depends(get_db_session)
+) -> None:
     """
     説明:
 

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cruds import pages as pages_cruds
 from app.cruds import trips as trips_cruds
@@ -18,7 +18,7 @@ router = APIRouter(tags=["Pages"])
     response_model=Page,
 )
 async def create_page(
-    trip_id: int, page: PageCreate, db: Session = Depends(get_db_session)
+    trip_id: int, page: PageCreate, db: AsyncSession = Depends(get_db_session)
 ) -> Page:
     """
     説明:
@@ -38,7 +38,7 @@ async def create_page(
     operation_id="pages-list",
     response_model=list[Page],
 )
-async def get_pages(trip_id: int, db: Session = Depends(get_db_session)) -> list[Page]:
+async def get_pages(trip_id: int, db: AsyncSession = Depends(get_db_session)) -> list[Page]:
     """
     説明:
 
@@ -53,7 +53,7 @@ async def get_pages(trip_id: int, db: Session = Depends(get_db_session)) -> list
     operation_id="pages-get",
     response_model=Page,
 )
-async def get_page(page_id: int, db: Session = Depends(get_db_session)) -> Page:
+async def get_page(page_id: int, db: AsyncSession = Depends(get_db_session)) -> Page:
     """
     説明:
 
@@ -73,7 +73,7 @@ async def get_page(page_id: int, db: Session = Depends(get_db_session)) -> Page:
     response_model=Page,
 )
 async def update_page(
-    page_id: int, page: PageUpdate, db: Session = Depends(get_db_session)
+    page_id: int, page: PageUpdate, db: AsyncSession = Depends(get_db_session)
 ) -> Page:
     """
     説明:
@@ -93,7 +93,7 @@ async def update_page(
     operation_id="pages-delete",
     status_code=204,
 )
-async def delete_page(page_id: int, db: Session = Depends(get_db_session)):
+async def delete_page(page_id: int, db: AsyncSession = Depends(get_db_session)):
     """
     説明:
 

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -45,7 +45,7 @@ async def get_pages(trip_id: int, db: AsyncSession = Depends(get_db_session)) ->
 
     - 特定の旅行プランに関連するすべてのページを取得する
     """
-    return await pages_cruds.get_pages(db=db, trip_id=trip_id)
+    return await pages_cruds.find_pages(db=db, trip_id=trip_id)
 
 
 @router.get(

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -39,7 +39,9 @@ async def create_page(
     operation_id="pages-list",
     response_model=list[Page],
 )
-async def get_pages(trip_id: int, db: AsyncSession = Depends(get_db_session)) -> list[Page]:
+async def get_pages(
+    trip_id: int, db: AsyncSession = Depends(get_db_session)
+) -> list[Page]:
     """
     説明:
 

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cruds import pages as pages_cruds
 from app.cruds import trips as trips_cruds
 from app.db_connection import get_db_session
+from app.errors import NotFound
 from app.schemas.page import Page, PageCreate, PageUpdate
 
 # /trips/{trip_id}/pages で作成と一覧取得
@@ -27,7 +28,7 @@ async def create_page(
     """
     db_trip = await trips_cruds.get_trip(db, trip_id=trip_id)
     if db_trip is None:
-        raise HTTPException(status_code=404, detail="Trip not found")
+        raise NotFound(message="Trip not found")
 
     return await pages_cruds.create_page(db=db, page=page, trip_id=trip_id)
 
@@ -61,7 +62,7 @@ async def get_page(page_id: int, db: AsyncSession = Depends(get_db_session)) -> 
     """
     db_page = await pages_cruds.get_page(db, page_id=page_id)
     if db_page is None:
-        raise HTTPException(status_code=404, detail="Page not found")
+        raise NotFound(message="Page not found")
 
     return db_page
 
@@ -82,7 +83,7 @@ async def update_page(
     """
     db_page = await pages_cruds.update_page(db, page_id=page_id, page=page)
     if db_page is None:
-        raise HTTPException(status_code=404, detail="Page not found")
+        raise NotFound(message="Page not found")
 
     return db_page
 
@@ -100,6 +101,6 @@ async def delete_page(page_id: int, db: AsyncSession = Depends(get_db_session)):
     - IDで指定された単一のページを削除する
     """
     if not await pages_cruds.delete_page(db, page_id=page_id):
-        raise HTTPException(status_code=404, detail="Page not found")
+        raise NotFound(message="Page not found")
 
     return

--- a/server/app/routers/trips.py
+++ b/server/app/routers/trips.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from nanoid import generate
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cruds import trips as trips_cruds
 from app.db_connection import get_db_session
+from app.errors import NotFound
 from app.schemas.trip import Trip, TripCreateIn, TripCreateOut, TripUpdate
 
 router = APIRouter(tags=["Trips"], prefix="/trips")
@@ -61,7 +62,7 @@ async def get_trip(trip_id: int, db: AsyncSession = Depends(get_db_session)) -> 
     """
     db_trip = await trips_cruds.get_trip(db, trip_id=trip_id)
     if db_trip is None:
-        raise HTTPException(status_code=404, detail="Trip not found")
+        raise NotFound(message="Trip not found")
 
     return db_trip
 
@@ -82,7 +83,7 @@ async def get_trip_by_url_id(
     """
     db_trip = await trips_cruds.get_trip_by_url_id(db, url_id=url_id)
     if db_trip is None:
-        raise HTTPException(status_code=404, detail="Trip not found")
+        raise NotFound(message="Trip not found")
 
     return db_trip
 
@@ -103,7 +104,7 @@ async def update_trip(
     """
     db_trip = await trips_cruds.update_trip(db, trip_id=trip_id, trip=trip_in)
     if db_trip is None:
-        raise HTTPException(status_code=404, detail="Trip not found")
+        raise NotFound(message="Trip not found")
 
     return db_trip
 
@@ -121,6 +122,6 @@ async def delete_trip(trip_id: int, db: AsyncSession = Depends(get_db_session)) 
     - IDで指定された単一の旅行プランを削除する
     """
     if not await trips_cruds.delete_trip(db, trip_id=trip_id):
-        raise HTTPException(status_code=404, detail="Trip not found")
+        raise NotFound(message="Trip not found")
 
     return

--- a/server/app/routers/trips.py
+++ b/server/app/routers/trips.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from nanoid import generate
-from sqlalchemy.orm.session import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cruds import trips as trips_cruds
 from app.db_connection import get_db_session
@@ -18,7 +18,7 @@ URL_ID_SIZE = 16
     response_model=TripCreateOut,
 )
 async def create_trip(
-    trip_in: TripCreateIn, db: Session = Depends(get_db_session)
+    trip_in: TripCreateIn, db: AsyncSession = Depends(get_db_session)
 ) -> TripCreateOut:
     """
     説明:
@@ -38,7 +38,7 @@ async def create_trip(
     operation_id="trips-list",
     response_model=list[Trip],
 )
-async def list_trips(db: Session = Depends(get_db_session)) -> list[Trip]:
+async def list_trips(db: AsyncSession = Depends(get_db_session)) -> list[Trip]:
     """
     説明:
 
@@ -53,7 +53,7 @@ async def list_trips(db: Session = Depends(get_db_session)) -> list[Trip]:
     operation_id="trips-get",
     response_model=Trip,
 )
-async def get_trip(trip_id: int, db: Session = Depends(get_db_session)) -> Trip:
+async def get_trip(trip_id: int, db: AsyncSession = Depends(get_db_session)) -> Trip:
     """
     説明:
 
@@ -73,7 +73,7 @@ async def get_trip(trip_id: int, db: Session = Depends(get_db_session)) -> Trip:
     response_model=Trip,
 )
 async def get_trip_by_url_id(
-    url_id: str, db: Session = Depends(get_db_session)
+    url_id: str, db: AsyncSession = Depends(get_db_session)
 ) -> Trip:
     """
     説明:
@@ -94,7 +94,7 @@ async def get_trip_by_url_id(
     response_model=Trip,
 )
 async def update_trip(
-    trip_id: int, trip_in: TripUpdate, db: Session = Depends(get_db_session)
+    trip_id: int, trip_in: TripUpdate, db: AsyncSession = Depends(get_db_session)
 ) -> Trip:
     """
     説明:
@@ -114,7 +114,7 @@ async def update_trip(
     operation_id="trips-delete",
     status_code=204,
 )
-async def delete_trip(trip_id: int, db: Session = Depends(get_db_session)) -> None:
+async def delete_trip(trip_id: int, db: AsyncSession = Depends(get_db_session)) -> None:
     """
     説明:
 

--- a/server/app/routers/trips.py
+++ b/server/app/routers/trips.py
@@ -45,7 +45,7 @@ async def list_trips(db: AsyncSession = Depends(get_db_session)) -> list[Trip]:
 
     - すべての旅行プランを取得する
     """
-    return await trips_cruds.list_trips(db=db)
+    return await trips_cruds.find_trips(db=db)
 
 
 @router.get(

--- a/server/tests/cruds/test_pages.py
+++ b/server/tests/cruds/test_pages.py
@@ -72,9 +72,9 @@ async def test_get_page(db_session: AsyncSession, test_create_trip: Trip):
 
 
 @pytest.mark.asyncio
-async def test_get_pages(db_session: AsyncSession, test_create_trip: Trip):
+async def test_find_pages(db_session: AsyncSession, test_create_trip: Trip):
     """
-    get_pages()/正常系
+    find_pages()/正常系
     """
     # arrange
     await pages_cruds.create_page(
@@ -85,7 +85,7 @@ async def test_get_pages(db_session: AsyncSession, test_create_trip: Trip):
     )
 
     # act
-    pages = await pages_cruds.get_pages(db=db_session, trip_id=test_create_trip.id)
+    pages = await pages_cruds.find_pages(db=db_session, trip_id=test_create_trip.id)
 
     # assert
     assert len(pages) == 2

--- a/server/tests/cruds/test_trips.py
+++ b/server/tests/cruds/test_trips.py
@@ -110,9 +110,9 @@ async def test_get_trip_by_url_id(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_list_trips(db_session: AsyncSession):
+async def test_find_trips(db_session: AsyncSession):
     """
-    list_trips()/正常系
+    find_trips()/正常系
     """
     # arrange
     await trips_cruds.create_trip(
@@ -123,7 +123,7 @@ async def test_list_trips(db_session: AsyncSession):
     )
 
     # act
-    trips = await trips_cruds.list_trips(db=db_session)
+    trips = await trips_cruds.find_trips(db=db_session)
 
     # assert
     assert len(trips) == 2

--- a/server/tests/routers/test_blocks_router.py
+++ b/server/tests/routers/test_blocks_router.py
@@ -128,7 +128,7 @@ async def test_create_block_non_existent_page(
     }
     response = await client.post("/pages/999/blocks", json=block_data)
     assert response.status_code == 404
-    assert response.json()["detail"] == "Page not found"
+    assert response.json()["message"] == "Page not found"
 
 
 async def test_read_blocks(
@@ -169,7 +169,7 @@ async def test_get_block_non_existent_id(client: AsyncClient, db_session: AsyncS
     """
     response = await client.get("/blocks/999")
     assert response.status_code == 404
-    assert response.json()["detail"] == "Block not found"
+    assert response.json()["message"] == "Block not found"
 
 
 async def test_update_block(
@@ -218,7 +218,7 @@ async def test_update_block_non_existent_id(
     }
     response = await client.put("/blocks/999", json=update_data)
     assert response.status_code == 404
-    assert response.json()["detail"] == "Block not found"
+    assert response.json()["message"] == "Block not found"
 
 
 async def test_update_block_invalid_input(

--- a/server/tests/routers/test_pages_router.py
+++ b/server/tests/routers/test_pages_router.py
@@ -53,7 +53,7 @@ async def test_create_page_non_existent_trip(
     page_data = {"title": "test page"}
     response = await client.post("/trips/999/pages", json=page_data)
     assert response.status_code == 404
-    assert response.json()["detail"] == "Trip not found"
+    assert response.json()["message"] == "Trip not found"
 
 
 async def test_read_pages(
@@ -78,7 +78,7 @@ async def test_get_page_non_existent_id(client: AsyncClient, db_session: AsyncSe
     """
     response = await client.get("/pages/999")
     assert response.status_code == 404
-    assert response.json()["detail"] == "Page not found"
+    assert response.json()["message"] == "Page not found"
 
 
 async def test_update_page(
@@ -105,7 +105,7 @@ async def test_update_page_non_existent_id(
     update_data = {"title": "non existent"}
     response = await client.put("/pages/999", json=update_data)
     assert response.status_code == 404
-    assert response.json()["detail"] == "Page not found"
+    assert response.json()["message"] == "Page not found"
 
 
 async def test_update_page_invalid_input(

--- a/server/tests/routers/test_trips_router.py
+++ b/server/tests/routers/test_trips_router.py
@@ -84,7 +84,7 @@ async def test_get_trip_non_existent_id(client: AsyncClient, db_session: AsyncSe
     """
     response = await client.get("/trips/999")
     assert response.status_code == 404
-    assert response.json()["detail"] == "Trip not found"
+    assert response.json()["message"] == "Trip not found"
 
 
 async def test_get_trip_by_url_id_non_existent(
@@ -95,7 +95,7 @@ async def test_get_trip_by_url_id_non_existent(
     """
     response = await client.get("/trips/url/non_existent_url")
     assert response.status_code == 404
-    assert response.json()["detail"] == "Trip not found"
+    assert response.json()["message"] == "Trip not found"
 
 
 async def test_update_trip(client: AsyncClient, db_session: AsyncSession):
@@ -126,7 +126,7 @@ async def test_update_trip_non_existent_id(
     update_data = {"title": "non existent", "detail": "update"}
     response = await client.put("/trips/999", json=update_data)
     assert response.status_code == 404
-    assert response.json()["detail"] == "Trip not found"
+    assert response.json()["message"] == "Trip not found"
 
 
 async def test_update_trip_invalid_input(client: AsyncClient, db_session: AsyncSession):


### PR DESCRIPTION
## 概要

serverディレクトリのコードを探索し、発見した問題点を修正・リファクタリングした。

## 詳細

### fix: ミュータブルデフォルト引数の修正
- `errors.py` の `ErrorResponseException.__init__` で `detail: dict | None = {}` となっており、Python のミュータブルデフォルト引数アンチパターンだった
- `= {}` → `= None` に変更

### fix: routersの型注釈修正（Session → AsyncSession）
- `routers/trips.py`, `routers/pages.py`, `routers/blocks.py` で同期版の `Session` をimportしていたが、実際にDIされるのは非同期の `AsyncSession`
- 全ルーターの型注釈を `AsyncSession` に統一

### feat: NotFound例外追加・HTTPException(404)の統一
- 各ルーターで `HTTPException(status_code=404)` と `ErrorResponseException` サブクラスが混在していた
- `NotFound` クラスを `errors.py` に追加し、404エラーのレスポンス形式を統一
  - 変更前: `{"detail": "Trip not found"}`
  - 変更後: `{"message": "Trip not found", "code": "not_found", "detail": null}`

### refactor: 複数件取得関数のfind_*への命名統一
- 命名ルール: 複数件取得 → `find_*` / 1件取得 → `get_*`
- `cruds/trips.py`: `list_trips()` → `find_trips()`
- `cruds/pages.py`: `get_pages()` → `find_pages()`
- 呼び出し元のrouters・testsも合わせて更新

## 動作確認

PostgreSQL コンテナを起動して全52件のテストがパスすることを確認。

## 確認項目
- [x] 動作確認を実施している
- [x] issueはPRページ右下のDevelopmentからissueが紐づいている