### PR TITLE
feat(db): trip 期間 / page 単日程カラムを追加 (#129)

### DIFF
--- a/server/app/models.py
+++ b/server/app/models.py
@@ -2,9 +2,18 @@
 Add Trip, Page, Block, and Location models with relationships.
 """
 
-from datetime import datetime
+from datetime import date, datetime
 
-from sqlalchemy import CheckConstraint, DateTime, Float, ForeignKey, String, Text, func
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .db_connection import Base
@@ -44,6 +53,12 @@ class Location(Base):
 
 class Trip(Base):
     __tablename__ = "trips"
+    __table_args__ = (
+        CheckConstraint(
+            "start_date IS NULL OR end_date IS NULL OR start_date <= end_date",
+            name="ck_trips_start_date_le_end_date",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     url_id: Mapped[str] = mapped_column(
@@ -58,6 +73,12 @@ class Trip(Base):
     )
     detail: Mapped[str | None] = mapped_column(
         Text, nullable=True, comment="Detailed description of the trip"
+    )
+    start_date: Mapped[date | None] = mapped_column(
+        Date, nullable=True, comment="旅程開始日"
+    )
+    end_date: Mapped[date | None] = mapped_column(
+        Date, nullable=True, comment="旅程終了日"
     )
     # Relationships
     pages: Mapped[list["Page"]] = relationship(
@@ -81,6 +102,9 @@ class Page(Base):
     )
     title: Mapped[str] = mapped_column(
         String(200), nullable=False, comment="Title of the page"
+    )
+    date: Mapped[date | None] = mapped_column(
+        Date, nullable=True, comment="ページの単日程"
     )
     # Relationships
     trip: Mapped["Trip"] = relationship(

--- a/server/migrations/versions/20260519_1200_add_dates_to_trips_and_pages.py
+++ b/server/migrations/versions/20260519_1200_add_dates_to_trips_and_pages.py
@@ -1,0 +1,47 @@
+"""add_dates_to_trips_and_pages
+
+Revision ID: c3f1a7b2d9e4
+Revises: baa80efb492a
+Create Date: 2026-05-19 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3f1a7b2d9e4'
+down_revision: Union[str, Sequence[str], None] = 'baa80efb492a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'trips',
+        sa.Column('start_date', sa.Date(), nullable=True, comment='旅程開始日'),
+    )
+    op.add_column(
+        'trips',
+        sa.Column('end_date', sa.Date(), nullable=True, comment='旅程終了日'),
+    )
+    op.create_check_constraint(
+        'ck_trips_start_date_le_end_date',
+        'trips',
+        'start_date IS NULL OR end_date IS NULL OR start_date <= end_date',
+    )
+    op.add_column(
+        'pages',
+        sa.Column('date', sa.Date(), nullable=True, comment='ページの単日程'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('pages', 'date')
+    op.drop_constraint('ck_trips_start_date_le_end_date', 'trips', type_='check')
+    op.drop_column('trips', 'end_date')
+    op.drop_column('trips', 'start_date')


### PR DESCRIPTION
## 概要

Issue #129 のための DB マイグレーション + SQLAlchemy モデル定義の PR。staging に先行反映する必要があるため、Pydantic スキーマ・API・frontend の変更とは分離している。

## 変更内容

### DB マイグレーション
- `trips.start_date` (`DATE`, nullable) を追加
- `trips.end_date` (`DATE`, nullable) を追加
- `pages.date` (`DATE`, nullable) を追加
- CHECK 制約 `ck_trips_start_date_le_end_date`（両方設定時のみ `start_date <= end_date`）

### SQLAlchemy モデル定義
- `Trip` / `Page` モデルに対応カラムを追加
- `Trip` に `CheckConstraint('ck_trips_start_date_le_end_date')` を追加（テスト DB の `create_all` でも制約を再現するため）

### 意図的に含めないもの
- **インデックス**: サーバー側で日付カラムを使ったソート/フィルタクエリは現状なく（旅程一覧はクライアント側で並び替え）、テーブル規模も小さいため YAGNI で見送る
- **Pydantic スキーマ / CRUD / API ルート / frontend**: 後続 PR #133 に分離

## デプロイ手順

1. この PR を `develop` にマージ
2. staging で `alembic upgrade head` を実行してカラム追加を反映
3. その後、code PR (#133) をマージ・デプロイ

中間状態（この PR マージ後・#133 マージ前）は「DB にカラムあり / SQLAlchemy にも定義あり / API では未公開」なので実害なし。

## 関連

- 親 Issue: #129
- 後続 PR: #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
