### PR TITLE
feat: trip 期間 / page 単日程の入力・表示を追加 (#129)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@latest"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,5 +1,9 @@
 import type { Preview } from '@storybook/react';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ja';
 import '../src/index.css';
+
+dayjs.locale('ja');
 
 const preview: Preview = {
   parameters: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "jotai": "^2.18.1",
     "lodash-es": "^4.17.21",
     "lucide-react": "^0.525.0",
+    "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-day-picker": "^9.8.0",
     "react-dom": "^19.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.2.4)
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -1261,6 +1264,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
     peerDependencies:
@@ -1289,6 +1305,32 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1348,6 +1390,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -1392,6 +1447,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -1414,6 +1482,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -1423,8 +1517,99 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1501,8 +1686,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1527,8 +1751,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1584,6 +1834,71 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -1613,6 +1928,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3788,6 +4112,19 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -5784,6 +6121,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5818,6 +6164,28 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -5874,6 +6242,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -5921,6 +6303,21 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -5938,6 +6335,37 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
@@ -5945,11 +6373,145 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -6010,6 +6572,34 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -6021,6 +6611,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -6056,9 +6663,37 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -6110,6 +6745,87 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -6135,6 +6851,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -8491,6 +9214,69 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   randombytes@2.1.0:
     dependencies:

--- a/frontend/src/atoms/tripPage.ts
+++ b/frontend/src/atoms/tripPage.ts
@@ -11,6 +11,16 @@ import type { Trip } from '@/types/trip';
 /** 現在表示中の Trip */
 export const tripAtom = atom<Trip | null>(null);
 
+/** Page を date 昇順 → id 昇順で並び替える。date が null の Page は末尾。 */
+export const sortPages = (pages: Page[]): Page[] =>
+  [...pages].sort((a, b) => {
+    if (!(a.date || b.date)) return a.id - b.id;
+    if (!a.date) return 1;
+    if (!b.date) return -1;
+    const dateDiff = a.date.getTime() - b.date.getTime();
+    return dateDiff !== 0 ? dateDiff : a.id - b.id;
+  });
+
 /** Trip に紐づくページ一覧 */
 export const tripPagesAtom = atom<Page[]>([]);
 

--- a/frontend/src/components/Header.stories.tsx
+++ b/frontend/src/components/Header.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { createStore, Provider } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
 import type { ReactNode } from 'react';
-import { useRef } from 'react';
+import { useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { selectedPageIdAtom, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
 import type { Page } from '@/types';
@@ -131,7 +131,7 @@ export const LogoOnly: Story = {
 export const Default: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -158,7 +158,7 @@ export const Default: Story = {
 export const EditMode: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -185,7 +185,7 @@ export const EditMode: Story = {
 export const SinglePage: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -212,7 +212,7 @@ export const SinglePage: Story = {
 export const EmptyPages: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -239,7 +239,7 @@ export const EmptyPages: Story = {
 export const WithCustomClass: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
     className: 'border-b-2 border-blue-500',
   },
@@ -267,7 +267,7 @@ export const WithCustomClass: Story = {
 export const WithDateRange: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -295,7 +295,7 @@ export const WithDateRange: Story = {
 export const PartialDateRange: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -322,7 +322,7 @@ export const PartialDateRange: Story = {
 export const MixedDatePages: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -350,7 +350,7 @@ export const MixedDatePages: Story = {
 export const LongPageTitle: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
@@ -378,18 +378,18 @@ export const LongPageTitle: Story = {
 export const ScrolledState: Story = {
   args: {
     variant: 'full',
-    scrollContainerRef: { current: null },
+    scrollContainer: null,
     isDraggingRef: { current: false },
   },
   decorators: [
     (Story, context) => {
-      const scrollContainerRef = useRef<HTMLDivElement>(null);
+      const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
       const store = createStore();
       return (
         <Provider store={store}>
           <AtomHydrator trip={demoTrip} pages={demoPages} selectedPageId={1} mode='view'>
-            <div ref={scrollContainerRef} style={{ height: '200vh', overflow: 'auto' }}>
-              <Story args={{ ...context.args, variant: 'full', scrollContainerRef }} />
+            <div ref={setScrollContainer} style={{ height: '200vh', overflow: 'auto' }}>
+              <Story args={{ ...context.args, variant: 'full', scrollContainer }} />
               <div style={{ padding: '2rem', marginTop: '2rem' }}>
                 <h2>スクロールしてヘッダーの変化を確認</h2>
                 <p>

--- a/frontend/src/components/Header.stories.tsx
+++ b/frontend/src/components/Header.stories.tsx
@@ -23,6 +23,39 @@ const demoPages: Page[] = [
 
 const singlePage: Page[] = [{ id: 1, title: '日帰り旅行', tripId: 1 }];
 
+const demoTripWithDates: Trip = {
+  id: 1,
+  title: '北海道旅行',
+  urlId: 'trip1',
+  startDate: new Date(2026, 4, 24),
+  endDate: new Date(2026, 4, 26),
+};
+
+const demoTripStartOnly: Trip = {
+  id: 1,
+  title: '北海道旅行',
+  urlId: 'trip1',
+  startDate: new Date(2026, 4, 24),
+};
+
+const pagesWithDates: Page[] = [
+  { id: 1, title: '札幌観光', tripId: 1, date: new Date(2026, 4, 24) },
+  { id: 2, title: '小樽散策', tripId: 1, date: new Date(2026, 4, 25) },
+  { id: 3, title: '函館見学', tripId: 1, date: new Date(2026, 4, 26) },
+];
+
+const mixedDatePages: Page[] = [
+  { id: 1, title: '札幌観光', tripId: 1, date: new Date(2026, 4, 24) },
+  { id: 2, title: '札幌観光（B案）', tripId: 1, date: new Date(2026, 4, 24) },
+  { id: 3, title: '小樽散策', tripId: 1, date: new Date(2026, 4, 25) },
+  { id: 4, title: '予備プラン', tripId: 1, date: null },
+];
+
+const longTitlePages: Page[] = [
+  { id: 1, title: '北海道満喫ガッツリ堪能プラン', tripId: 1, date: new Date(2026, 4, 24) },
+  { id: 2, title: '小樽運河と寿司めぐり', tripId: 1, date: new Date(2026, 4, 25) },
+];
+
 /** Storybook 用に atom を初期化するラッパー */
 const AtomHydrator = ({
   trip,
@@ -226,6 +259,117 @@ export const WithCustomClass: Story = {
     docs: {
       description: {
         story: 'カスタムCSSクラスを適用した例。下部に青い境界線が追加されます。',
+      },
+    },
+  },
+};
+
+export const WithDateRange: Story = {
+  args: {
+    variant: 'full',
+    scrollContainerRef: { current: null },
+    isDraggingRef: { current: false },
+  },
+  decorators: [
+    Story => {
+      const store = createStore();
+      return (
+        <Provider store={store}>
+          <AtomHydrator trip={demoTripWithDates} pages={pagesWithDates} selectedPageId={1} mode='view'>
+            <Story />
+          </AtomHydrator>
+        </Provider>
+      );
+    },
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Trip 期間あり・Page 日付ありの基本ケース。タイトル下に期間（M/D(曜)〜M/D(曜)）、Select に MM/DD(曜) · title。',
+      },
+    },
+  },
+};
+
+export const PartialDateRange: Story = {
+  args: {
+    variant: 'full',
+    scrollContainerRef: { current: null },
+    isDraggingRef: { current: false },
+  },
+  decorators: [
+    Story => {
+      const store = createStore();
+      return (
+        <Provider store={store}>
+          <AtomHydrator trip={demoTripStartOnly} pages={pagesWithDates} selectedPageId={1} mode='view'>
+            <Story />
+          </AtomHydrator>
+        </Provider>
+      );
+    },
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Trip 期間が片方のみ（開始日のみ）設定されている場合。サブタイトルは `M/D(曜) 〜` のみ。',
+      },
+    },
+  },
+};
+
+export const MixedDatePages: Story = {
+  args: {
+    variant: 'full',
+    scrollContainerRef: { current: null },
+    isDraggingRef: { current: false },
+  },
+  decorators: [
+    Story => {
+      const store = createStore();
+      return (
+        <Provider store={store}>
+          <AtomHydrator trip={demoTripWithDates} pages={mixedDatePages} selectedPageId={1} mode='edit'>
+            <Story />
+          </AtomHydrator>
+        </Provider>
+      );
+    },
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'date 重複（同日に A案/B案 のような複数 Page）と date=null（予備プラン）が混在するケース。並び順: date 昇順 → id 昇順 → null 末尾。',
+      },
+    },
+  },
+};
+
+export const LongPageTitle: Story = {
+  args: {
+    variant: 'full',
+    scrollContainerRef: { current: null },
+    isDraggingRef: { current: false },
+  },
+  decorators: [
+    Story => {
+      const store = createStore();
+      return (
+        <Provider store={store}>
+          <AtomHydrator trip={demoTripWithDates} pages={longTitlePages} selectedPageId={1} mode='view'>
+            <Story />
+          </AtomHydrator>
+        </Provider>
+      );
+    },
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '長いタイトルで Select トリガーが 2 行に折り返されるケース。狭いビューポートで顕著（max-w-[30vw] の制約による）。',
       },
     },
   },

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -356,7 +356,7 @@ const ShareButton = () => {
 const PageLabel = ({ page }: { page: { title: string; date?: Date | null } }) => (
   <>
     {page.date && (
-      <span className='whitespace-nowrap font-mono text-12px text-slate-500'>{formatDateMDWithDow(page.date)} ·</span>
+      <span className='whitespace-nowrap font-mono text-12px text-slate-500'>{formatDateMDWithDow(page.date)} </span>
     )}
     <span className='min-w-[7em] flex-1 truncate'>{page.title}</span>
   </>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -196,12 +196,17 @@ function HeaderFull({ className, scrollContainer, isDraggingRef, ...props }: Omi
               }
             }}
           >
-            <SelectTrigger className='h-auto min-h-9 max-w-[90vw] bg-white *:data-[slot=select-value]:line-clamp-none *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:flex-wrap *:data-[slot=select-value]:gap-x-2 sm:max-w-[30vw]'>
+            <SelectTrigger className='min-h-9 max-w-[90vw] bg-white data-[size=default]:h-auto *:data-[slot=select-value]:line-clamp-none *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:flex-wrap *:data-[slot=select-value]:gap-x-2 sm:max-w-[30vw]'>
               <SelectValue placeholder='ページ選択' />
             </SelectTrigger>
             <SelectContent className='max-w-[90vw]'>
               {pages.map(page => (
-                <SelectItem key={page.id} value={String(page.id)}>
+                <SelectItem
+                  key={page.id}
+                  value={String(page.id)}
+                  // ItemText span (shadcn の `*:[span]:last:*` で flex化される) に flex-1 + min-w-0 を当てて PageLabel 側の truncate を有効化
+                  className='*:[span]:last:min-w-0 *:[span]:last:flex-1'
+                >
                   <PageLabel page={page} />
                 </SelectItem>
               ))}
@@ -354,12 +359,15 @@ const ShareButton = () => {
 };
 
 const PageLabel = ({ page }: { page: { title: string; date?: Date | null } }) => (
-  <>
+  // flex-wrap で長すぎたら 2 行折り返し、items-center で日付（小フォント）と title の縦位置を揃える
+  <span className='flex min-w-0 flex-1 flex-wrap items-center gap-x-2'>
     {page.date && (
-      <span className='whitespace-nowrap font-mono text-12px text-slate-500'>{formatDateMDWithDow(page.date)} </span>
+      <span className='shrink-0 whitespace-nowrap font-mono text-12px text-slate-500'>
+        {formatDateMDWithDow(page.date)}
+      </span>
     )}
-    <span className='min-w-[7em] flex-1 truncate'>{page.title}</span>
-  </>
+    <span className='min-w-0 truncate'>{page.title}</span>
+  </span>
 );
 
 const PageInfoEditButton = ({ isScrolled, onClick }: { isScrolled: boolean; onClick?: () => void }) => (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -12,6 +12,7 @@ import { selectedPageAtom, selectedPageIdAtom, tripAtom, tripModeAtom, tripPages
 import { AddPageDialog } from '@/dialogs/AddPageDialog';
 import { EditPageDialog } from '@/dialogs/EditPageDialog';
 import { EditTripDialog } from '@/dialogs/EditTripDialog';
+import { formatDateMDWithDow, formatTripRangeMD } from '@/lib/date';
 import { cn } from '@/lib/utils';
 import { Logo } from './Logo';
 import { NetworkStatusButton } from './NetworkStatusButton';
@@ -58,6 +59,7 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
   const [selectedPageId, setSelectedPageId] = useAtom(selectedPageIdAtom);
   const mode = useAtomValue(tripModeAtom);
   const selectedPage = useAtomValue(selectedPageAtom);
+  const tripRangeText = formatTripRangeMD(trip?.startDate, trip?.endDate);
 
   const [isScrolled, setIsScrolled] = useState(false);
   const [editPageDialogOpen, setEditPageDialogOpen] = useState(false);
@@ -89,21 +91,23 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
     // isScrolledの次の状態を計算する
     let nextIsScrolled = isScrolled;
 
-    if (scrollTop < 50) {
+    const scrollTopThreshold = 100;
+
+    if (scrollTop < scrollTopThreshold) {
       // ページ最上部では常に表示
       nextIsScrolled = false;
     }
 
     // スクロール末端のバウンスを無視
     const maxScroll = container.scrollHeight - container.clientHeight;
-    const isNearBottom = maxScroll - scrollTop < 50;
+    const isNearBottom = maxScroll - scrollTop < scrollTopThreshold;
 
     if (isNearBottom && isScrolled && deltaY < 0) {
       // 最下部バウンスではヘッダー展開しない（ベースラインも更新しない）
       return;
     }
 
-    if (scrollTop >= 50 && Math.abs(deltaY) > 10) {
+    if (scrollTop >= scrollTopThreshold && Math.abs(deltaY) > 10) {
       if (deltaY < 0 && isScrolled) {
         // 上スクロール and ヘッダーが非表示中 -> 表示させる
         nextIsScrolled = false;
@@ -151,7 +155,7 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
         {/* 左カラム */}
         <div
           className={cn(
-            'flex justify-start transition-[font-size] sm:justify-end',
+            'flex flex-col items-start transition-[font-size] sm:items-end',
             transitionClassNames,
             isScrolled ? 'text-14px sm:text-16px' : 'text-16px sm:text-20px'
           )}
@@ -166,7 +170,10 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
               <Pencil className='size-3 shrink-0 opacity-60' />
             </button>
           ) : (
-            trip.title
+            <span>{trip.title}</span>
+          )}
+          {!isScrolled && tripRangeText && (
+            <span className='text-12px text-slate-500 sm:text-14px'>{tripRangeText}</span>
           )}
         </div>
 
@@ -188,13 +195,13 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
               }
             }}
           >
-            <SelectTrigger className='max-w-[90vw] bg-white sm:max-w-[30vw]'>
+            <SelectTrigger className='h-auto min-h-9 max-w-[90vw] bg-white *:data-[slot=select-value]:line-clamp-none *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:flex-wrap *:data-[slot=select-value]:gap-x-2 sm:max-w-[30vw]'>
               <SelectValue placeholder='ページ選択' />
             </SelectTrigger>
             <SelectContent className='max-w-[90vw]'>
               {pages.map(page => (
                 <SelectItem key={page.id} value={String(page.id)}>
-                  {page.title}
+                  <PageLabel page={page} />
                 </SelectItem>
               ))}
               {mode === 'edit' && (
@@ -344,6 +351,15 @@ const ShareButton = () => {
     </Button>
   );
 };
+
+const PageLabel = ({ page }: { page: { title: string; date?: Date | null } }) => (
+  <>
+    {page.date && (
+      <span className='whitespace-nowrap font-mono text-12px text-slate-500'>{formatDateMDWithDow(page.date)} ·</span>
+    )}
+    <span className='min-w-[7em] flex-1 truncate'>{page.title}</span>
+  </>
+);
 
 const PageInfoEditButton = ({ isScrolled, onClick }: { isScrolled: boolean; onClick?: () => void }) => (
   <HeaderButtonBase

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -28,7 +28,8 @@ type HeaderLogoOnlyProps = HeaderBaseProps & {
 
 type HeaderFullProps = HeaderBaseProps & {
   variant: 'full';
-  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  /** スクロール監視対象。state で渡すことで、要素が差し替わったときに listener を再 attach する */
+  scrollContainer: HTMLDivElement | null;
   isDraggingRef: React.RefObject<boolean>;
 };
 
@@ -52,7 +53,7 @@ function HeaderLogoOnly({ className, ...props }: HeaderLogoOnlyProps) {
   );
 }
 
-function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: Omit<HeaderFullProps, 'variant'>) {
+function HeaderFull({ className, scrollContainer, isDraggingRef, ...props }: Omit<HeaderFullProps, 'variant'>) {
   const isOffline = useAtomValue(isOfflineReadAtom);
   const trip = useAtomValue(tripAtom);
   const pages = useAtomValue(tripPagesAtom);
@@ -75,44 +76,41 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
   }, []);
 
   const handleScroll = useCallback(() => {
-    const container = scrollContainerRef?.current;
+    const container = scrollContainer;
     if (!container) return;
 
     const scrollTop = container.scrollTop;
 
-    // ドラッグ中はisScrolledの更新をスキップし、スクロール位置の基準だけ更新する
+    // ドラッグ中は自動スクロールを誤検知しないよう、基準だけ更新して判定はスキップ
     if (isDraggingRef.current) {
       scrollY.current = scrollTop;
       return;
     }
 
     const deltaY = scrollTop - scrollY.current;
-
-    // isScrolledの次の状態を計算する
     let nextIsScrolled = isScrolled;
 
-    const scrollTopThreshold = 100;
+    const TOP_JITTER_PX = 30;
+    const BOTTOM_BOUNCE_PX = 40; // iOS ラバーバンドでの誤展開を防ぐ末端マージン
 
-    if (scrollTop < scrollTopThreshold) {
-      // ページ最上部では常に表示
+    // deltaY <= 0 条件: compact のままコンテナ切替(scrollTop=0始まり)→下スクロール開始時に
+    // 一瞬 expanded へ戻るちらつきを防ぐ（下スクロール中は最上部判定を効かせない）
+    if (scrollTop < TOP_JITTER_PX && deltaY <= 0) {
       nextIsScrolled = false;
     }
 
-    // スクロール末端のバウンスを無視
     const maxScroll = container.scrollHeight - container.clientHeight;
-    const isNearBottom = maxScroll - scrollTop < scrollTopThreshold;
+    const isNearBottom = maxScroll - scrollTop < BOTTOM_BOUNCE_PX;
 
     if (isNearBottom && isScrolled && deltaY < 0) {
-      // 最下部バウンスではヘッダー展開しない（ベースラインも更新しない）
+      // 最下部バウンスでの誤展開を無視（基準も更新しない）
       return;
     }
 
-    if (scrollTop >= scrollTopThreshold && Math.abs(deltaY) > 10) {
+    if (scrollTop >= TOP_JITTER_PX && Math.abs(deltaY) > 10) {
       if (deltaY < 0 && isScrolled) {
-        // 上スクロール and ヘッダーが非表示中 -> 表示させる
         nextIsScrolled = false;
       } else if (deltaY > 0 && !isScrolled) {
-        // 下スクロール and ヘッダーが表示中 -> 非表示にさせる
         nextIsScrolled = true;
       }
     }
@@ -120,19 +118,22 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
     if (nextIsScrolled !== isScrolled) {
       setIsScrolled(nextIsScrolled);
     } else {
-      // 状態が変化しなかった場合のみ、スクロール位置の基準を更新
-      // レイアウトシフトによる誤作動を防ぐ
+      // 状態が変わらない時だけ基準更新（レイアウトシフトでの誤作動防止）
       scrollY.current = scrollTop;
     }
-  }, [isScrolled, scrollContainerRef, isDraggingRef]);
+  }, [isScrolled, scrollContainer, isDraggingRef]);
+
+  // コンテナ切替時に基準を同期しないと、初回 deltaY が前コンテナとの差分になり誤判定する
+  useEffect(() => {
+    scrollY.current = scrollContainer?.scrollTop ?? 0;
+  }, [scrollContainer]);
 
   useEffect(() => {
-    const container = scrollContainerRef?.current;
-    if (!container) return;
+    if (!scrollContainer) return;
 
-    container.addEventListener('scroll', handleScroll);
-    return () => container.removeEventListener('scroll', handleScroll);
-  }, [handleScroll, scrollContainerRef]);
+    scrollContainer.addEventListener('scroll', handleScroll);
+    return () => scrollContainer.removeEventListener('scroll', handleScroll);
+  }, [handleScroll, scrollContainer]);
 
   if (!trip) return null;
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -223,7 +223,7 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
       <AddPageDialog
         open={addPageDialogOpen}
         onOpenChange={setAddPageDialogOpen}
-        tripId={trip.id}
+        trip={trip}
         onCreated={page => {
           setSelectedPageId(page.id);
         }}
@@ -235,6 +235,7 @@ function HeaderFull({ className, scrollContainerRef, isDraggingRef, ...props }: 
           open={editPageDialogOpen}
           onOpenChange={setEditPageDialogOpen}
           page={selectedPage}
+          trip={trip}
           onDeleted={pageId => {
             const remainingPages = pages.filter(p => p.id !== pageId);
             if (remainingPages.length > 0) {

--- a/frontend/src/components/PageSwipeContainer.tsx
+++ b/frontend/src/components/PageSwipeContainer.tsx
@@ -7,12 +7,12 @@ import type { Page } from '@/types';
 
 type PageSwipeContainerProps = {
   renderPage: (page: Page) => ReactNode;
-  /** 現在アクティブなスライドのスクロールコンテナの ref を外部に公開する */
-  activeSlideScrollRef?: React.RefObject<HTMLDivElement | null>;
+  /** アクティブなスライドのスクロールコンテナが変わったときに通知するコールバック */
+  onActiveSlideChange?: (el: HTMLDivElement | null) => void;
   className?: string;
 };
 
-const PageSwipeContainer = ({ renderPage, activeSlideScrollRef, className }: PageSwipeContainerProps) => {
+const PageSwipeContainer = ({ renderPage, onActiveSlideChange, className }: PageSwipeContainerProps) => {
   const pages = useAtomValue(tripPagesAtom);
   const [selectedPageId, setSelectedPageId] = useAtom(selectedPageIdAtom);
   // ドット表示も含めて selectedPageId を単一の真実の源とする
@@ -54,13 +54,12 @@ const PageSwipeContainer = ({ renderPage, activeSlideScrollRef, className }: Pag
     }
   }, [emblaApi, pages, selectedPageId]);
 
-  // アクティブスライドの scroll コンテナを外部 ref に接続
+  // アクティブスライドの scroll コンテナを外部に通知
   useEffect(() => {
-    if (!activeSlideScrollRef) return;
+    if (!onActiveSlideChange) return;
     const activeSlide = slideRefs.current[activeSnapIndex] ?? null;
-    // RefObject の current を書き換え
-    (activeSlideScrollRef as { current: HTMLDivElement | null }).current = activeSlide;
-  }, [activeSnapIndex, activeSlideScrollRef]);
+    onActiveSlideChange(activeSlide);
+  }, [activeSnapIndex, onActiveSlideChange]);
 
   return (
     <div className={cn('flex h-full flex-col', className)}>

--- a/frontend/src/components/ui/date-picker.stories.tsx
+++ b/frontend/src/components/ui/date-picker.stories.tsx
@@ -1,0 +1,187 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { DatePicker, DateRangePicker } from './date-picker';
+
+const meta: Meta<typeof DatePicker> = {
+  title: 'UI/DatePicker',
+  component: DatePicker,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DatePicker>;
+
+const ControlledDatePicker = ({
+  initial = null,
+  highlightStart,
+  highlightEnd,
+  invalid,
+}: {
+  initial?: Date | null;
+  highlightStart?: Date | null;
+  highlightEnd?: Date | null;
+  invalid?: boolean;
+}) => {
+  const [value, setValue] = useState<Date | null>(initial);
+  return (
+    <div className='w-72'>
+      <DatePicker
+        value={value}
+        onChange={setValue}
+        highlightStart={highlightStart}
+        highlightEnd={highlightEnd}
+        invalid={invalid}
+      />
+    </div>
+  );
+};
+
+const ControlledDateRangePicker = ({
+  initialStart = null,
+  initialEnd = null,
+}: {
+  initialStart?: Date | null;
+  initialEnd?: Date | null;
+}) => {
+  const [start, setStart] = useState<Date | null>(initialStart);
+  const [end, setEnd] = useState<Date | null>(initialEnd);
+  return (
+    <div className='w-72'>
+      <DateRangePicker
+        start={start}
+        end={end}
+        onChange={(s, e) => {
+          setStart(s);
+          setEnd(e);
+        }}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <ControlledDatePicker />,
+  parameters: {
+    docs: {
+      description: {
+        story: '未選択の単一日付ピッカー。クリックでカレンダーを開く。',
+      },
+    },
+  },
+};
+
+export const Selected: Story = {
+  render: () => <ControlledDatePicker initial={new Date(2026, 4, 25)} />,
+  parameters: {
+    docs: {
+      description: {
+        story: '日付選択済み。✕ ボタンで未選択に戻せる。',
+      },
+    },
+  },
+};
+
+export const WithTripRangeHighlight: Story = {
+  render: () => <ControlledDatePicker highlightStart={new Date(2026, 4, 24)} highlightEnd={new Date(2026, 4, 26)} />,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Trip 期間（05/24〜05/26）をハイライト表示。範囲外も選択可。',
+      },
+    },
+  },
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <ControlledDatePicker
+      initial={new Date(2026, 4, 30)}
+      highlightStart={new Date(2026, 4, 24)}
+      highlightEnd={new Date(2026, 4, 26)}
+      invalid
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Trip 期間外の日付が選択されている状態（warning 配色）。',
+      },
+    },
+  },
+};
+
+export const Range: Story = {
+  render: () => <ControlledDateRangePicker />,
+  parameters: {
+    docs: {
+      description: {
+        story: '期間選択（DateRangePicker）。範囲カレンダーで開始日と終了日を指定。',
+      },
+    },
+  },
+};
+
+export const RangeSelected: Story = {
+  render: () => <ControlledDateRangePicker initialStart={new Date(2026, 4, 24)} initialEnd={new Date(2026, 4, 26)} />,
+  parameters: {
+    docs: {
+      description: {
+        story: '期間選択済み。',
+      },
+    },
+  },
+};
+
+export const RangeStartOnly: Story = {
+  render: () => <ControlledDateRangePicker initialStart={new Date(2026, 4, 24)} />,
+  parameters: {
+    docs: {
+      description: {
+        story: '開始日のみ設定（終了日なし）。表示は `YYYY/MM/DD(曜) 〜`。',
+      },
+    },
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className='flex flex-col gap-6'>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-sm'>DatePicker - 未選択</p>
+        <ControlledDatePicker />
+      </div>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-sm'>DatePicker - 選択済み</p>
+        <ControlledDatePicker initial={new Date(2026, 4, 25)} />
+      </div>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-sm'>DatePicker - Trip 期間ハイライト</p>
+        <ControlledDatePicker highlightStart={new Date(2026, 4, 24)} highlightEnd={new Date(2026, 4, 26)} />
+      </div>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-sm'>DatePicker - 範囲外警告</p>
+        <ControlledDatePicker
+          initial={new Date(2026, 4, 30)}
+          highlightStart={new Date(2026, 4, 24)}
+          highlightEnd={new Date(2026, 4, 26)}
+          invalid
+        />
+      </div>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-sm'>DateRangePicker - 未選択</p>
+        <ControlledDateRangePicker />
+      </div>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-sm'>DateRangePicker - 選択済み</p>
+        <ControlledDateRangePicker initialStart={new Date(2026, 4, 24)} initialEnd={new Date(2026, 4, 26)} />
+      </div>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-sm'>DateRangePicker - 開始日のみ</p>
+        <ControlledDateRangePicker initialStart={new Date(2026, 4, 24)} />
+      </div>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -1,0 +1,144 @@
+import { CalendarIcon, XIcon } from 'lucide-react';
+import { useState } from 'react';
+import type { DateRange } from 'react-day-picker';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { formatDateYMDWithDow, formatTripRangeYMD } from '@/lib/date';
+import { cn } from '@/lib/utils';
+
+interface DatePickerProps {
+  value: Date | null;
+  onChange: (value: Date | null) => void;
+  /** 強調表示する基準範囲（Trip 期間など） */
+  highlightStart?: Date | null;
+  highlightEnd?: Date | null;
+  placeholder?: string;
+  id?: string;
+  invalid?: boolean;
+}
+
+/**
+ * 単一日付選択用のピッカー。Popover + Calendar の組み合わせ。
+ */
+export const DatePicker = ({
+  value,
+  onChange,
+  highlightStart,
+  highlightEnd,
+  placeholder = '日付を選択',
+  id,
+  invalid = false,
+}: DatePickerProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className='relative'>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type='button'
+            variant='outline'
+            className={cn(
+              'w-full justify-start gap-2 pr-9 font-normal',
+              !value && 'text-muted-foreground',
+              invalid && 'border-amber-400 bg-amber-50 hover:bg-amber-50'
+            )}
+          >
+            <CalendarIcon className='size-4 shrink-0' />
+            <span className='flex-1 text-left'>{value ? formatDateYMDWithDow(value) : placeholder}</span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className='w-auto p-0' align='start'>
+          <Calendar
+            mode='single'
+            selected={value ?? undefined}
+            defaultMonth={value ?? highlightStart ?? undefined}
+            onSelect={d => {
+              onChange(d ?? null);
+              setOpen(false);
+            }}
+            modifiers={{
+              tripRange:
+                highlightStart || highlightEnd
+                  ? (date: Date) => {
+                      if (highlightStart && date < highlightStart) return false;
+                      if (highlightEnd && date > highlightEnd) return false;
+                      return Boolean(highlightStart) || Boolean(highlightEnd);
+                    }
+                  : undefined,
+            }}
+            modifiersClassNames={{
+              tripRange: 'bg-teal-50 text-teal-900',
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+      {value && (
+        <button
+          type='button'
+          aria-label='クリア'
+          onClick={() => onChange(null)}
+          className='-translate-y-1/2 absolute top-1/2 right-2 rounded p-0.5 text-muted-foreground hover:text-foreground'
+        >
+          <XIcon className='size-3.5' />
+        </button>
+      )}
+    </div>
+  );
+};
+
+interface DateRangePickerProps {
+  start: Date | null;
+  end: Date | null;
+  onChange: (start: Date | null, end: Date | null) => void;
+  placeholder?: string;
+  id?: string;
+}
+
+/**
+ * 期間（開始日〜終了日）選択用のピッカー。片方のみの設定も可能。
+ */
+export const DateRangePicker = ({ start, end, onChange, placeholder = '期間を選択', id }: DateRangePickerProps) => {
+  const [open, setOpen] = useState(false);
+  const display = formatTripRangeYMD(start, end);
+
+  return (
+    <div className='relative'>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type='button'
+            variant='outline'
+            className={cn('w-full justify-start gap-2 pr-9 font-normal', !display && 'text-muted-foreground')}
+          >
+            <CalendarIcon className='size-4 shrink-0' />
+            <span className='flex-1 text-left'>{display ?? placeholder}</span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className='w-auto p-0' align='start'>
+          <Calendar
+            mode='range'
+            selected={{ from: start ?? undefined, to: end ?? undefined } as DateRange}
+            defaultMonth={start ?? end ?? undefined}
+            onSelect={range => {
+              onChange(range?.from ?? null, range?.to ?? null);
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+      {display && (
+        <button
+          type='button'
+          aria-label='クリア'
+          onClick={() => onChange(null, null)}
+          className='-translate-y-1/2 absolute top-1/2 right-2 rounded p-0.5 text-muted-foreground hover:text-foreground'
+        >
+          <XIcon className='size-3.5' />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -1,3 +1,4 @@
+import { ja } from 'date-fns/locale/ja';
 import { CalendarIcon, XIcon } from 'lucide-react';
 import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
@@ -52,6 +53,7 @@ export const DatePicker = ({
         </PopoverTrigger>
         <PopoverContent className='w-auto p-0' align='start'>
           <Calendar
+            locale={ja}
             mode='single'
             selected={value ?? undefined}
             defaultMonth={value ?? highlightStart ?? undefined}
@@ -120,6 +122,7 @@ export const DateRangePicker = ({ start, end, onChange, placeholder = '期間を
         </PopoverTrigger>
         <PopoverContent className='w-auto p-0' align='start'>
           <Calendar
+            locale={ja}
             mode='range'
             selected={{ from: start ?? undefined, to: end ?? undefined } as DateRange}
             defaultMonth={start ?? end ?? undefined}

--- a/frontend/src/components/ui/popover.stories.tsx
+++ b/frontend/src/components/ui/popover.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './button';
+import { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger } from './popover';
+
+const meta: Meta<typeof Popover> = {
+  title: 'UI/Popover',
+  component: Popover,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline'>開く</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverHeader>
+          <PopoverTitle>ポップオーバー</PopoverTitle>
+          <PopoverDescription>説明文をここに表示します。</PopoverDescription>
+        </PopoverHeader>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const WithForm: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline'>設定を開く</Button>
+      </PopoverTrigger>
+      <PopoverContent className='w-80'>
+        <div className='space-y-2'>
+          <h4 className='font-medium leading-none'>表示設定</h4>
+          <p className='text-muted-foreground text-sm'>パネルの表示形式をカスタマイズします。</p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const AlignStart: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline'>左寄せ</Button>
+      </PopoverTrigger>
+      <PopoverContent align='start'>
+        <p className='text-sm'>align=&quot;start&quot; で左寄せ表示。</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const AlignEnd: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='outline'>右寄せ</Button>
+      </PopoverTrigger>
+      <PopoverContent align='end'>
+        <p className='text-sm'>align=&quot;end&quot; で右寄せ表示。</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className='flex flex-wrap gap-4'>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant='outline'>Default</Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <PopoverHeader>
+            <PopoverTitle>タイトル</PopoverTitle>
+            <PopoverDescription>説明</PopoverDescription>
+          </PopoverHeader>
+        </PopoverContent>
+      </Popover>
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant='outline'>Align start</Button>
+        </PopoverTrigger>
+        <PopoverContent align='start'>
+          <p className='text-sm'>左寄せ</p>
+        </PopoverContent>
+      </Popover>
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant='outline'>Align end</Button>
+        </PopoverTrigger>
+        <PopoverContent align='end'>
+          <p className='text-sm'>右寄せ</p>
+        </PopoverContent>
+      </Popover>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -42,7 +42,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
-  return <div data-slot='popover-title' className={cn('font-medium', className)} {...props} />;
+  return <h2 data-slot='popover-title' className={cn('font-medium', className)} {...props} />;
 }
 
 function PopoverDescription({ className, ...props }: React.ComponentProps<'p'>) {

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,52 @@
+import { Popover as PopoverPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot='popover' {...props} />;
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot='popover-trigger' {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot='popover-content'
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot='popover-anchor' {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot='popover-header' className={cn('flex flex-col gap-1 text-sm', className)} {...props} />;
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
+  return <div data-slot='popover-title' className={cn('font-medium', className)} {...props} />;
+}
+
+function PopoverDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return <p data-slot='popover-description' className={cn('text-muted-foreground', className)} {...props} />;
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, PopoverHeader, PopoverTitle, PopoverDescription };

--- a/frontend/src/dialogs/AddPageDialog.tsx
+++ b/frontend/src/dialogs/AddPageDialog.tsx
@@ -1,26 +1,38 @@
-import { useEffect, useState } from 'react';
+import { AlertTriangleIcon } from 'lucide-react';
+import { useEffect, useId, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
 import { Dialog, DialogBody, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useCreatePage } from '@/hooks/usePages';
+import { formatTripRangeYMD, isDateOutsideRange } from '@/lib/date';
 import { PAGE_TITLE_MAX_LENGTH, type Page } from '@/types';
+import type { Trip } from '@/types/trip';
 
 interface AddPageDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  tripId: number;
+  /** 親 Trip。tripId と日付範囲ハイライト・警告判定に使用 */
+  trip: Trip;
   onCreated?: (page: Page) => void;
 }
 
-export const AddPageDialog = ({ open, onOpenChange, tripId, onCreated }: AddPageDialogProps) => {
+export const AddPageDialog = ({ open, onOpenChange, trip, onCreated }: AddPageDialogProps) => {
+  const titleId = useId();
+  const dateId = useId();
   const [title, setTitle] = useState('');
-  const { createPage, isCreating } = useCreatePage(tripId);
+  const [date, setDate] = useState<Date | null>(null);
+  const { createPage, isCreating } = useCreatePage(trip.id);
+
+  const isOutsideRange = isDateOutsideRange(date, trip.startDate, trip.endDate);
+  const tripRangeText = formatTripRangeYMD(trip.startDate, trip.endDate);
 
   // ダイアログが開いたときにフォームを初期化
   useEffect(() => {
     if (open && !isCreating) {
       setTitle('');
+      setDate(null);
     }
   }, [open, isCreating]);
 
@@ -29,7 +41,7 @@ export const AddPageDialog = ({ open, onOpenChange, tripId, onCreated }: AddPage
       return;
     }
 
-    const newPage = await createPage({ title: title.trim(), detail: '', tripId });
+    const newPage = await createPage({ title: title.trim(), detail: '', tripId: trip.id, date });
     if (newPage) {
       onCreated?.(newPage);
       onOpenChange(false);
@@ -37,9 +49,9 @@ export const AddPageDialog = ({ open, onOpenChange, tripId, onCreated }: AddPage
   };
 
   // 作成中はダイアログを閉じない
-  const handleOpenChange = (open: boolean) => {
-    if (!open && isCreating) return;
-    onOpenChange(open);
+  const handleOpenChange = (next: boolean) => {
+    if (!next && isCreating) return;
+    onOpenChange(next);
   };
 
   return (
@@ -59,17 +71,37 @@ export const AddPageDialog = ({ open, onOpenChange, tripId, onCreated }: AddPage
         <DialogBody>
           <div className='space-y-4'>
             <div className='space-y-2'>
-              <Label htmlFor='add-page-title'>
+              <Label htmlFor={titleId}>
                 タイトル<span className='text-red-500'>*</span>
               </Label>
               <Input
-                id='add-page-title'
+                id={titleId}
                 value={title}
                 onChange={e => setTitle(e.target.value)}
                 placeholder='ページのタイトル'
                 required
                 maxLength={PAGE_TITLE_MAX_LENGTH}
               />
+            </div>
+            <div className='space-y-2'>
+              <Label htmlFor={dateId}>
+                日付
+                <span className='ml-1 text-muted-foreground text-xs'>（任意）</span>
+              </Label>
+              <DatePicker
+                id={dateId}
+                value={date}
+                onChange={setDate}
+                highlightStart={trip.startDate}
+                highlightEnd={trip.endDate}
+                invalid={isOutsideRange}
+              />
+              {isOutsideRange && tripRangeText && (
+                <p className='flex items-center gap-1 text-amber-600 text-xs'>
+                  <AlertTriangleIcon className='size-3.5' />
+                  旅行期間（{tripRangeText}）外の日付です
+                </p>
+              )}
             </div>
           </div>
         </DialogBody>

--- a/frontend/src/dialogs/AddTripDialog.tsx
+++ b/frontend/src/dialogs/AddTripDialog.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react';
+import { ChevronRightIcon } from 'lucide-react';
+import { useEffect, useId, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { DateRangePicker } from '@/components/ui/date-picker';
 import { Dialog, DialogBody, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -14,9 +16,14 @@ interface AddTripDialogProps {
 }
 
 export const AddTripDialog = ({ open, onOpenChange, onCreated }: AddTripDialogProps) => {
+  const titleId = useId();
+  const dateId = useId();
+  const detailId = useId();
   const [title, setTitle] = useState('');
   const [detail, setDetail] = useState('');
-  const [peopleNum, setPeopleNum] = useState<number | undefined>(undefined);
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
   const { createTrip, isCreating } = useCreateTrip();
 
   // ダイアログが開いたときにフォームを初期化
@@ -24,7 +31,9 @@ export const AddTripDialog = ({ open, onOpenChange, onCreated }: AddTripDialogPr
     if (open && !isCreating) {
       setTitle('');
       setDetail('');
-      setPeopleNum(undefined);
+      setStartDate(null);
+      setEndDate(null);
+      setDetailOpen(false);
     }
   }, [open, isCreating]);
 
@@ -36,7 +45,9 @@ export const AddTripDialog = ({ open, onOpenChange, onCreated }: AddTripDialogPr
     const newTrip = await createTrip({
       title: title.trim(),
       detail: detail.trim() || undefined,
-      peopleNum: peopleNum,
+      peopleNum: undefined,
+      startDate,
+      endDate,
     });
 
     if (newTrip) {
@@ -46,9 +57,9 @@ export const AddTripDialog = ({ open, onOpenChange, onCreated }: AddTripDialogPr
   };
 
   // 作成中はダイアログを閉じない
-  const handleOpenChange = (open: boolean) => {
-    if (!open && isCreating) return;
-    onOpenChange(open);
+  const handleOpenChange = (next: boolean) => {
+    if (!next && isCreating) return;
+    onOpenChange(next);
   };
 
   return (
@@ -68,11 +79,11 @@ export const AddTripDialog = ({ open, onOpenChange, onCreated }: AddTripDialogPr
         <DialogBody>
           <div className='space-y-4'>
             <div className='space-y-2'>
-              <Label htmlFor='add-trip-title'>
+              <Label htmlFor={titleId}>
                 タイトル<span className='text-red-500'>*</span>
               </Label>
               <Input
-                id='add-trip-title'
+                id={titleId}
                 value={title}
                 onChange={e => setTitle(e.target.value)}
                 placeholder='例: 箱根温泉旅行'
@@ -81,31 +92,42 @@ export const AddTripDialog = ({ open, onOpenChange, onCreated }: AddTripDialogPr
               />
             </div>
             <div className='space-y-2'>
-              <Label htmlFor='add-trip-detail'>詳細</Label>
-              <LazyMarkdownEditor
-                className='max-h-72'
-                id='add-trip-detail'
-                value={detail}
-                onChange={setDetail}
-                placeholder='旅程の詳細や目的など（省略可）'
-              />
-            </div>
-            {/* 人数フィールドは一旦非表示
-            <div className='space-y-2'>
-              <Label htmlFor='add-trip-people-num'>人数</Label>
-              <Input
-                id='add-trip-people-num'
-                type='number'
-                min='1'
-                value={peopleNum ?? ''}
-                onChange={e => {
-                  const parsed = parseInt(e.target.value, 10);
-                  setPeopleNum(!Number.isNaN(parsed) && parsed >= 1 ? parsed : undefined);
+              <Label htmlFor={dateId}>
+                期間
+                <span className='ml-1 text-muted-foreground text-xs'>（任意）</span>
+              </Label>
+              <DateRangePicker
+                id={dateId}
+                start={startDate}
+                end={endDate}
+                onChange={(s, e) => {
+                  setStartDate(s);
+                  setEndDate(e);
                 }}
-                placeholder='例: 4（省略可）'
               />
             </div>
-            */}
+
+            <button
+              type='button'
+              onClick={() => setDetailOpen(prev => !prev)}
+              className='flex w-full items-center gap-1 rounded border border-input px-3 py-2 text-left text-muted-foreground text-sm hover:bg-accent'
+              aria-expanded={detailOpen}
+              aria-controls={detailId}
+            >
+              <ChevronRightIcon className={`size-4 transition-transform ${detailOpen ? 'rotate-90' : ''}`} />
+              <span>詳細を追加（任意）</span>
+            </button>
+            {detailOpen && (
+              <div id={detailId} className='space-y-2'>
+                <LazyMarkdownEditor
+                  className='max-h-72'
+                  id={`${detailId}-editor`}
+                  value={detail}
+                  onChange={setDetail}
+                  placeholder='旅程の詳細や目的など（省略可）'
+                />
+              </div>
+            )}
           </div>
         </DialogBody>
 

--- a/frontend/src/dialogs/EditPageDialog.tsx
+++ b/frontend/src/dialogs/EditPageDialog.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { AlertTriangleIcon } from 'lucide-react';
+import { useEffect, useId, useState } from 'react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,28 +12,40 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
 import { Dialog, DialogBody, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useDeletePage, useUpdatePage } from '@/hooks/usePages';
+import { formatTripRangeYMD, isDateOutsideRange } from '@/lib/date';
 import { PAGE_TITLE_MAX_LENGTH, type Page } from '@/types';
+import type { Trip } from '@/types/trip';
 
 interface EditPageDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   page: Page;
+  /** 親 Trip。日付範囲ハイライト・警告判定に使用 */
+  trip: Trip;
   onDeleted?: (pageId: number) => void;
 }
 
-export const EditPageDialog = ({ open, onOpenChange, page, onDeleted }: EditPageDialogProps) => {
+export const EditPageDialog = ({ open, onOpenChange, page, trip, onDeleted }: EditPageDialogProps) => {
+  const titleId = useId();
+  const dateId = useId();
   const [title, setTitle] = useState(page.title);
+  const [date, setDate] = useState<Date | null>(page.date ?? null);
   const { updatePage } = useUpdatePage(page.tripId);
   const { deletePage } = useDeletePage(page.tripId);
+
+  const isOutsideRange = isDateOutsideRange(date, trip.startDate, trip.endDate);
+  const tripRangeText = formatTripRangeYMD(trip.startDate, trip.endDate);
 
   // ダイアログが開いたときにフォームを初期化
   useEffect(() => {
     if (open) {
       setTitle(page.title);
+      setDate(page.date ?? null);
     }
   }, [open, page]);
 
@@ -49,9 +62,10 @@ export const EditPageDialog = ({ open, onOpenChange, page, onDeleted }: EditPage
       return;
     }
 
-    if (title.trim() !== page.title) {
-      updatePage({ id: page.id, data: { title: title.trim(), detail: page.detail, tripId: page.tripId } });
-    }
+    updatePage({
+      id: page.id,
+      data: { title: title.trim(), detail: page.detail, tripId: page.tripId, date },
+    });
 
     onOpenChange(false);
   };
@@ -64,18 +78,37 @@ export const EditPageDialog = ({ open, onOpenChange, page, onDeleted }: EditPage
         </DialogHeader>
 
         <DialogBody>
-          <div className='space-y-2'>
-            <Label htmlFor='edit-page-title'>
-              タイトル<span className='text-red-500'>*</span>
-            </Label>
-            <Input
-              id='edit-page-title'
-              value={title}
-              onChange={e => setTitle(e.target.value)}
-              placeholder='ページのタイトル'
-              required
-              maxLength={PAGE_TITLE_MAX_LENGTH}
-            />
+          <div className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor={titleId}>
+                タイトル<span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id={titleId}
+                value={title}
+                onChange={e => setTitle(e.target.value)}
+                placeholder='ページのタイトル'
+                required
+                maxLength={PAGE_TITLE_MAX_LENGTH}
+              />
+            </div>
+            <div className='space-y-2'>
+              <Label htmlFor={dateId}>日付</Label>
+              <DatePicker
+                id={dateId}
+                value={date}
+                onChange={setDate}
+                highlightStart={trip.startDate}
+                highlightEnd={trip.endDate}
+                invalid={isOutsideRange}
+              />
+              {isOutsideRange && tripRangeText && (
+                <p className='flex items-center gap-1 text-amber-600 text-xs'>
+                  <AlertTriangleIcon className='size-3.5' />
+                  旅行期間（{tripRangeText}）外の日付です
+                </p>
+              )}
+            </div>
           </div>
         </DialogBody>
 

--- a/frontend/src/dialogs/EditTripDialog.tsx
+++ b/frontend/src/dialogs/EditTripDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,6 +11,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { DateRangePicker } from '@/components/ui/date-picker';
 import { Dialog, DialogBody, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -28,8 +29,13 @@ interface EditTripDialogProps {
 }
 
 export const EditTripDialog = ({ open, onOpenChange, trip, onDeleted }: EditTripDialogProps) => {
+  const titleId = useId();
+  const dateId = useId();
+  const detailId = useId();
   const [tripTitle, setTripTitle] = useState(trip.title);
   const [tripDetail, setTripDetail] = useState(trip.detail ?? '');
+  const [startDate, setStartDate] = useState<Date | null>(trip.startDate ?? null);
+  const [endDate, setEndDate] = useState<Date | null>(trip.endDate ?? null);
   const { updateTrip } = useUpdateTrip();
   const { deleteTrip } = useDeleteTrip();
   const { removeVisitedTrip } = useVisitedTrips();
@@ -39,6 +45,8 @@ export const EditTripDialog = ({ open, onOpenChange, trip, onDeleted }: EditTrip
     if (open) {
       setTripTitle(trip.title);
       setTripDetail(trip.detail ?? '');
+      setStartDate(trip.startDate ?? null);
+      setEndDate(trip.endDate ?? null);
     }
   }, [open, trip]);
 
@@ -59,12 +67,16 @@ export const EditTripDialog = ({ open, onOpenChange, trip, onDeleted }: EditTrip
       return;
     }
 
-    if (trimmedTitle !== trip.title || trimmedDetail !== (trip.detail ?? '')) {
-      updateTrip({
-        id: trip.id,
-        data: { title: trimmedTitle, detail: trimmedDetail || undefined, peopleNum: trip.peopleNum },
-      });
-    }
+    updateTrip({
+      id: trip.id,
+      data: {
+        title: trimmedTitle,
+        detail: trimmedDetail || undefined,
+        peopleNum: trip.peopleNum,
+        startDate,
+        endDate,
+      },
+    });
 
     onOpenChange(false);
   };
@@ -79,11 +91,11 @@ export const EditTripDialog = ({ open, onOpenChange, trip, onDeleted }: EditTrip
         <DialogBody>
           <div className='space-y-4'>
             <div className='space-y-2'>
-              <Label htmlFor='edit-trip-title'>
+              <Label htmlFor={titleId}>
                 旅程タイトル<span className='text-red-500'>*</span>
               </Label>
               <Input
-                id='edit-trip-title'
+                id={titleId}
                 value={tripTitle}
                 onChange={e => setTripTitle(e.target.value)}
                 placeholder='旅程のタイトル'
@@ -92,10 +104,22 @@ export const EditTripDialog = ({ open, onOpenChange, trip, onDeleted }: EditTrip
               />
             </div>
             <div className='space-y-2'>
-              <Label htmlFor='edit-trip-detail'>旅程全体メモ</Label>
+              <Label htmlFor={dateId}>期間</Label>
+              <DateRangePicker
+                id={dateId}
+                start={startDate}
+                end={endDate}
+                onChange={(s, e) => {
+                  setStartDate(s);
+                  setEndDate(e);
+                }}
+              />
+            </div>
+            <div className='space-y-2'>
+              <Label htmlFor={detailId}>旅程全体メモ</Label>
               <LazyMarkdownEditor
                 className='max-h-72'
-                id='edit-trip-detail'
+                id={detailId}
                 value={tripDetail}
                 onChange={setTripDetail}
                 placeholder='旅程の詳細や目的など（任意）'

--- a/frontend/src/hooks/useTrips.ts
+++ b/frontend/src/hooks/useTrips.ts
@@ -134,7 +134,7 @@ type UpdateTripArg = { id: Trip['id']; data: TripMutation };
  * Tripを更新するためのフック
  */
 export const useUpdateTrip = () => {
-  const { mutate } = useSWRConfig();
+  const { mutate, cache } = useSWRConfig();
 
   const updateTripFetcher = useCallback(async (_key: string | null, { arg }: { arg: UpdateTripArg }) => {
     const { id, data } = arg;
@@ -143,31 +143,40 @@ export const useUpdateTrip = () => {
     return tripFromApi.parse(response.data);
   }, []);
 
-  const { trigger, isMutating, error, data } = useSWRMutation(
-    TRIPS_BASE_PATH, // リストの再検証トリガーとして利用
-    updateTripFetcher,
-    {
-      onError: (err: unknown) => toast.error(getErrorMessage(err)),
-      // 更新成功時、APIレスポンスを使ってキャッシュを操作
-      onSuccess: (updatedTrip: Trip) => {
-        // 個別IDのキャッシュを更新 (populate)
-        mutate(
-          `${TRIPS_BASE_PATH}/${updatedTrip.id}`,
-          updatedTrip,
-          false // 再検証はしない
-        );
-      },
-      // リスト自体のキャッシュ更新
-      populateCache: (updatedTrip, currentTrips: Trip[] | undefined) => {
-        if (!currentTrips) return [];
-        return currentTrips.map(t => (t.id === updatedTrip.id ? updatedTrip : t));
-      },
-      revalidate: false, // populateCacheで更新したのでリストの再取得は防ぐ
-    }
+  const { trigger, isMutating, error, data } = useSWRMutation(TRIPS_BASE_PATH, updateTripFetcher, {
+    // サーバーレスポンスで個別キャッシュ（id ベース・urlId ベース）を確定
+    onSuccess: (updatedTrip: Trip) => {
+      mutate(`${TRIPS_BASE_PATH}/${updatedTrip.id}`, updatedTrip, { revalidate: false });
+      mutate(`${TRIPS_BASE_PATH}/url/${updatedTrip.urlId}`, updatedTrip, { revalidate: false });
+    },
+  });
+
+  const updateTrip = useCallback(
+    async (arg: UpdateTripArg) => {
+      const idKey = `${TRIPS_BASE_PATH}/${arg.id}`;
+      // 既存キャッシュから urlId を引いて、id ベースと urlId ベース両方の個別キャッシュを楽観更新する
+      const cachedTrip = (cache.get(idKey)?.data ?? null) as Trip | null;
+      const urlKey = cachedTrip?.urlId ? `${TRIPS_BASE_PATH}/url/${cachedTrip.urlId}` : null;
+      const optimisticTrip = { ...(cachedTrip ?? {}), ...arg.data, id: arg.id } as Trip;
+
+      // 個別キャッシュの楽観的更新（リスト /trips は未使用のため対象外）
+      mutate(idKey, optimisticTrip, { revalidate: false });
+      if (urlKey) mutate(urlKey, optimisticTrip, { revalidate: false });
+
+      return trigger(arg, {
+        revalidate: false,
+        onError: (err: unknown) => {
+          toast.error(getErrorMessage(err));
+          mutate(idKey); // 個別データのロールバック（再検証）
+          if (urlKey) mutate(urlKey);
+        },
+      });
+    },
+    [trigger, mutate, cache]
   );
 
   return {
-    updateTrip: trigger,
+    updateTrip,
     isUpdating: isMutating,
     error,
     updatedTrip: data,

--- a/frontend/src/hooks/useTrips.ts
+++ b/frontend/src/hooks/useTrips.ts
@@ -16,6 +16,7 @@ import {
   tripFromApi,
   tripMutationToApi,
 } from '@/types/trip';
+import { VISITED_TRIPS_CACHE_KEY } from './useVisitedTrips';
 
 const TRIPS_BASE_PATH = '/trips';
 
@@ -143,11 +144,28 @@ export const useUpdateTrip = () => {
     return tripFromApi.parse(response.data);
   }, []);
 
+  // useVisitedTrips の SWR cache (`[VISITED_TRIPS_CACHE_KEY, ...urlIds]`) は個別 /trips/url/:urlId とは別キーで
+  // 自動追従しない。HomePage の期間バッジ等が古いまま残らないよう、ここから明示的に置換する
+  const updateVisitedTripsCache = useCallback(
+    (trip: Trip) => {
+      mutate(
+        key => Array.isArray(key) && key[0] === VISITED_TRIPS_CACHE_KEY,
+        (currentTrips: Trip[] | undefined) => {
+          if (!currentTrips) return currentTrips;
+          return currentTrips.map(t => (t.id === trip.id ? trip : t));
+        },
+        { revalidate: false }
+      );
+    },
+    [mutate]
+  );
+
   const { trigger, isMutating, error, data } = useSWRMutation(TRIPS_BASE_PATH, updateTripFetcher, {
     // サーバーレスポンスで個別キャッシュ（id ベース・urlId ベース）を確定
     onSuccess: (updatedTrip: Trip) => {
       mutate(`${TRIPS_BASE_PATH}/${updatedTrip.id}`, updatedTrip, { revalidate: false });
       mutate(`${TRIPS_BASE_PATH}/url/${updatedTrip.urlId}`, updatedTrip, { revalidate: false });
+      updateVisitedTripsCache(updatedTrip);
     },
   });
 
@@ -162,6 +180,7 @@ export const useUpdateTrip = () => {
       // 個別キャッシュの楽観的更新（リスト /trips は未使用のため対象外）
       mutate(idKey, optimisticTrip, { revalidate: false });
       if (urlKey) mutate(urlKey, optimisticTrip, { revalidate: false });
+      updateVisitedTripsCache(optimisticTrip);
 
       return trigger(arg, {
         revalidate: false,
@@ -169,10 +188,12 @@ export const useUpdateTrip = () => {
           toast.error(getErrorMessage(err));
           mutate(idKey); // 個別データのロールバック（再検証）
           if (urlKey) mutate(urlKey);
+          // visitedTrips は revalidate して同期（fetcher が urlIds 全件を取得するので失敗時のみ）
+          mutate(key => Array.isArray(key) && key[0] === VISITED_TRIPS_CACHE_KEY);
         },
       });
     },
-    [trigger, mutate, cache]
+    [trigger, mutate, cache, updateVisitedTripsCache]
   );
 
   return {

--- a/frontend/src/hooks/useVisitedTrips.ts
+++ b/frontend/src/hooks/useVisitedTrips.ts
@@ -6,6 +6,8 @@ import { db } from '@/lib/db';
 import { type Trip, tripFromApi } from '@/types/trip';
 
 const VISITED_TRIPS_KEY = 'visitedTripUrlIds';
+/** useVisitedTrips の SWR キャッシュ key プレフィックス。Trip 更新側から mutate するために export */
+export const VISITED_TRIPS_CACHE_KEY = 'visitedTrips';
 // TODO: IndexedDB完全移行後、LEGACY_STORAGE_KEYとmigrateFromLocalStorageを削除する
 /** localStorage のキー（マイグレーション用） */
 const LEGACY_STORAGE_KEY = 'visitedTripUrlIds';
@@ -92,7 +94,7 @@ export const useVisitedTrips = () => {
 
   // SWRで各urlIdからTripを取得
   const { data, error, isLoading } = useSWR<Trip[]>(
-    isInitialized && urlIds.length > 0 ? ['visitedTrips', ...urlIds] : null,
+    isInitialized && urlIds.length > 0 ? [VISITED_TRIPS_CACHE_KEY, ...urlIds] : null,
     async () => {
       const results = await Promise.all(
         urlIds.map(async urlId => {

--- a/frontend/src/lib/date.test.ts
+++ b/frontend/src/lib/date.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatDateDisplay,
+  formatDateMDWithDow,
+  formatDateOnly,
+  formatDateYMDWithDow,
+  formatTripRangeMD,
+  formatTripRangeYMD,
+  isDateOutsideRange,
+  parseDateOnly,
+} from './date';
+
+describe('parseDateOnly', () => {
+  it('YYYY-MM-DD をローカル 00:00 の Date に変換する', () => {
+    const d = parseDateOnly('2026-05-24');
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(4); // 0-indexed
+    expect(d.getDate()).toBe(24);
+    expect(d.getHours()).toBe(0);
+  });
+});
+
+describe('formatDateOnly', () => {
+  it('Date を YYYY-MM-DD にフォーマットする', () => {
+    expect(formatDateOnly(new Date(2026, 4, 24))).toBe('2026-05-24');
+  });
+});
+
+describe('formatDateDisplay', () => {
+  it('Date を YYYY/MM/DD にフォーマットする', () => {
+    expect(formatDateDisplay(new Date(2026, 4, 24))).toBe('2026/05/24');
+  });
+});
+
+describe('formatDateMDWithDow', () => {
+  it('Date を M/D(曜) 形式にフォーマットする', () => {
+    // 2026-05-24 は日曜日
+    expect(formatDateMDWithDow(new Date(2026, 4, 24))).toBe('5/24(日)');
+    // 2026-05-26 は火曜日
+    expect(formatDateMDWithDow(new Date(2026, 4, 26))).toBe('5/26(火)');
+  });
+});
+
+describe('formatDateYMDWithDow', () => {
+  it('Date を YYYY/MM/DD(曜) 形式にフォーマットする', () => {
+    expect(formatDateYMDWithDow(new Date(2026, 4, 24))).toBe('2026/05/24(日)');
+  });
+});
+
+describe('formatTripRangeMD', () => {
+  const start = new Date(2026, 4, 24);
+  const end = new Date(2026, 4, 26);
+
+  it('両方ある場合は連結する', () => {
+    expect(formatTripRangeMD(start, end)).toBe('5/24(日) 〜 5/26(火)');
+  });
+
+  it('start のみの場合は右側を省略する', () => {
+    expect(formatTripRangeMD(start, null)).toBe('5/24(日) 〜 ');
+  });
+
+  it('end のみの場合は左側を省略する', () => {
+    expect(formatTripRangeMD(null, end)).toBe(' 〜 5/26(火)');
+  });
+
+  it('両方 null の場合は null を返す', () => {
+    expect(formatTripRangeMD(null, null)).toBeNull();
+    expect(formatTripRangeMD(undefined, undefined)).toBeNull();
+  });
+});
+
+describe('formatTripRangeYMD', () => {
+  const start = new Date(2026, 4, 24);
+  const end = new Date(2026, 4, 26);
+
+  it('両方ある場合は連結する', () => {
+    expect(formatTripRangeYMD(start, end)).toBe('2026/05/24(日) 〜 2026/05/26(火)');
+  });
+
+  it('start のみの場合', () => {
+    expect(formatTripRangeYMD(start, null)).toBe('2026/05/24(日) 〜 ');
+  });
+
+  it('end のみの場合', () => {
+    expect(formatTripRangeYMD(null, end)).toBe(' 〜 2026/05/26(火)');
+  });
+
+  it('両方 null の場合は null を返す', () => {
+    expect(formatTripRangeYMD(null, null)).toBeNull();
+  });
+});
+
+describe('isDateOutsideRange', () => {
+  const start = new Date(2026, 4, 24);
+  const end = new Date(2026, 4, 26);
+
+  it('範囲内は false', () => {
+    expect(isDateOutsideRange(new Date(2026, 4, 25), start, end)).toBe(false);
+  });
+
+  it('範囲の端は範囲内', () => {
+    expect(isDateOutsideRange(start, start, end)).toBe(false);
+    expect(isDateOutsideRange(end, start, end)).toBe(false);
+  });
+
+  it('範囲より前は true', () => {
+    expect(isDateOutsideRange(new Date(2026, 4, 23), start, end)).toBe(true);
+  });
+
+  it('範囲より後は true', () => {
+    expect(isDateOutsideRange(new Date(2026, 4, 27), start, end)).toBe(true);
+  });
+
+  it('date が null のときは false', () => {
+    expect(isDateOutsideRange(null, start, end)).toBe(false);
+  });
+
+  it('start のみ指定で前は true / 後は false', () => {
+    expect(isDateOutsideRange(new Date(2026, 4, 23), start, null)).toBe(true);
+    expect(isDateOutsideRange(new Date(2026, 4, 30), start, null)).toBe(false);
+  });
+
+  it('end のみ指定で後は true / 前は false', () => {
+    expect(isDateOutsideRange(new Date(2026, 4, 27), null, end)).toBe(true);
+    expect(isDateOutsideRange(new Date(2026, 4, 1), null, end)).toBe(false);
+  });
+});

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -1,0 +1,28 @@
+import dayjs from 'dayjs';
+
+/**
+ * `YYYY-MM-DD` 形式の日付文字列を、ローカル時刻 00:00 の `Date` に変換する。
+ * （`new Date('YYYY-MM-DD')` は UTC 解釈で日付がずれる場合があるため、dayjs 経由で正規化する）
+ */
+export const parseDateOnly = (value: string): Date => dayjs(value).startOf('day').toDate();
+
+/**
+ * `Date` を `YYYY-MM-DD` 形式（ローカル日付）の文字列に変換する。
+ */
+export const formatDateOnly = (value: Date): string => dayjs(value).format('YYYY-MM-DD');
+
+/**
+ * `Date` を `YYYY/MM/DD` 形式の表示用文字列に変換する。
+ */
+export const formatDateDisplay = (value: Date): string => dayjs(value).format('YYYY/MM/DD');
+
+/**
+ * `date` が `[start, end]` の範囲外かを判定する。`start` / `end` が未指定（`null` / `undefined`）の場合はその境界はチェックしない。
+ * `date` が `null` のときは常に `false`（未設定は範囲外とみなさない）。
+ */
+export const isDateOutsideRange = (date: Date | null, start?: Date | null, end?: Date | null): boolean => {
+  if (!date) return false;
+  if (start && date < start) return true;
+  if (end && date > end) return true;
+  return false;
+};

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -17,6 +17,41 @@ export const formatDateOnly = (value: Date): string => dayjs(value).format('YYYY
 export const formatDateDisplay = (value: Date): string => dayjs(value).format('YYYY/MM/DD');
 
 /**
+ * `Date` を `M/D(曜)` 形式に変換する。Header の Page Select や Trip 期間サブタイトルなど省スペース用途向け。
+ */
+export const formatDateMDWithDow = (value: Date): string => dayjs(value).format('M/D(dd)');
+
+/**
+ * `Date` を `YYYY/MM/DD(曜)` 形式に変換する。HomePage 旅程カードや EditTripDialog などフル表示向け。
+ */
+export const formatDateYMDWithDow = (value: Date): string => dayjs(value).format('YYYY/MM/DD(dd)');
+
+const formatRange = (
+  start: Date | null | undefined,
+  end: Date | null | undefined,
+  formatter: (d: Date) => string
+): string | null => {
+  if (!(start || end)) return null;
+  const startStr = start ? formatter(start) : '';
+  const endStr = end ? formatter(end) : '';
+  return `${startStr} 〜 ${endStr}`;
+};
+
+/**
+ * Trip 期間を `M/D(曜) 〜 M/D(曜)` 形式に整形する。片方のみ設定時は片側を省略 (`M/D(曜) 〜` / `〜 M/D(曜)`)。
+ * 両方未設定の場合は `null` を返す。
+ */
+export const formatTripRangeMD = (start: Date | null | undefined, end: Date | null | undefined): string | null =>
+  formatRange(start, end, formatDateMDWithDow);
+
+/**
+ * Trip 期間を `YYYY/MM/DD(曜) 〜 YYYY/MM/DD(曜)` 形式に整形する。片方のみ設定時は片側を省略。
+ * 両方未設定の場合は `null` を返す。
+ */
+export const formatTripRangeYMD = (start: Date | null | undefined, end: Date | null | undefined): string | null =>
+  formatRange(start, end, formatDateYMDWithDow);
+
+/**
  * `date` が `[start, end]` の範囲外かを判定する。`start` / `end` が未指定（`null` / `undefined`）の場合はその境界はチェックしない。
  * `date` が `null` のときは常に `false`（未設定は範囲外とみなさない）。
  */

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import { PwaInstallBanner } from '@/components/PwaInstallBanner';
 import { Button } from '@/components/ui/button';
 import { AddTripDialog } from '@/dialogs/AddTripDialog';
 import { useVisitedTrips } from '@/hooks/useVisitedTrips';
+import { formatTripRangeYMD } from '@/lib/date';
 import { cn } from '@/lib/utils';
 
 const HomePage = () => {
@@ -50,15 +51,19 @@ const HomePage = () => {
           {/* Trip一覧 */}
           {!isLoading && hasTrips && (
             <div className='space-y-3'>
-              {trips.map(trip => (
-                <Link
-                  key={trip.id}
-                  to={`/trip/${trip.urlId}`}
-                  className='block rounded-lg bg-white p-4 shadow-sm transition hover:shadow-md'
-                >
-                  <h3 className='mb-1 font-semibold text-gray-900 text-lg'>{trip.title}</h3>
-                </Link>
-              ))}
+              {trips.map(trip => {
+                const rangeText = formatTripRangeYMD(trip.startDate, trip.endDate);
+                return (
+                  <Link
+                    key={trip.id}
+                    to={`/trip/${trip.urlId}`}
+                    className='block rounded-lg bg-white p-4 shadow-sm transition hover:shadow-md'
+                  >
+                    <h3 className='font-semibold text-gray-900 text-lg'>{trip.title}</h3>
+                    {rangeText && <p className='text-gray-500 text-xs'>{rangeText}</p>}
+                  </Link>
+                );
+              })}
             </div>
           )}
         </div>

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -2,7 +2,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { isOfflineReadAtom } from '@/atoms/network';
-import { selectedPageIdAtom, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
+import { selectedPageIdAtom, sortPages, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
 import { FetchErrorView } from '@/components/FetchErrorView';
 import { Header } from '@/components/Header';
 import { HeaderSkeleton } from '@/components/HeaderSkeleton';
@@ -51,7 +51,7 @@ const TripPage = () => {
   }, [trip, setTripAtom]);
 
   useEffect(() => {
-    if (pages) setTripPages(pages);
+    if (pages) setTripPages(sortPages(pages));
   }, [pages, setTripPages]);
 
   // 1秒間の最小ローディング表示を管理

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { isOfflineReadAtom } from '@/atoms/network';
 import { selectedPageIdAtom, sortPages, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
@@ -17,7 +17,13 @@ import { EditTripLayout } from './TripPage/EditTripLayout';
 import { ViewTripLayout } from './TripPage/ViewTripLayout';
 
 const TripPage = () => {
+  // useDragAutoScroll は ref を読み続けるので維持。Header は state で再 attach するため両方持つ
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
+  const handleScrollContainerChange = useCallback((el: HTMLDivElement | null) => {
+    scrollContainerRef.current = el;
+    setScrollContainerEl(el);
+  }, []);
   const { isDraggingRef, startDrag, stopDrag } = useDragAutoScroll(scrollContainerRef);
   const [selectedPageId, setSelectedPageId] = useAtom(selectedPageIdAtom);
   const [mode, setMode] = useAtom(tripModeAtom);
@@ -137,7 +143,7 @@ const TripPage = () => {
       {trip && pages && (
         <div className='flex h-dvh w-full flex-col'>
           <Title>{trip.title}</Title>
-          <Header variant='full' scrollContainerRef={scrollContainerRef} isDraggingRef={isDraggingRef} />
+          <Header variant='full' scrollContainer={scrollContainerEl} isDraggingRef={isDraggingRef} />
           {pages.length === 0 && (
             <div className='flex flex-1 items-center justify-center text-gray-500'>
               編集モードからページを追加してください
@@ -145,7 +151,7 @@ const TripPage = () => {
           )}
           {pages.length > 0 && mode === 'view' && (
             <PageSwipeContainer
-              activeSlideScrollRef={scrollContainerRef}
+              onActiveSlideChange={handleScrollContainerChange}
               className='min-h-0 flex-1'
               renderPage={page => (
                 <div className='flex h-full flex-col items-center pt-4'>
@@ -160,7 +166,7 @@ const TripPage = () => {
           )}
           {mode === 'edit' && (
             <div
-              ref={scrollContainerRef}
+              ref={handleScrollContainerChange}
               className='flex flex-1 flex-col items-center overflow-auto overscroll-y-none pt-4'
             >
               {selectedPageId != null && (

--- a/frontend/src/types/page.ts
+++ b/frontend/src/types/page.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { formatDateOnly, parseDateOnly } from '@/lib/date';
 
 // --- アプリケーション層のスキーマ ---
 
@@ -15,6 +16,7 @@ export const PageSchema = z.object({
     .max(PAGE_TITLE_MAX_LENGTH, { message: `ページ名は最大${PAGE_TITLE_MAX_LENGTH}文字です` }),
   detail: z.string().nullish(),
   tripId: z.number(),
+  date: z.date().nullish(),
 });
 
 export type Page = z.infer<typeof PageSchema>;
@@ -29,6 +31,7 @@ const ApiPageSchema = z.object({
   title: z.string(),
   detail: z.string().nullish(),
   trip_id: z.number(),
+  date: z.string().date().nullish(),
 });
 
 export type ApiPage = z.infer<typeof ApiPageSchema>;
@@ -44,6 +47,7 @@ export const pageFromApi = ApiPageSchema.transform(
     title: apiData.title,
     detail: apiData.detail,
     tripId: apiData.trip_id,
+    date: apiData.date ? parseDateOnly(apiData.date) : null,
   })
 );
 
@@ -58,6 +62,7 @@ export const pageToApi = PageSchema.transform(
     title: appData.title,
     detail: appData.detail,
     trip_id: appData.tripId,
+    date: appData.date ? formatDateOnly(appData.date) : null,
   })
 );
 
@@ -78,5 +83,6 @@ export const pageMutationToApi = PageMutationSchema.transform(
     title: appData.title,
     detail: appData.detail,
     trip_id: appData.tripId,
+    date: appData.date ? formatDateOnly(appData.date) : null,
   })
 );

--- a/frontend/src/types/trip.ts
+++ b/frontend/src/types/trip.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { formatDateOnly, parseDateOnly } from '@/lib/date';
 
 // --- アプリケーション層のスキーマ ---
 
@@ -11,6 +12,8 @@ export const TripSchema = z.object({
   detail: z.string().nullish(),
   peopleNum: z.number().nullish(),
   urlId: z.string(),
+  startDate: z.date().nullish(),
+  endDate: z.date().nullish(),
 });
 
 export type Trip = z.infer<typeof TripSchema>;
@@ -31,6 +34,8 @@ const ApiTripSchema = z.object({
   detail: z.string().nullish(),
   people_num: z.number().nullish(),
   url_id: z.string().max(100),
+  start_date: z.string().date().nullish(),
+  end_date: z.string().date().nullish(),
 });
 
 export type ApiTrip = z.infer<typeof ApiTripSchema>;
@@ -42,9 +47,13 @@ export type ApiTrip = z.infer<typeof ApiTripSchema>;
  */
 export const tripFromApi = ApiTripSchema.transform(
   (apiData): Trip => ({
-    ...apiData,
+    id: apiData.id,
+    title: apiData.title,
+    detail: apiData.detail,
     peopleNum: apiData.people_num,
     urlId: apiData.url_id,
+    startDate: apiData.start_date ? parseDateOnly(apiData.start_date) : null,
+    endDate: apiData.end_date ? parseDateOnly(apiData.end_date) : null,
   })
 );
 
@@ -78,5 +87,7 @@ export const tripMutationToApi = TripMutationSchema.transform(
     title: appData.title,
     detail: appData.detail ?? '',
     people_num: appData.peopleNum,
+    start_date: appData.startDate ? formatDateOnly(appData.startDate) : null,
+    end_date: appData.endDate ? formatDateOnly(appData.endDate) : null,
   })
 );

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ja';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { server } from './msw/server';
+
+dayjs.locale('ja');
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());

--- a/server/app/schemas/page.py
+++ b/server/app/schemas/page.py
@@ -1,3 +1,5 @@
+import datetime
+
 from pydantic import BaseModel, ConfigDict
 
 from .block import Block
@@ -5,6 +7,7 @@ from .block import Block
 
 class PageBase(BaseModel):
     title: str
+    date: datetime.date | None = None
 
 
 class PageCreate(PageBase):

--- a/server/app/schemas/trip.py
+++ b/server/app/schemas/trip.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.fields import Field
 
 from .page import Page
@@ -10,6 +12,18 @@ TRIP_MAX_DETAIL_LENGTH = 2000
 class TripBase(BaseModel):
     title: str = Field(min_length=1, max_length=TRIP_MAX_TITLE_LENGTH)
     detail: str | None = Field(default=None, max_length=TRIP_MAX_DETAIL_LENGTH)
+    start_date: date | None = None
+    end_date: date | None = None
+
+    @model_validator(mode="after")
+    def _check_date_range(self) -> "TripBase":
+        if (
+            self.start_date is not None
+            and self.end_date is not None
+            and self.start_date > self.end_date
+        ):
+            raise ValueError("start_date must be on or before end_date")
+        return self
 
 
 class TripCreateIn(TripBase):

--- a/server/tests/cruds/test_pages.py
+++ b/server/tests/cruds/test_pages.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -122,6 +124,53 @@ async def test_update_page(db_session: AsyncSession, test_create_trip: Trip):
 
     # act
     assert non_existent_page is None
+
+
+@pytest.mark.asyncio
+async def test_create_page_with_date(
+    db_session: AsyncSession, test_create_trip: Trip
+):
+    """
+    create_page()/正常系/date を持つ
+    """
+    # arrange
+    page_in = PageCreate(title="1 日目", date=date(2026, 5, 1))
+
+    # act
+    db_page = await pages_cruds.create_page(
+        db=db_session, page=page_in, trip_id=test_create_trip.id
+    )
+    fetched = await pages_cruds.get_page(db=db_session, page_id=db_page.id)
+
+    # assert
+    assert fetched is not None
+    assert fetched.date == date(2026, 5, 1)
+
+
+@pytest.mark.asyncio
+async def test_update_page_date_overwrite(
+    db_session: AsyncSession, test_create_trip: Trip
+):
+    """
+    update_page()/正常系/後勝ち全置換で date が上書きされる
+    """
+    # arrange
+    created = await pages_cruds.create_page(
+        db=db_session,
+        page=PageCreate(title="2 日目", date=date(2026, 5, 2)),
+        trip_id=test_create_trip.id,
+    )
+
+    # act: date を None にして送り、全置換で消えることを確認
+    updated = await pages_cruds.update_page(
+        db=db_session,
+        page_id=created.id,
+        page=PageUpdate(title="2 日目", date=None),
+    )
+
+    # assert
+    assert updated is not None
+    assert updated.date is None
 
 
 @pytest.mark.asyncio

--- a/server/tests/cruds/test_trips.py
+++ b/server/tests/cruds/test_trips.py
@@ -1,4 +1,7 @@
+from datetime import date
+
 import pytest
+from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -161,6 +164,73 @@ async def test_update_trip(db_session: AsyncSession):
 
     # assert
     assert non_existent_trip is None
+
+
+@pytest.mark.asyncio
+async def test_create_trip_with_dates(db_session: AsyncSession):
+    """
+    create_trip()/正常系/start_date と end_date を持つ
+    """
+    # arrange
+    trip_in = TripCreateIn(
+        title="trip with dates",
+        detail=None,
+        start_date=date(2026, 5, 1),
+        end_date=date(2026, 5, 3),
+    )
+
+    # act
+    trip_id = await trips_cruds.create_trip(
+        db=db_session, trip=trip_in, url_id="url_with_dates"
+    )
+    db_trip = await trips_cruds.get_trip(db=db_session, trip_id=trip_id)
+
+    # assert
+    assert db_trip is not None
+    assert db_trip.start_date == date(2026, 5, 1)
+    assert db_trip.end_date == date(2026, 5, 3)
+
+
+def test_trip_schema_rejects_inverted_date_range():
+    """
+    TripCreateIn/異常系/start_date > end_date は ValidationError
+    """
+    with pytest.raises(ValidationError):
+        TripCreateIn(
+            title="invalid",
+            detail=None,
+            start_date=date(2026, 5, 3),
+            end_date=date(2026, 5, 1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_trip_dates_overwrite(db_session: AsyncSession):
+    """
+    update_trip()/正常系/後勝ち全置換で日付フィールドが上書きされる
+    """
+    # arrange
+    trip_in = TripCreateIn(
+        title="initial",
+        detail=None,
+        start_date=date(2026, 5, 1),
+        end_date=date(2026, 5, 3),
+    )
+    trip_id = await trips_cruds.create_trip(
+        db=db_session, trip=trip_in, url_id="url_update_dates"
+    )
+
+    # act: 日付を None にして送り、全置換で消えることを確認
+    updated = await trips_cruds.update_trip(
+        db=db_session,
+        trip_id=trip_id,
+        trip=TripUpdate(title="cleared", detail=None, start_date=None, end_date=None),
+    )
+
+    # assert
+    assert updated is not None
+    assert updated.start_date is None
+    assert updated.end_date is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概要

Issue #129 のコード変更 PR。DB マイグレーション + モデル定義の先行 PR (#132) が staging に反映された後にマージ・デプロイする想定。

> Base: `feature/issue129-trip-page-date-migration`（#132 の上に積まれた stacked PR）

## 変更内容

### server
- `TripBase` / `PageBase` に `start_date` / `end_date` / `date` を追加
- `TripBase` は `model_validator` で `start_date <= end_date` を検証
- 既存の後勝ち全置換 PUT パターンに自動連動（CRUD 変更なし）
- `test_trips` / `test_pages` に日付フィールドのテスト追加（日付付き Create、無効範囲のスキーマエラー、後勝ち全置換で None に上書き）

### frontend
- `lib/date.ts` に `parseDateOnly` / `formatDateOnly` / `formatDateDisplay` / `isDateOutsideRange` を追加（dayjs ベース）
- `types/trip.ts` / `types/page.ts` の zod スキーマ・API 変換層を更新（`TripMutationSchema` に `refine` で範囲チェック）
- shadcn 流の `Popover` / `DatePicker` / `DateRangePicker` を新規追加（Storybook 同梱）
- `@radix-ui/react-popover` を依存追加
- `AddTripDialog` / `EditTripDialog` に `DateRangePicker` を追加
- `AddPageDialog` / `EditPageDialog` に `DatePicker` を追加。trip 期間外の日付選択時は警告のみ表示（保存は許可）
- `Header.tsx` で Page ダイアログに trip の期間を渡す
- `HomePage` の Trip カードに期間バッジ (`YYYY/MM/DD 〜 YYYY/MM/DD`) を表示

## マージ順

1. #132（migration + モデル定義）を `develop` にマージ
2. staging に `alembic upgrade head` 反映
3. 本 PR の base を `develop` に変更してマージ

## 関連

- 親 Issue: #129
- 依存 PR: #132（migration + モデル定義）
- 派生 Issue: #130（一覧アクセス順並び替え）, #131（ページ日程順並び替え）

## Test plan

- [ ] Trip の作成・編集で期間を設定／クリアできる
- [ ] Page の作成・編集で単日程を設定／クリアできる
- [ ] 期間が Trip 範囲外の Page を編集すると警告が表示される（保存は可）
- [ ] `start_date > end_date` での更新が 422 エラーになる
- [ ] HomePage の Trip カードに期間バッジが表示される
- [ ] `pnpm run type-check` / `pnpm run lint:check` が通る
- [ ] `pytest` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 旅行に開始日・終了日を設定可能に（一覧やカードに期間表示）
  * ページに日付を付与・編集できるように（作成/編集ダイアログで日付選択）
  * 日付選択UI（単日/期間ピッカー）とポップオーバーUIを追加
  * ページが日付順で自動ソートされ表示されるように

* **Tests**
  * 日付関連ユーティリティの挙動を検証するテストを追加

* **Server**
  * 旅行/ページに日付フィールドを追加し入力検証を強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tabi-bit/tabi-share/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->