### PR TITLE
perf(#124): API レイテンシー計装ミドルウェアを追加

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -9,11 +9,13 @@ from fastapi.responses import HTMLResponse, JSONResponse
 
 from app.auth import require_basic_auth
 from app.config import get_settings
+from app.db_connection import engine
 from app.errors import (
     ErrorResponseException,
     error_response_exception_handler,
     validation_exception_handler,
 )
+from app.observability import setup_observability
 
 from .routers import blocks, pages, trips
 
@@ -75,6 +77,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+setup_observability(app, engine)
 
 app.include_router(trips.router)
 app.include_router(pages.router)

--- a/server/app/observability.py
+++ b/server/app/observability.py
@@ -1,0 +1,170 @@
+"""
+リクエストレイテンシー計装モジュール
+
+各 HTTP リクエストの総処理時間と DB クエリ統計（件数 / 累積時間 / 最遅クエリ）を
+ContextVar 経由で集計し、Cloud Logging で集計しやすい JSON 構造化ログとして
+stdout へ 1 リクエスト 1 行で出力する。
+
+Issue: #124 ボトルネック特定のための計装。
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import sys
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+# Cloud Run が拾う stdout の JSON ログ専用 logger
+_logger = logging.getLogger("tabi_share.latency")
+
+# 計装ログ出力対象外のパス（ヘルスチェック等の高頻度ノイズ）
+_EXCLUDED_PATHS: frozenset[str] = frozenset({"/health"})
+
+# SQLAlchemy connection.info にクエリ開始時刻を保存するキー
+_QUERY_START_KEY = "tabi_share_query_start"
+
+# DB ログに保持する SQL の最大文字数（ログ肥大防止）
+_SLOW_SQL_MAX_LEN = 200
+
+
+@dataclass
+class RequestStats:
+    """1 リクエストあたりの DB 統計"""
+
+    db_query_count: int = 0
+    db_total_ms: float = 0.0
+    db_max_ms: float = 0.0
+    db_slowest_statement: str = ""
+
+
+_request_stats: contextvars.ContextVar[RequestStats | None] = contextvars.ContextVar(
+    "tabi_share_request_stats", default=None
+)
+
+
+def _ensure_logger_configured() -> None:
+    """計装 logger に handler を 1 つだけ設定する。再設定では何もしない。"""
+    if _logger.handlers:
+        return
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    _logger.addHandler(handler)
+    _logger.setLevel(logging.INFO)
+    _logger.propagate = False
+
+
+def _on_before_cursor_execute(
+    conn: Any,
+    cursor: Any,
+    statement: str,
+    parameters: Any,
+    context: Any,
+    executemany: bool,
+) -> None:
+    conn.info[_QUERY_START_KEY] = time.perf_counter()
+
+
+def _on_after_cursor_execute(
+    conn: Any,
+    cursor: Any,
+    statement: str,
+    parameters: Any,
+    context: Any,
+    executemany: bool,
+) -> None:
+    started = conn.info.pop(_QUERY_START_KEY, None)
+    if started is None:
+        return
+    stats = _request_stats.get()
+    if stats is None:
+        return
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    stats.db_query_count += 1
+    stats.db_total_ms += elapsed_ms
+    if elapsed_ms > stats.db_max_ms:
+        stats.db_max_ms = elapsed_ms
+        stats.db_slowest_statement = statement.replace("\n", " ").strip()[
+            :_SLOW_SQL_MAX_LEN
+        ]
+
+
+def setup_sqlalchemy_instrumentation(engine: AsyncEngine | Engine) -> None:
+    """SQLAlchemy engine にクエリ計装の event を登録する。
+
+    AsyncEngine の場合は `sync_engine` 側に listen する必要がある。
+    """
+    sync_engine = engine.sync_engine if isinstance(engine, AsyncEngine) else engine
+    event.listen(sync_engine, "before_cursor_execute", _on_before_cursor_execute)
+    event.listen(sync_engine, "after_cursor_execute", _on_after_cursor_execute)
+
+
+def _route_template(request: Request) -> str | None:
+    """マッチしたルートのパステンプレート（例: /trips/{trip_id}）を返す。"""
+    route = request.scope.get("route")
+    return getattr(route, "path", None)
+
+
+def _build_log_payload(
+    request: Request,
+    status_code: int,
+    total_ms: float,
+    stats: RequestStats,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": "request",
+        "method": request.method,
+        "path": request.url.path,
+        "route": _route_template(request),
+        "status": status_code,
+        "total_ms": round(total_ms, 2),
+        "db_query_count": stats.db_query_count,
+        "db_total_ms": round(stats.db_total_ms, 2),
+        "db_max_ms": round(stats.db_max_ms, 2),
+    }
+    if stats.db_slowest_statement:
+        payload["db_slowest_sql"] = stats.db_slowest_statement
+    return payload
+
+
+async def latency_logging_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    """1 リクエスト 1 行で総処理時間と DB 統計を JSON ログ出力する。"""
+    if request.url.path in _EXCLUDED_PATHS:
+        return await call_next(request)
+
+    stats = RequestStats()
+    token = _request_stats.set(stats)
+    started = time.perf_counter()
+    status_code = 500
+    try:
+        response = await call_next(request)
+        status_code = response.status_code
+        return response
+    finally:
+        total_ms = (time.perf_counter() - started) * 1000.0
+        _request_stats.reset(token)
+        _logger.info(
+            json.dumps(
+                _build_log_payload(request, status_code, total_ms, stats),
+                ensure_ascii=False,
+            )
+        )
+
+
+def setup_observability(app: FastAPI, engine: AsyncEngine | Engine) -> None:
+    """計装 logger / SQL イベント / HTTP middleware を一括設定する。"""
+    _ensure_logger_configured()
+    setup_sqlalchemy_instrumentation(engine)
+    app.middleware("http")(latency_logging_middleware)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -20,6 +20,7 @@ from app.cruds import pages as pages_cruds
 from app.cruds import trips as trips_cruds
 from app.db_connection import Base, get_db_session
 from app.main import app
+from app.observability import setup_sqlalchemy_instrumentation
 from app.schemas.block import Block as BlockSchema
 from app.schemas.block import BlockCreate
 from app.schemas.page import Page, PageCreate
@@ -33,6 +34,10 @@ test_engine: AsyncEngine = create_async_engine(
     echo=False,
     poolclass=NullPool,
 )
+
+# 計装 SQL イベントをテスト engine にも attach し、ミドルウェア出力が
+# 本番と同じ統計を持つようにする
+setup_sqlalchemy_instrumentation(test_engine)
 
 # テスト用の非同期セッションファクトリ
 TestingAsyncSessionLocal = async_sessionmaker(

--- a/server/tests/test_observability.py
+++ b/server/tests/test_observability.py
@@ -1,0 +1,90 @@
+"""
+レイテンシー計装ミドルウェアのテスト
+
+middleware が 1 リクエスト 1 行の JSON ログを出力し、DB クエリ統計が
+正しく集計されることを検証する。
+"""
+
+import json
+import logging
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+from app.observability import _logger as latency_logger
+
+
+def _capture_records(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
+    """tabi_share.latency に流れた JSON 行をパースして返す。"""
+    records: list[dict[str, Any]] = []
+    for r in caplog.records:
+        if r.name != "tabi_share.latency":
+            continue
+        try:
+            records.append(json.loads(r.getMessage()))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+@pytest.fixture
+def latency_caplog(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    """propagate=False の計装 logger を pytest の caplog で拾えるようにする。"""
+    caplog.set_level(logging.INFO, logger="tabi_share.latency")
+    # _logger 自身に caplog.handler を attach（propagate=False のため）
+    latency_logger.addHandler(caplog.handler)
+    try:
+        yield caplog
+    finally:
+        latency_logger.removeHandler(caplog.handler)
+
+
+async def test_latency_log_excludes_health(
+    client: AsyncClient,
+    latency_caplog: pytest.LogCaptureFixture,
+) -> None:
+    """/health は計装ログから除外される"""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert _capture_records(latency_caplog) == []
+
+
+async def test_latency_log_emits_for_api_request(
+    authed_client: AsyncClient,
+    test_create_trip,
+    latency_caplog: pytest.LogCaptureFixture,
+) -> None:
+    """通常 API は 1 行の JSON ログを出し、DB クエリ統計を含む"""
+    response = await authed_client.get(f"/trips/{test_create_trip.id}")
+    assert response.status_code == 200
+
+    records = _capture_records(latency_caplog)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["type"] == "request"
+    assert rec["method"] == "GET"
+    assert rec["path"] == f"/trips/{test_create_trip.id}"
+    assert rec["route"] == "/trips/{trip_id}"
+    assert rec["status"] == 200
+    assert rec["total_ms"] >= 0
+    # selectinload で最低 1 クエリ（trips の取得）が走る
+    assert rec["db_query_count"] >= 1
+    assert rec["db_total_ms"] >= 0
+    assert rec["db_max_ms"] >= 0
+    assert "db_slowest_sql" in rec
+
+
+async def test_latency_log_records_no_db_for_404_unauthorized(
+    client: AsyncClient,
+    latency_caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cookie なしの認可失敗 (403) でも JSON ログは出力される"""
+    response = await client.get("/trips/9999")
+    assert response.status_code == 403
+
+    records = _capture_records(latency_caplog)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["status"] == 403
+    assert rec["db_query_count"] == 0


### PR DESCRIPTION
## Summary
- Issue #124 のボトルネック特定のため、リクエストごとの総処理時間と DB クエリ統計（件数 / 累積時間 / 最遅クエリ）を JSON 構造化ログで stdout に出力する計装ミドルウェアを追加
- SQLAlchemy `before/after_cursor_execute` フックで ContextVar にクエリ単位の経過時間を集計
- `/health` は計装ログ対象外（高頻度ノイズ排除）

これは Issue #124 の **計測** フェーズの実装で、改善 PR はこれを使った STG 実測結果を踏まえて別 PR で出します。

## 出力ログ例
Cloud Logging が `jsonPayload` として拾える 1 行 JSON:

```json
{
  "type": "request",
  "method": "GET",
  "path": "/trips/url/abc123",
  "route": "/trips/url/{url_id}",
  "status": 200,
  "total_ms": 1483.21,
  "db_query_count": 5,
  "db_total_ms": 1102.4,
  "db_max_ms": 320.5,
  "db_slowest_sql": "SELECT trips.id, trips.url_id, trips.title, trips.detail FROM trips WHERE trips.url_id = $1::VARCHAR"
}
```

## STG デプロイ後の実測手順（PR マージ後に実施）
1. `develop` にマージ → GitHub Actions が staging に自動デプロイ、もしくは workflow_dispatch で先行デプロイ
2. ステージング (https://tabi-share-api-staging-jsmfpzrd6q-an.a.run.app/) に対し、認可 Cookie を持つクライアントから代表エンドポイントを叩く:
   - `GET /trips/url/{url_id}` （閲覧の起点・selectinload で 4–5 クエリ）
   - `GET /trips/{trip_id}/pages`
   - `GET /pages/{page_id}/blocks`
   - `PUT /blocks/{block_id}` （location 置換含む）
3. Cloud Logging で `jsonPayload.type="request"` を絞り込み、`route` 別に `total_ms` / `db_total_ms` / `db_query_count` / `db_slowest_sql` を集計
4. ウォーム後 N 回（例: 20–50 回）の p50/p95 を算出してボトルネックを判定
   - `db_total_ms` が `total_ms` の大半 → DB クエリが主因（クエリ最適化 / connection pool 見直し）
   - `total_ms - db_total_ms` が大きい → DB 以外（コールドスタート / 認証 / シリアライズ）
   - `db_query_count` が想定以上 → 残り N+1 / `selectinload` ペア漏れ

## Test plan
- [ ] CI でユニットテスト通過（test_observability.py を追加）
- [ ] STG デプロイ後にログが Cloud Logging に届くことを確認
- [ ] 代表 4 エンドポイントの p50/p95 を集計し Issue #124 のコメントに貼る