### PR TITLE
perf: ルーター層の冗長な DB 存在確認を削除

### DIFF
--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: '3.13'

--- a/server/app/routers/blocks.py
+++ b/server/app/routers/blocks.py
@@ -3,7 +3,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_block_access, require_page_access
 from app.cruds import blocks as blocks_cruds
-from app.cruds import pages as pages_cruds
 from app.db_connection import get_db_session
 from app.errors import NotFound
 from app.schemas.block import Block, BlockCreate, BlockUpdate
@@ -29,10 +28,6 @@ async def create_block(
     - 新しいブロックを作成する
     - `location` / `destination_location` を含める場合は同一トランザクションで作成する
     """
-    db_page = await pages_cruds.get_page(db, page_id=page_id)
-    if db_page is None:
-        raise NotFound(message="Page not found")
-
     return await blocks_cruds.create_block(db=db, block=block, page_id=page_id)
 
 

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -3,7 +3,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_trip_access, require_page_access
 from app.cruds import pages as pages_cruds
-from app.cruds import trips as trips_cruds
 from app.db_connection import get_db_session
 from app.errors import NotFound
 from app.schemas.page import Page, PageCreate, PageUpdate
@@ -30,10 +29,6 @@ async def create_page(
 
     - 新しいページを作成する
     """
-    db_trip = await trips_cruds.get_trip(db, trip_id=trip_id)
-    if db_trip is None:
-        raise NotFound(message="Trip not found")
-
     return await pages_cruds.create_page(db=db, page=page, trip_id=trip_id)
 
 


### PR DESCRIPTION
## 概要

認可チェックで既に存在確認済みのエンティティを、ルーター内で再度 SELECT しているケースを削除した。

## 詳細

**`POST /trips/{trip_id}/pages`（`routers/pages.py`）**

`require_trip_access` は Cookie のみで検証するため DB 照会なし。
その後の `trips_cruds.get_trip()` による存在確認は、trip が削除済みの場合でも FK 制約（`page.trip_id` → `trips.id`）が INSERT を弾くため不要。

**`POST /pages/{page_id}/blocks`（`routers/blocks.py`）**

`require_page_access`（`auth.py:109`）が `SELECT page.trip_id WHERE page.id = X` で既に page の存在を DB 確認済み。
直後の `pages_cruds.get_page()` は同じページへの二重照会になっていた。

**想定効果**: 上記2エンドポイントで SELECT が 1 回削減される。

## 動作確認

ステージングデプロイ後に以下で計測予定：

```bash
for i in {1..5}; do
  curl -w "%{time_total}\n" -s -o /dev/null \
    "https://tabi-share-api-staging-jsmfpzrd6q-an.a.run.app/api/v1/trips/url/<url_id>"
done
```

## 確認項目
- [ ] 動作確認を実施している
- [ ] issueはPRページ右下のDevelopmentからissueが紐づいている