### PR TITLE
docs: メインブランチが develop である旨を CLAUDE.md に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,13 @@
 - リアルタイム協調編集は後勝ちルールで競合解決
 - UIテキストと仕様書は日本語で記述
 
+## ブランチ運用
+
+- **メインブランチは `develop`**。通常の feature / fix / chore PR はすべて `develop` を base にする
+- `main` はリリース専用。`develop` → `main` のリリース PR でのみ使用する（緊急時は `hotfix/*` から直接 `main` も可）
+- GitHub のデフォルトブランチも `develop` に設定されている
+- Claude Code が起動時に `Main branch: main` と表示することがあるが、それは GitHub の "main" 概念のことではなく、運用上のメインブランチとは別物。実態は `gh repo view --json defaultBranchRef` か既存 PR の base で確認すること
+
 ## 共通コーディング規約
 
 [@docs/coding_standards.md](docs/coding_standards.md)


### PR DESCRIPTION
## 概要

CLAUDE.md にこのリポジトリの運用上のメインブランチが \`develop\` であることを明記する。

## 経緯

Issue #129 の Draft PR (#132) を作成した際、Claude Code が起動時に環境メタとして \`Main branch: main\` を渡してきたため、それを default branch と取り違え、PR の base を \`main\` にしてしまった。

実態は：
- GitHub のデフォルトブランチは \`develop\`（\`gh repo view --json defaultBranchRef\` で確認できる）
- 通常の PR はすべて \`develop\` を base
- \`main\` は \`develop → main\` のリリース PR でのみ使う

既存 PR の base を確認すれば気づけたが、AI コーディングエージェント全般が同じ取り違えをしないよう、CLAUDE.md に明文化する。

## 変更内容

- CLAUDE.md に「## ブランチ運用」セクションを追加

## 関連

- 同じ趣旨の派生 PR: #132 / #133（base 取り違え修正済み）
- 親 Issue: #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)