### PR TITLE
fix: 同一開始時刻ブロックのタイムライン表示改善

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -26,3 +26,4 @@ paths:
 
 - テストファイルはテスト対象と同ディレクトリに `*.test.ts` / `*.test.tsx` として配置（コロケーション方式）
 - テスト名（describe/itの説明文）は日本語で記述
+- テストファイル内では非nullアサーション (`!`) を許可（`biome.json` の overrides で `noNonNullAssertion` を off 設定）。`querySelector` の結果に対し `expect(...).not.toBeNull()` の直後で `!` を使う形が標準

--- a/biome.json
+++ b/biome.json
@@ -130,5 +130,17 @@
       "enabled": true,
       "indentStyle": "space"
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/frontend/src/components/timeline/DottedLine.tsx
+++ b/frontend/src/components/timeline/DottedLine.tsx
@@ -1,0 +1,10 @@
+import { cn } from '@/lib/utils';
+
+export const DottedLine = ({ className, ...rest }: React.ComponentProps<'div'>) => {
+  return (
+    <div className={cn('flex h-8 flex-row pe-2.5 sm:pe-3.5', className)} {...rest}>
+      <div className='grow border-neutral-600 border-r-2 border-dashed' />
+      <div className='border-neutral-600 border-l-2 border-dashed'></div>
+    </div>
+  );
+};

