### PR TITLE
fix: ドットクリック時のアクティブ表示が追従しないバグを修正 (#127)

### DIFF
--- a/frontend/src/components/PageSwipeContainer.tsx
+++ b/frontend/src/components/PageSwipeContainer.tsx
@@ -1,6 +1,6 @@
 import useEmblaCarousel from 'embla-carousel-react';
 import { useAtom, useAtomValue } from 'jotai';
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import { selectedPageIdAtom, tripPagesAtom } from '@/atoms/tripPage';
 import { cn } from '@/lib/utils';
 import type { Page } from '@/types';
@@ -15,20 +15,22 @@ type PageSwipeContainerProps = {
 const PageSwipeContainer = ({ renderPage, activeSlideScrollRef, className }: PageSwipeContainerProps) => {
   const pages = useAtomValue(tripPagesAtom);
   const [selectedPageId, setSelectedPageId] = useAtom(selectedPageIdAtom);
-  const selectedIndex = pages.findIndex(p => p.id === selectedPageId);
-  const [activeSnapIndex, setActiveSnapIndex] = useState(selectedIndex >= 0 ? selectedIndex : 0);
+  // ドット表示も含めて selectedPageId を単一の真実の源とする
+  const activeSnapIndex = useMemo(() => {
+    const idx = pages.findIndex(p => p.id === selectedPageId);
+    return idx >= 0 ? idx : 0;
+  }, [pages, selectedPageId]);
   const slideRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const [emblaRef, emblaApi] = useEmblaCarousel({
-    startIndex: selectedIndex >= 0 ? selectedIndex : 0,
+    startIndex: activeSnapIndex,
     watchSlides: true,
   });
 
-  // スワイプ → selectedPageId の同期 + ドットインジケーター更新
+  // スワイプ → selectedPageId の同期
   const onSelect = useCallback(() => {
     if (!emblaApi) return;
     const index = emblaApi.selectedScrollSnap();
-    setActiveSnapIndex(index);
     const page = pages[index];
     if (page && page.id !== selectedPageId) {
       setSelectedPageId(page.id);


### PR DESCRIPTION
Closes #127

## Summary

- `PageSwipeContainer` のドットインジケーターで、ドットクリック後にアクティブ表示が追従しないバグを修正
- ローカル state `activeSnapIndex` を廃止し、`selectedPageId` から `useMemo` で派生させる構成に変更
- これにより `selectedPageId` の更新（ドットクリック / Header Select / スワイプ）に対し、ドットUIが必ず同一レンダリングで追従する

## 原因

ドットの active 判定 (`index === activeSnapIndex`) は **ローカル state** に依存していたが、ドットクリックハンドラは **グローバル state (`selectedPageId`)** しか更新せず、ローカル state は embla の `select` イベント経由でしか同期されない設計だった。`emblaApi.scrollTo()` から `select` イベント発火までの間接経路で同期が落ちるケースがあり、ドット表示が古いままになっていた。


https://github.com/user-attachments/assets/9a9a8028-68c3-445f-8c1e-30c4a877057b

## 修正方針

`selectedPageId` を単一の真実の源 (single source of truth) として扱い、`activeSnapIndex` を派生値にすることで二重管理を解消した。
