### PR TITLE
perf: create/update 時の不要な db.refresh() を削除

### DIFF
--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: '3.13'

--- a/server/app/cruds/blocks.py
+++ b/server/app/cruds/blocks.py
@@ -40,7 +40,6 @@ async def create_block(db: AsyncSession, block: BlockCreate, page_id: int) -> Bl
     db_block = Block(**block_data, page_id=page_id)
     db.add(db_block)
     await db.commit()
-    await db.refresh(db_block)
     return db_block
 
 
@@ -148,7 +147,6 @@ async def update_block(
     )
 
     await db.commit()
-    await db.refresh(db_block)
     return db_block
 
 

--- a/server/app/cruds/pages.py
+++ b/server/app/cruds/pages.py
@@ -20,7 +20,6 @@ async def create_page(db: AsyncSession, page: PageCreate, trip_id: int) -> Page:
     db_page = Page(**page.model_dump(), trip_id=trip_id)
     db.add(db_page)
     await db.commit()
-    await db.refresh(db_page)
     return db_page
 
 
@@ -71,7 +70,6 @@ async def update_page(db: AsyncSession, page_id: int, page: PageUpdate) -> Page 
         for key, value in page.model_dump().items():
             setattr(db_page, key, value)
         await db.commit()
-        await db.refresh(db_page)
 
     return db_page
 

--- a/server/app/cruds/trips.py
+++ b/server/app/cruds/trips.py
@@ -20,7 +20,6 @@ async def create_trip(db: AsyncSession, trip: TripCreateIn, url_id: str) -> int:
     db_trip = Trip(**trip.model_dump(), url_id=url_id)
     db.add(db_trip)
     await db.commit()
-    await db.refresh(db_trip)
     return db_trip.id
 
 
@@ -85,7 +84,6 @@ async def update_trip(db: AsyncSession, trip_id: int, trip: TripUpdate) -> Trip 
         for key, value in trip.model_dump().items():
             setattr(db_trip, key, value)
         await db.commit()
-        await db.refresh(db_trip)
 
     return db_trip
 


### PR DESCRIPTION
## 概要

`expire_on_commit=False` が設定されているため、`commit()` 後もオブジェクトの属性はメモリ上で有効。
各 CRUD の create/update で呼ばれていた `db.refresh()` は不要な SELECT を余分に1回発行しているだけだったため削除した。

## 詳細

`AsyncSessionLocal` に `expire_on_commit=False` が設定されているため（`db_connection.py:35`）、`commit()` 後もオブジェクト属性は期限切れにならない。
`db.refresh()` は「DB から再 SELECT して最新化する」操作であり、この設定下では不要。

**削除箇所（計6箇所）**

| ファイル | 関数 |
|---------|------|
| `cruds/trips.py` | `create_trip()`, `update_trip()` |
| `cruds/pages.py` | `create_page()`, `update_page()` |
| `cruds/blocks.py` | `create_block()`, `update_block()` |

**想定効果**: create/update エンドポイントで SELECT が 1 回削減される。

## 動作確認

ステージングデプロイ後に以下で計測予定：

```bash
for i in {1..5}; do
  curl -w "%{time_total}\n" -s -o /dev/null \
    "https://tabi-share-api-staging-jsmfpzrd6q-an.a.run.app/api/v1/trips/url/<url_id>"
done
```

## 確認項目
- [ ] 動作確認を実施している
- [ ] issueはPRページ右下のDevelopmentからissueが紐づいている