--- a/frontend/src/components/timeline/GroupTimelineRow.tsx
+++ b/frontend/src/components/timeline/GroupTimelineRow.tsx
@@ -1,0 +1,62 @@
+import type { Block } from '@/types/block';
+import { BlockScheduleView } from '../blocks/view/BlockScheduleView';
+import { BlockTransportationView } from '../blocks/view/BlockTransportationView';
+import { formatTime } from './formatTime';
+import { TimelineAxis } from './TimelineAxis';
+import type { OverlapGroup } from './ViewTimeline';
+
+interface GroupTimelineRowProps {
+  group: OverlapGroup;
+  isConnectedWithNext: boolean;
+  isLastItem: boolean;
+}
+
+const renderBlock = (block: Block) => {
+  switch (block.type) {
+    case 'schedule':
+      return <BlockScheduleView block={block} />;
+    case 'transportation':
+      return <BlockTransportationView block={block} />;
+    default:
+      return null;
+  }
+};
+
+export function GroupTimelineRow({ group, isConnectedWithNext, isLastItem }: GroupTimelineRowProps) {
+  const hasSchedule = group.blocks.some(b => b.type === 'schedule');
+  const themeColor = hasSchedule ? 'bg-teal-400' : 'bg-sky-200';
+  // 2件以上のときだけグルーピングコンテナで囲む（単一ブロックはそのまま表示）
+  const useContainer = group.blocks.length >= 2;
+
+  return (
+    <div className='contents'>
+      <TimelineAxis
+        startTime={group.groupStart}
+        endTime={group.groupEnd}
+        isConnectedWithNext={isConnectedWithNext}
+        isLastItem={isLastItem}
+        themeColor={themeColor}
+      />
+      <div className='flex flex-col gap-2 pb-4'>
+        {group.headerBlock && renderBlock(group.headerBlock)}
+
+        {group.containerBlocks.length > 0 &&
+          (useContainer ? (
+            <div className='flex flex-col gap-3 rounded-xl bg-neutral-100/60 p-3'>
+              {group.containerBlocks.map(block => (
+                <div key={block.id}>
+                  <div className='mb-1 font-medium text-12px text-neutral-500'>
+                    {formatTime(block.startTime)}
+                    {block.endTime && `–${formatTime(block.endTime)}`}
+                  </div>
+                  {renderBlock(block)}
+                </div>
+              ))}
+            </div>
+          ) : (
+            group.containerBlocks.map(block => <div key={block.id}>{renderBlock(block)}</div>)
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/timeline/Timeline.stories.tsx
+++ b/frontend/src/components/timeline/Timeline.stories.tsx
@@ -92,3 +92,119 @@ export const EditMode: Story = {
     type: 'edit',
   },
 };
+
+// --- 重なりケース ---
+
+/** ケース1: 同一開始時刻 + nullあり（ユーザーの例） */
+export const OverlappingSameStart: Story = {
+  args: {
+    blocks: [
+      {
+        id: 1,
+        type: 'schedule',
+        title: '温泉旅館チェックイン',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: new Date(2024, 0, 1, 11, 0),
+        pageId: 1,
+        location: null,
+      },
+      {
+        id: 2,
+        type: 'schedule',
+        title: 'お土産購入',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: null,
+        pageId: 1,
+        location: null,
+      },
+      {
+        id: 3,
+        type: 'transportation',
+        transportationType: 'car',
+        title: '駐車場まで移動',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: new Date(2024, 0, 1, 10, 30),
+        pageId: 1,
+        location: null,
+        destinationLocation: null,
+      },
+    ] satisfies Block[],
+    type: 'view',
+  },
+};
+
+/** ケース2: 同一開始時刻・nullなし */
+export const OverlappingNoNull: Story = {
+  args: {
+    blocks: [
+      {
+        id: 1,
+        type: 'transportation',
+        transportationType: 'car',
+        title: '駐車場まで移動',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: new Date(2024, 0, 1, 10, 30),
+        pageId: 1,
+        location: null,
+        destinationLocation: null,
+      },
+      {
+        id: 2,
+        type: 'schedule',
+        title: '温泉旅館チェックイン',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: new Date(2024, 0, 1, 11, 0),
+        pageId: 1,
+        location: null,
+      },
+    ] satisfies Block[],
+    type: 'view',
+  },
+};
+
+/** ケース3: グループ + gap + 単独ブロック */
+export const OverlappingWithGap: Story = {
+  args: {
+    blocks: [
+      {
+        id: 1,
+        type: 'schedule',
+        title: 'お土産購入',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: null,
+        pageId: 1,
+        location: null,
+      },
+      {
+        id: 2,
+        type: 'transportation',
+        transportationType: 'car',
+        title: '駐車場まで移動',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: new Date(2024, 0, 1, 10, 30),
+        pageId: 1,
+        location: null,
+        destinationLocation: null,
+      },
+      {
+        id: 3,
+        type: 'schedule',
+        title: '温泉旅館チェックイン',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: new Date(2024, 0, 1, 11, 0),
+        pageId: 1,
+        location: null,
+      },
+      {
+        id: 4,
+        type: 'schedule',
+        title: 'ランチ',
+        startTime: new Date(2024, 0, 1, 12, 0),
+        endTime: new Date(2024, 0, 1, 14, 0),
+        pageId: 1,
+        location: null,
+      },
+    ] satisfies Block[],
+    type: 'view',
+  },
+};

--- a/frontend/src/components/timeline/TimelineAxis.tsx
+++ b/frontend/src/components/timeline/TimelineAxis.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/lib/utils';
+import { DottedLine } from './DottedLine';
+import { formatTime } from './formatTime';
+
+interface TimelineAxisProps {
+  startTime: Date;
+  endTime: Date | null;
+  isConnectedWithNext: boolean;
+  isLastItem: boolean;
+  themeColor: string;
+}
+
+export function TimelineAxis({ startTime, endTime, isConnectedWithNext, isLastItem, themeColor }: TimelineAxisProps) {
+  return (
+    <div className='flex flex-row gap-2'>
+      <div className='flex flex-col justify-between'>
+        <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
+          {formatTime(startTime)}
+        </div>
+        {!isConnectedWithNext && endTime && (
+          <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
+            {formatTime(endTime)}
+          </div>
+        )}
+      </div>
+      <div className='flex min-h-24 flex-col items-center justify-between'>
+        <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
+        {endTime ? (
+          <div className={cn('-my-4 h-full w-2', themeColor)}></div>
+        ) : (
+          !isLastItem && <DottedLine className='h-full self-end' />
+        )}
+        {!isConnectedWithNext && endTime && (
+          <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/timeline/ViewTimeline.test.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.test.tsx
@@ -1,0 +1,313 @@
+import { render, screen, within } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import type { ScheduleBlock, TransportationBlock } from '@/types/block';
+import { groupByStartTime, ViewTimeline } from './ViewTimeline';
+
+vi.mock('../blocks/view/BlockScheduleView', () => ({
+  BlockScheduleView: ({ block }: { block: ScheduleBlock }) => (
+    <div data-testid={`schedule-${block.id}`}>{block.title}</div>
+  ),
+}));
+
+vi.mock('../blocks/view/BlockTransportationView', () => ({
+  BlockTransportationView: ({ block }: { block: TransportationBlock }) => (
+    <div data-testid={`transportation-${block.id}`}>{block.title}</div>
+  ),
+}));
+
+// --- ファクトリ ---
+
+const at = (h: number, m = 0): Date => new Date(2026, 0, 1, h, m);
+
+const makeSchedule = (id: number, start: Date, end: Date | null, title = `S${id}`): ScheduleBlock => ({
+  id,
+  type: 'schedule',
+  title,
+  startTime: start,
+  endTime: end,
+  detail: null,
+  pageId: 1,
+  location: null,
+});
+
+const makeTransport = (id: number, start: Date, end: Date | null, title = `T${id}`): TransportationBlock => ({
+  id,
+  type: 'transportation',
+  title,
+  startTime: start,
+  endTime: end,
+  detail: null,
+  pageId: 1,
+  location: null,
+  transportationType: 'train',
+  destinationLocation: null,
+});
+
+// --- ヘルパー ---
+
+const countBorderDashed = (container: HTMLElement): number => {
+  return container.querySelectorAll('.border-dashed').length;
+};
+
+describe('groupByStartTime', () => {
+  it('空配列を渡すと空配列を返す', () => {
+    expect(groupByStartTime([])).toEqual([]);
+  });
+
+  it('単一ブロックは1グループになり、groupEnd は endTime と一致する', () => {
+    const block = makeSchedule(1, at(9), at(10));
+    const groups = groupByStartTime([block]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].blocks).toEqual([block]);
+    expect(groups[0].groupStart).toEqual(at(9));
+    expect(groups[0].groupEnd).toEqual(at(10));
+    expect(groups[0].headerBlock).toBeNull();
+    expect(groups[0].containerBlocks).toEqual([block]);
+  });
+
+  it('異なる startTime のブロックは別々のグループに分かれる', () => {
+    const a = makeSchedule(1, at(9), at(10));
+    const b = makeSchedule(2, at(11), at(12));
+    const groups = groupByStartTime([a, b]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].blocks).toEqual([a]);
+    expect(groups[1].blocks).toEqual([b]);
+  });
+
+  it('同一 startTime の複数ブロックは1グループにまとめられる', () => {
+    const a = makeSchedule(1, at(9), at(10));
+    const b = makeSchedule(2, at(9), at(11));
+    const groups = groupByStartTime([a, b]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].blocks).toHaveLength(2);
+    expect(groups[0].groupStart).toEqual(at(9));
+  });
+
+  it('グループ内に endTime=null のブロックがあると headerBlock に設定され containerBlocks から除外される', () => {
+    const headerCandidate = makeSchedule(1, at(9), null, 'header');
+    const other = makeSchedule(2, at(9), at(10), 'other');
+    // sortBlocks 後は endTime=null が先頭になる前提
+    const groups = groupByStartTime([headerCandidate, other]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].headerBlock).toBe(headerCandidate);
+    expect(groups[0].containerBlocks).toEqual([other]);
+  });
+
+  it('グループの全ブロックが endTime=null のとき groupEnd は null になる', () => {
+    const a = makeSchedule(1, at(9), null);
+    const b = makeSchedule(2, at(9), null);
+    const groups = groupByStartTime([a, b]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].groupEnd).toBeNull();
+  });
+
+  it('groupEnd はグループ内の endTime の最大値になる', () => {
+    const a = makeSchedule(1, at(9), at(10));
+    const b = makeSchedule(2, at(9), at(13));
+    const c = makeSchedule(3, at(9), at(11));
+    const groups = groupByStartTime([a, b, c]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].groupEnd).toEqual(at(13));
+  });
+});
+
+describe('ViewTimeline', () => {
+  describe('空・基本表示', () => {
+    it('blocks=[] のとき子要素が描画されない', () => {
+      const { container } = render(<ViewTimeline blocks={[]} />);
+      const root = container.firstChild as HTMLElement;
+
+      expect(root).not.toBeNull();
+      expect(root.children).toHaveLength(0);
+    });
+
+    it('endTime を持つ単一スケジュールブロックで開始・終了時刻ラベルが両方表示される', () => {
+      const block = makeSchedule(1, at(9), at(10));
+      render(<ViewTimeline blocks={[block]} />);
+
+      expect(screen.getByText('09:00')).toBeInTheDocument();
+      expect(screen.getByText('10:00')).toBeInTheDocument();
+      expect(screen.getByTestId('schedule-1')).toBeInTheDocument();
+    });
+  });
+
+  describe('endTime=null の単一ブロック', () => {
+    it('開始時刻ラベルのみ表示され、終了時刻ラベルは出ない', () => {
+      const block = makeSchedule(1, at(9), null);
+      render(<ViewTimeline blocks={[block]} />);
+
+      expect(screen.getAllByText('09:00')).toHaveLength(1);
+      // 終了時刻ラベル候補（10:00 など）は存在しない
+      expect(screen.queryByText('10:00')).not.toBeInTheDocument();
+    });
+
+    it('リストの最後でないとき DottedLine（破線）が描画される', () => {
+      const a = makeSchedule(1, at(9), null);
+      const b = makeSchedule(2, at(11), at(12));
+      const { container } = render(<ViewTimeline blocks={[a, b]} />);
+
+      // a の自前 DottedLine = 1 つ（border-dashed の div を 2 つ含む）
+      // 直前 group の groupEnd=null なので gap は追加されない
+      expect(countBorderDashed(container)).toBe(2);
+    });
+
+    it('リストの最後のとき DottedLine は描画されない', () => {
+      const block = makeSchedule(1, at(9), null);
+      const { container } = render(<ViewTimeline blocks={[block]} />);
+
+      expect(countBorderDashed(container)).toBe(0);
+    });
+  });
+
+  describe('連結・gap 判定', () => {
+    it('前ブロックの endTime と次ブロックの startTime が一致するとき、中間の時刻ラベルが重複しない', () => {
+      const a = makeSchedule(1, at(9), at(10));
+      const b = makeSchedule(2, at(10), at(11));
+      render(<ViewTimeline blocks={[a, b]} />);
+
+      expect(screen.getAllByText('10:00')).toHaveLength(1);
+      expect(screen.getByText('09:00')).toBeInTheDocument();
+      expect(screen.getByText('11:00')).toBeInTheDocument();
+    });
+
+    it('連続しない2ブロックの間に gap（DottedLine）が描画される', () => {
+      const a = makeSchedule(1, at(9), at(10));
+      const b = makeSchedule(2, at(11), at(12));
+      const { container } = render(<ViewTimeline blocks={[a, b]} />);
+
+      // gap が 1 つ = border-dashed が 2 つ
+      expect(countBorderDashed(container)).toBe(2);
+    });
+
+    it('直前グループの groupEnd=null のとき、次グループの前に追加の gap は描画されない', () => {
+      const a = makeSchedule(1, at(9), null);
+      const b = makeSchedule(2, at(11), at(12));
+      const { container } = render(<ViewTimeline blocks={[a, b]} />);
+
+      // a 自身の DottedLine のみで、追加の gap DottedLine は無い
+      // border-dashed は 2（a の DottedLine 内の 2 つ）
+      expect(countBorderDashed(container)).toBe(2);
+    });
+  });
+
+  describe('同一 startTime グループ表示', () => {
+    it('同一 startTime の2ブロックが1つのコンテナにまとめて描画される', () => {
+      const a = makeSchedule(1, at(9), at(10));
+      const b = makeSchedule(2, at(9), at(11));
+      const { container } = render(<ViewTimeline blocks={[a, b]} />);
+
+      const groupContainer = container.querySelector<HTMLElement>('.bg-neutral-100\\/60');
+      expect(groupContainer).not.toBeNull();
+      expect(within(groupContainer!).getByTestId('schedule-1')).toBeInTheDocument();
+      expect(within(groupContainer!).getByTestId('schedule-2')).toBeInTheDocument();
+    });
+
+    it('グループ内に endTime=null のブロックがあると、それはコンテナの外（header 位置）に描画される', () => {
+      const header = makeSchedule(1, at(9), null, 'header');
+      const other = makeSchedule(2, at(9), at(10), 'other');
+      const { container } = render(<ViewTimeline blocks={[header, other]} />);
+
+      const groupContainer = container.querySelector<HTMLElement>('.bg-neutral-100\\/60');
+      expect(groupContainer).not.toBeNull();
+      // header はコンテナ外に居る
+      expect(within(groupContainer!).queryByTestId('schedule-1')).not.toBeInTheDocument();
+      expect(within(groupContainer!).getByTestId('schedule-2')).toBeInTheDocument();
+      // ただし全体としては描画されている
+      expect(screen.getByTestId('schedule-1')).toBeInTheDocument();
+    });
+
+    it('グループ内が全て endTime 持ちの場合、全ブロックがコンテナ内に描画される（header なし）', () => {
+      const a = makeSchedule(1, at(9), at(10));
+      const b = makeSchedule(2, at(9), at(11));
+      const c = makeSchedule(3, at(9), at(12));
+      const { container } = render(<ViewTimeline blocks={[a, b, c]} />);
+
+      const groupContainer = container.querySelector<HTMLElement>('.bg-neutral-100\\/60');
+      expect(groupContainer).not.toBeNull();
+      expect(within(groupContainer!).getByTestId('schedule-1')).toBeInTheDocument();
+      expect(within(groupContainer!).getByTestId('schedule-2')).toBeInTheDocument();
+      expect(within(groupContainer!).getByTestId('schedule-3')).toBeInTheDocument();
+    });
+
+    it('3ブロック以上の同時刻グループでも全てがコンテナ内に並んで描画される', () => {
+      const blocks = [
+        makeSchedule(1, at(9), at(10)),
+        makeSchedule(2, at(9), at(11)),
+        makeTransport(3, at(9), at(12)),
+        makeSchedule(4, at(9), at(13)),
+      ];
+      const { container } = render(<ViewTimeline blocks={blocks} />);
+
+      const groupContainer = container.querySelector<HTMLElement>('.bg-neutral-100\\/60');
+      expect(groupContainer).not.toBeNull();
+      expect(within(groupContainer!).getByTestId('schedule-1')).toBeInTheDocument();
+      expect(within(groupContainer!).getByTestId('schedule-2')).toBeInTheDocument();
+      expect(within(groupContainer!).getByTestId('transportation-3')).toBeInTheDocument();
+      expect(within(groupContainer!).getByTestId('schedule-4')).toBeInTheDocument();
+    });
+  });
+
+  describe('テーマカラー', () => {
+    it('単一 schedule ブロックは bg-teal-400 の丸が描画される', () => {
+      const block = makeSchedule(1, at(9), at(10));
+      const { container } = render(<ViewTimeline blocks={[block]} />);
+
+      const circle = container.querySelector('.rounded-full');
+      expect(circle).not.toBeNull();
+      expect(circle).toHaveClass('bg-teal-400');
+    });
+
+    it('単一 transportation ブロックは bg-sky-200 の丸が描画される', () => {
+      const block = makeTransport(1, at(9), at(10));
+      const { container } = render(<ViewTimeline blocks={[block]} />);
+
+      const circle = container.querySelector('.rounded-full');
+      expect(circle).not.toBeNull();
+      expect(circle).toHaveClass('bg-sky-200');
+    });
+
+    it.each([
+      {
+        name: 'schedule + transportation の混在',
+        blocks: [makeSchedule(1, at(9), at(10)), makeTransport(2, at(9), at(11))],
+        expectedClass: 'bg-teal-400',
+      },
+      {
+        name: 'transportation のみ',
+        blocks: [makeTransport(1, at(9), at(10)), makeTransport(2, at(9), at(11))],
+        expectedClass: 'bg-sky-200',
+      },
+    ])('同時刻グループのテーマカラー: $name → $expectedClass', ({ blocks, expectedClass }) => {
+      const { container } = render(<ViewTimeline blocks={blocks} />);
+
+      const circle = container.querySelector('.rounded-full');
+      expect(circle).not.toBeNull();
+      expect(circle).toHaveClass(expectedClass);
+    });
+  });
+
+  describe('時刻フォーマット', () => {
+    it('24時間表記の HH:mm 形式で表示される', () => {
+      const block = makeSchedule(1, at(13, 30), at(15, 45));
+      render(<ViewTimeline blocks={[block]} />);
+
+      expect(screen.getByText('13:30')).toBeInTheDocument();
+      expect(screen.getByText('15:45')).toBeInTheDocument();
+    });
+
+    it('1桁の時・分は 0 パディングされる', () => {
+      const block = makeSchedule(1, at(9, 5), at(9, 30));
+      render(<ViewTimeline blocks={[block]} />);
+
+      expect(screen.getByText('09:05')).toBeInTheDocument();
+      expect(screen.getByText('09:30')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/timeline/ViewTimeline.test.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.test.tsx
@@ -198,6 +198,13 @@ describe('ViewTimeline', () => {
   });
 
   describe('同一 startTime グループ表示', () => {
+    it('単一ブロックのときはコンテナ枠（bg-neutral-100/60）が描画されない', () => {
+      const block = makeSchedule(1, at(9), at(10));
+      const { container } = render(<ViewTimeline blocks={[block]} />);
+
+      expect(container.querySelector('.bg-neutral-100\\/60')).toBeNull();
+    });
+
     it('同一 startTime の2ブロックが1つのコンテナにまとめて描画される', () => {
       const a = makeSchedule(1, at(9), at(10));
       const b = makeSchedule(2, at(9), at(11));

--- a/frontend/src/components/timeline/ViewTimeline.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import type { Block } from '@/types/block';
-import { BlockScheduleView } from '../blocks/view/BlockScheduleView';
-import { BlockTransportationView } from '../blocks/view/BlockTransportationView';
+import { ViewTimelineItem } from './ViewTimelineItem';
 
 // --- 型定義 ---
 
-interface OverlapGroup {
+export interface OverlapGroup {
   blocks: Block[];
   headerBlock: Block | null; // endTime=null のブロック（あれば）
   containerBlocks: Block[]; // コンテナ内に表示するブロック
@@ -14,7 +13,7 @@ interface OverlapGroup {
   groupEnd: Date | null; // 全ブロックの max endTime（全 null なら null）
 }
 
-interface TimelineItem {
+export interface TimelineItem {
   id: string;
   type: 'group' | 'gap';
   group?: OverlapGroup;
@@ -25,27 +24,6 @@ interface ViewTimelineProps {
   blocks: Block[];
   className?: string;
 }
-
-// --- ユーティリティ ---
-
-const formatTime = (date: Date): string => {
-  return date.toLocaleTimeString('ja-JP', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
-};
-
-const renderBlock = (block: Block) => {
-  switch (block.type) {
-    case 'schedule':
-      return <BlockScheduleView block={block} />;
-    case 'transportation':
-      return <BlockTransportationView block={block} />;
-    default:
-      return null;
-  }
-};
 
 // --- ソート ---
 
@@ -158,163 +136,3 @@ export function ViewTimeline({ blocks, className }: ViewTimelineProps) {
     </div>
   );
 }
-
-// --- 単一ブロック表示（既存と同じ） ---
-
-interface SingleBlockTimelineProps {
-  block: Block;
-  isConnectedWithNext: boolean;
-  isLastItem: boolean;
-}
-
-function SingleBlockTimeline({ block, isConnectedWithNext, isLastItem }: SingleBlockTimelineProps) {
-  const themeColor = block.type === 'schedule' ? 'bg-teal-400' : 'bg-sky-200';
-
-  return (
-    <div className='contents'>
-      {/* 時間軸(左) */}
-      <div className='flex flex-row gap-2'>
-        <div className='flex flex-col justify-between'>
-          <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
-            {formatTime(block.startTime)}
-          </div>
-          {!isConnectedWithNext && block.endTime && (
-            <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
-              {formatTime(block.endTime)}
-            </div>
-          )}
-        </div>
-        <div className='flex min-h-24 flex-col items-center justify-between'>
-          <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
-          {block.endTime ? (
-            <div className={cn('-my-4 h-full w-2', themeColor)}></div>
-          ) : (
-            !isLastItem && <DottedLine className='h-full self-end' />
-          )}
-          {!isConnectedWithNext && block.endTime && (
-            <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
-          )}
-        </div>
-      </div>
-
-      {/* ブロック内容(右) */}
-      <div className='pb-4'>{renderBlock(block)}</div>
-    </div>
-  );
-}
-
-// --- 複数ブロックグループ表示 ---
-
-interface MultiBlockGroupTimelineProps {
-  group: OverlapGroup;
-  isConnectedWithNext: boolean;
-  isLastItem: boolean;
-}
-
-function MultiBlockGroupTimeline({ group, isConnectedWithNext, isLastItem }: MultiBlockGroupTimelineProps) {
-  const hasSchedule = group.blocks.some(b => b.type === 'schedule');
-  const themeColor = hasSchedule ? 'bg-teal-400' : 'bg-sky-200';
-
-  return (
-    <div className='contents'>
-      {/* 時間軸(左) */}
-      <div className='flex flex-row gap-2'>
-        <div className='flex flex-col justify-between'>
-          <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
-            {formatTime(group.groupStart)}
-          </div>
-          {!isConnectedWithNext && group.groupEnd && (
-            <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
-              {formatTime(group.groupEnd)}
-            </div>
-          )}
-        </div>
-        <div className='flex min-h-24 flex-col items-center justify-between'>
-          <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
-          {group.groupEnd ? (
-            <div className={cn('-my-4 h-full w-2', themeColor)}></div>
-          ) : (
-            !isLastItem && <DottedLine className='h-full self-end' />
-          )}
-          {!isConnectedWithNext && group.groupEnd && (
-            <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
-          )}
-        </div>
-      </div>
-
-      {/* ブロック内容(右) */}
-      <div className='flex flex-col gap-2 pb-4'>
-        {/* ヘッダーブロック（endTime=null） */}
-        {group.headerBlock && renderBlock(group.headerBlock)}
-
-        {/* コンテナ（他のブロック） */}
-        {group.containerBlocks.length > 0 && (
-          <div className='flex flex-col gap-3 rounded-xl bg-neutral-100/60 p-3'>
-            {group.containerBlocks.map(block => (
-              <div key={block.id}>
-                <div className='mb-1 font-medium text-12px text-neutral-500'>
-                  {formatTime(block.startTime)}
-                  {block.endTime && `–${formatTime(block.endTime)}`}
-                </div>
-                {renderBlock(block)}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// --- タイムラインアイテム ---
-
-interface ViewTimelineItemProps {
-  item: TimelineItem;
-  isLastItem: boolean;
-}
-
-function ViewTimelineItem({ item, isLastItem }: ViewTimelineItemProps) {
-  if (item.type === 'gap') {
-    return (
-      <div className='contents'>
-        <DottedLine />
-        <div />
-      </div>
-    );
-  }
-
-  const group = item.group;
-  if (!group) return null;
-  const isSingleBlock = group.blocks.length === 1;
-
-  if (isSingleBlock) {
-    return (
-      <SingleBlockTimeline
-        block={group.blocks[0]}
-        isConnectedWithNext={item.isConnectedWithNextGroup ?? false}
-        isLastItem={isLastItem}
-      />
-    );
-  }
-
-  return (
-    <MultiBlockGroupTimeline
-      group={group}
-      isConnectedWithNext={item.isConnectedWithNextGroup ?? false}
-      isLastItem={isLastItem}
-    />
-  );
-}
-
-// --- 破線 ---
-
-const DottedLine = ({ ...props }: React.ComponentProps<'div'>) => {
-  const { className, ...rest } = props;
-
-  return (
-    <div className={cn('flex h-8 flex-row pe-2.5 sm:pe-3.5', className)} {...rest}>
-      <div className='grow border-neutral-600 border-r-2 border-dashed' />
-      <div className='border-neutral-600 border-l-2 border-dashed'></div>
-    </div>
-  );
-};

--- a/frontend/src/components/timeline/ViewTimeline.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.tsx
@@ -1,127 +1,312 @@
+import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import type { Block } from '@/types/block';
 import { BlockScheduleView } from '../blocks/view/BlockScheduleView';
 import { BlockTransportationView } from '../blocks/view/BlockTransportationView';
+
+// --- 型定義 ---
+
+interface OverlapGroup {
+  blocks: Block[];
+  headerBlock: Block | null; // endTime=null のブロック（あれば）
+  containerBlocks: Block[]; // コンテナ内に表示するブロック
+  groupStart: Date;
+  groupEnd: Date | null; // 全ブロックの max endTime（全 null なら null）
+}
+
+interface TimelineItem {
+  id: string;
+  type: 'group' | 'gap';
+  group?: OverlapGroup;
+  isConnectedWithNextGroup?: boolean;
+}
 
 interface ViewTimelineProps {
   blocks: Block[];
   className?: string;
 }
 
-interface TimelineItem {
-  id: string;
-  type: 'block' | 'gap';
-  isConnectedWithNextBlock?: boolean; // 次のブロックの開始時間と終了時間が同じかどうか（blockタイプの場合）
-  block?: Block;
-}
+// --- ユーティリティ ---
 
-export function ViewTimeline({ blocks, className }: ViewTimelineProps) {
-  // ブロックを時間順にソート
-  const sortedBlocks = [...blocks].sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+const formatTime = (date: Date): string => {
+  return date.toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+};
 
-  // タイムラインアイテムを構築（ブロックと間隔を含む）
-  const timelineItems: TimelineItem[] = [];
+const renderBlock = (block: Block) => {
+  switch (block.type) {
+    case 'schedule':
+      return <BlockScheduleView block={block} />;
+    case 'transportation':
+      return <BlockTransportationView block={block} />;
+    default:
+      return null;
+  }
+};
 
-  for (let i = 0; i < sortedBlocks.length; i++) {
-    const currentBlock = sortedBlocks[i];
-    const previousBlock = i > 0 ? sortedBlocks[i - 1] : null;
-    const nextBlock = i < sortedBlocks.length - 1 ? sortedBlocks[i + 1] : null;
+// --- ソート ---
 
-    // 前のブロックとの間に時間間隔があるかが設定されていない場合、破線ブロックを追加
-    // ただし、前ブロックが終了時間を持たない場合は間隔を入れない（例: 終了時間が未定のスケジュール）
-    if (
-      previousBlock &&
-      previousBlock.endTime != null &&
-      previousBlock.endTime.getTime() !== currentBlock.startTime.getTime()
-    ) {
-      timelineItems.push({
-        type: 'gap',
-        id: `gap-${previousBlock.id}-${currentBlock.id}`,
-      });
+const sortBlocks = (blocks: Block[]): Block[] => {
+  return [...blocks].sort((a, b) => {
+    const startDiff = a.startTime.getTime() - b.startTime.getTime();
+    if (startDiff !== 0) return startDiff;
+    // startTime が同じ場合: endTime 昇順（null 先頭）
+    if (a.endTime === null && b.endTime === null) return 0;
+    if (a.endTime === null) return -1;
+    if (b.endTime === null) return 1;
+    return a.endTime.getTime() - b.endTime.getTime();
+  });
+};
+
+// --- グループ化 ---
+
+/** 同一 startTime のブロックを OverlapGroup にまとめる */
+export const groupByStartTime = (sortedBlocks: Block[]): OverlapGroup[] => {
+  if (sortedBlocks.length === 0) return [];
+
+  const groups: OverlapGroup[] = [];
+  let i = 0;
+
+  while (i < sortedBlocks.length) {
+    const startMs = sortedBlocks[i].startTime.getTime();
+    const groupBlocks: Block[] = [sortedBlocks[i]];
+    i++;
+
+    // 同じ startTime のブロックを集める
+    while (i < sortedBlocks.length && sortedBlocks[i].startTime.getTime() === startMs) {
+      groupBlocks.push(sortedBlocks[i]);
+      i++;
     }
 
-    timelineItems.push({
-      type: 'block',
-      block: currentBlock,
-      id: String(currentBlock.id),
-      isConnectedWithNextBlock: nextBlock ? nextBlock.startTime.getTime() === currentBlock.endTime?.getTime() : false,
+    // headerBlock: endTime === null のブロック（最初の1つ）
+    const headerBlock = groupBlocks.find(b => b.endTime === null) ?? null;
+    const containerBlocks = headerBlock ? groupBlocks.filter(b => b !== headerBlock) : groupBlocks;
+
+    // groupEnd: endTime を持つブロックの中で最も遅い endTime
+    const endTimes = groupBlocks.map(b => b.endTime?.getTime()).filter((t): t is number => t != null);
+    const groupEnd = endTimes.length > 0 ? new Date(Math.max(...endTimes)) : null;
+
+    groups.push({
+      blocks: groupBlocks,
+      headerBlock,
+      containerBlocks,
+      groupStart: sortedBlocks[i - 1].startTime, // 全て同じ startTime
+      groupEnd,
     });
   }
+
+  return groups;
+};
+
+// --- タイムラインアイテム構築 ---
+
+const buildTimelineItems = (blocks: Block[]): TimelineItem[] => {
+  const sorted = sortBlocks(blocks);
+  const groups = groupByStartTime(sorted);
+  const items: TimelineItem[] = [];
+
+  let maxEndTime = -Infinity;
+
+  for (let i = 0; i < groups.length; i++) {
+    const currentGroup = groups[i];
+    const nextGroup = i < groups.length - 1 ? groups[i + 1] : null;
+
+    // gap 判定: 前のグループの maxEndTime と現在グループの startTime を比較
+    // 直前のグループが groupEnd=null の場合、そのコンポーネント自身が DottedLine を描画するため gap は不要
+    if (i > 0 && maxEndTime !== -Infinity && groups[i - 1].groupEnd !== null) {
+      if (currentGroup.groupStart.getTime() > maxEndTime) {
+        items.push({
+          type: 'gap',
+          id: `gap-${i}`,
+        });
+      }
+    }
+
+    // maxEndTime を更新
+    const currentEnd = currentGroup.groupEnd?.getTime() ?? currentGroup.groupStart.getTime();
+    maxEndTime = Math.max(maxEndTime, currentEnd);
+
+    // isConnected 判定
+    const isConnectedWithNextGroup = nextGroup
+      ? nextGroup.groupStart.getTime() === currentGroup.groupEnd?.getTime()
+      : false;
+
+    items.push({
+      type: 'group',
+      id: `group-${currentGroup.blocks.map(b => b.id).join('-')}`,
+      group: currentGroup,
+      isConnectedWithNextGroup,
+    });
+  }
+
+  return items;
+};
+
+// --- コンポーネント ---
+
+export function ViewTimeline({ blocks, className }: ViewTimelineProps) {
+  const timelineItems = useMemo(() => buildTimelineItems(blocks), [blocks]);
 
   return (
     <div className={cn('grid w-full grid-cols-[auto_1fr] gap-x-4', className)}>
       {timelineItems.map((item, index) => (
-        <ViewTimelineBlock key={item.id} item={item} isLastBlock={index === timelineItems.length - 1} />
+        <ViewTimelineItem key={item.id} item={item} isLastItem={index === timelineItems.length - 1} />
       ))}
     </div>
   );
 }
 
-interface ViewTimelineBlockProps {
-  item: TimelineItem;
-  isLastBlock?: boolean;
+// --- 単一ブロック表示（既存と同じ） ---
+
+interface SingleBlockTimelineProps {
+  block: Block;
+  isConnectedWithNext: boolean;
+  isLastItem: boolean;
 }
 
-function ViewTimelineBlock({ item, isLastBlock = false }: ViewTimelineBlockProps) {
-  const formatTime = (date: Date) => {
-    return date.toLocaleTimeString('ja-JP', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
-  };
-
-  const themeColor = item.type === 'block' && item.block?.type === 'schedule' ? 'bg-teal-400' : 'bg-sky-200';
-
-  const renderBlock = (block: Block) => {
-    switch (block.type) {
-      case 'schedule':
-        return <BlockScheduleView block={block} />;
-      case 'transportation':
-        return <BlockTransportationView block={block} />;
-      default:
-        return null;
-    }
-  };
+function SingleBlockTimeline({ block, isConnectedWithNext, isLastItem }: SingleBlockTimelineProps) {
+  const themeColor = block.type === 'schedule' ? 'bg-teal-400' : 'bg-sky-200';
 
   return (
     <div className='contents'>
       {/* 時間軸(左) */}
-      {item.type === 'block' && item.block?.startTime && (
-        <div className='flex flex-row gap-2'>
-          <div className='flex flex-col justify-between'>
-            {/* 時間ラベル */}
+      <div className='flex flex-row gap-2'>
+        <div className='flex flex-col justify-between'>
+          <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
+            {formatTime(block.startTime)}
+          </div>
+          {!isConnectedWithNext && block.endTime && (
             <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
-              {formatTime(item.block.startTime)}
+              {formatTime(block.endTime)}
             </div>
-            {!item.isConnectedWithNextBlock && item.block.endTime && (
-              <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
-                {formatTime(item.block.endTime)}
-              </div>
-            )}
-          </div>
-          <div className='flex min-h-24 flex-col items-center justify-between'>
-            {/* ●およびライン */}
-            <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
-            {item.block.endTime ? (
-              <div className={cn('-my-4 h-full w-2', themeColor)}></div>
-            ) : (
-              !isLastBlock && <DottedLine className='h-full self-end' />
-            )}
-            {!item.isConnectedWithNextBlock && item.block.endTime && (
-              <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
-            )}
-          </div>
+          )}
         </div>
-      )}
-      {item.type === 'gap' && <DottedLine />}
+        <div className='flex min-h-24 flex-col items-center justify-between'>
+          <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
+          {block.endTime ? (
+            <div className={cn('-my-4 h-full w-2', themeColor)}></div>
+          ) : (
+            !isLastItem && <DottedLine className='h-full self-end' />
+          )}
+          {!isConnectedWithNext && block.endTime && (
+            <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
+          )}
+        </div>
+      </div>
 
       {/* ブロック内容(右) */}
-      {item.type === 'block' && item.block && <div className='pb-4'>{renderBlock(item.block)}</div>}
-      {item.type === 'gap' && <div /> /* 固定高さの空スペース */}
+      <div className='pb-4'>{renderBlock(block)}</div>
     </div>
   );
 }
+
+// --- 複数ブロックグループ表示 ---
+
+interface MultiBlockGroupTimelineProps {
+  group: OverlapGroup;
+  isConnectedWithNext: boolean;
+  isLastItem: boolean;
+}
+
+function MultiBlockGroupTimeline({ group, isConnectedWithNext, isLastItem }: MultiBlockGroupTimelineProps) {
+  const hasSchedule = group.blocks.some(b => b.type === 'schedule');
+  const themeColor = hasSchedule ? 'bg-teal-400' : 'bg-sky-200';
+
+  return (
+    <div className='contents'>
+      {/* 時間軸(左) */}
+      <div className='flex flex-row gap-2'>
+        <div className='flex flex-col justify-between'>
+          <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
+            {formatTime(group.groupStart)}
+          </div>
+          {!isConnectedWithNext && group.groupEnd && (
+            <div className='flex h-6 flex-row items-center font-medium text-14px text-gray-700 sm:h-8 sm:text-18px'>
+              {formatTime(group.groupEnd)}
+            </div>
+          )}
+        </div>
+        <div className='flex min-h-24 flex-col items-center justify-between'>
+          <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
+          {group.groupEnd ? (
+            <div className={cn('-my-4 h-full w-2', themeColor)}></div>
+          ) : (
+            !isLastItem && <DottedLine className='h-full self-end' />
+          )}
+          {!isConnectedWithNext && group.groupEnd && (
+            <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />
+          )}
+        </div>
+      </div>
+
+      {/* ブロック内容(右) */}
+      <div className='flex flex-col gap-2 pb-4'>
+        {/* ヘッダーブロック（endTime=null） */}
+        {group.headerBlock && renderBlock(group.headerBlock)}
+
+        {/* コンテナ（他のブロック） */}
+        {group.containerBlocks.length > 0 && (
+          <div className='flex flex-col gap-3 rounded-xl bg-neutral-100/60 p-3'>
+            {group.containerBlocks.map(block => (
+              <div key={block.id}>
+                <div className='mb-1 font-medium text-12px text-neutral-500'>
+                  {formatTime(block.startTime)}
+                  {block.endTime && `–${formatTime(block.endTime)}`}
+                </div>
+                {renderBlock(block)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- タイムラインアイテム ---
+
+interface ViewTimelineItemProps {
+  item: TimelineItem;
+  isLastItem: boolean;
+}
+
+function ViewTimelineItem({ item, isLastItem }: ViewTimelineItemProps) {
+  if (item.type === 'gap') {
+    return (
+      <div className='contents'>
+        <DottedLine />
+        <div />
+      </div>
+    );
+  }
+
+  const group = item.group;
+  if (!group) return null;
+  const isSingleBlock = group.blocks.length === 1;
+
+  if (isSingleBlock) {
+    return (
+      <SingleBlockTimeline
+        block={group.blocks[0]}
+        isConnectedWithNext={item.isConnectedWithNextGroup ?? false}
+        isLastItem={isLastItem}
+      />
+    );
+  }
+
+  return (
+    <MultiBlockGroupTimeline
+      group={group}
+      isConnectedWithNext={item.isConnectedWithNextGroup ?? false}
+      isLastItem={isLastItem}
+    />
+  );
+}
+
+// --- 破線 ---
 
 const DottedLine = ({ ...props }: React.ComponentProps<'div'>) => {
   const { className, ...rest } = props;

--- a/frontend/src/components/timeline/ViewTimelineItem.tsx
+++ b/frontend/src/components/timeline/ViewTimelineItem.tsx
@@ -1,0 +1,30 @@
+import { DottedLine } from './DottedLine';
+import { GroupTimelineRow } from './GroupTimelineRow';
+import type { TimelineItem } from './ViewTimeline';
+
+interface ViewTimelineItemProps {
+  item: TimelineItem;
+  isLastItem: boolean;
+}
+
+export function ViewTimelineItem({ item, isLastItem }: ViewTimelineItemProps) {
+  if (item.type === 'gap') {
+    return (
+      <div className='contents'>
+        <DottedLine />
+        <div />
+      </div>
+    );
+  }
+
+  const group = item.group;
+  if (!group) return null;
+
+  return (
+    <GroupTimelineRow
+      group={group}
+      isConnectedWithNext={item.isConnectedWithNextGroup ?? false}
+      isLastItem={isLastItem}
+    />
+  );
+}

--- a/frontend/src/components/timeline/formatTime.ts
+++ b/frontend/src/components/timeline/formatTime.ts
@@ -1,0 +1,7 @@
+export const formatTime = (date: Date): string => {
+  return date.toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+};


### PR DESCRIPTION
## Summary
- 同一startTimeのブロックをグループ化し、endTime=nullブロックをヘッダーとして独立表示、他のブロックはコンテナ内に時間チップ付きで表示
- 不正なgap挿入・開始時刻ラベルの重複表示を解消
- ソート順を改善（startTime昇順 → endTime昇順、null先頭）

[確認用プレビュー](https://tabi-share-8ef6b--pr106-feature-issue100-ove-ir5fy19v.web.app/trip/gNtduddhqrgpLnAO)

<img width="781" height="550" alt="image" src="https://github.com/user-attachments/assets/2bdbe808-8e99-4d3c-bc55-5d77150a6159" />



closes #100
