### PR TITLE
fix: ブロックの幅を制限して右側に追加用の余白を作成 (#144)

### DIFF
--- a/frontend/src/components/ClampedText.stories.tsx
+++ b/frontend/src/components/ClampedText.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ClampedText } from './ClampedText';
+
+const meta: Meta<typeof ClampedText> = {
+  title: 'Components/ClampedText',
+  component: ClampedText,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 利用可能高さは「外側ラッパーの高さ」から算出されるため、高さ固定の親に flex で伸ばして配置する。
+const withBox = (height: number) => [
+  (Story: () => React.ReactElement) => (
+    <div style={{ display: 'flex', width: 220, height }} className='rounded bg-teal-500 p-2'>
+      <Story />
+    </div>
+  ),
+];
+
+const longTitle = '草津温泉街散策と湯畑見学、お土産購入とカフェタイム、そして地元グルメの食べ歩き';
+
+const titleClassName = 'w-full self-stretch font-bold text-14px text-white leading-snug';
+
+export const ShortText: Story = {
+  args: {
+    className: titleClassName,
+    children: '草津温泉入浴',
+  },
+  decorators: withBox(80),
+};
+
+export const ClampedToHeight: Story = {
+  args: {
+    className: titleClassName,
+    children: longTitle,
+  },
+  decorators: withBox(48),
+};
+
+export const TallShowsMoreLines: Story = {
+  args: {
+    className: titleClassName,
+    children: longTitle,
+  },
+  decorators: withBox(160),
+};

--- a/frontend/src/components/ClampedText.test.tsx
+++ b/frontend/src/components/ClampedText.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// useLineClamp は ResizeObserver に依存するため、ClampedText 単体の描画・props 透過を
+// 検証する目的では固定値を返すモックに差し替える（行数計算自体は useLineClamp.test で検証）。
+vi.mock('@/hooks/useLineClamp', () => ({
+  useLineClamp: () => ({ ref: { current: null }, lineClamp: 3 }),
+}));
+
+import { ClampedText } from './ClampedText';
+
+describe('ClampedText', () => {
+  it('children のテキストを表示する', () => {
+    render(<ClampedText>サンプルタイトル</ClampedText>);
+    expect(screen.getByText('サンプルタイトル')).toBeInTheDocument();
+  });
+
+  it('div の属性(className・任意属性)を外側ラッパーに透過する', () => {
+    render(
+      <ClampedText className='outer-class' data-testid='clamp' aria-label='タイトル'>
+        テキスト
+      </ClampedText>
+    );
+    const outer = screen.getByTestId('clamp');
+    expect(outer).toHaveClass('outer-class');
+    expect(outer).toHaveAttribute('aria-label', 'タイトル');
+  });
+
+  it('内側要素に省略表示用のスタイルとクリップを適用する', () => {
+    render(<ClampedText>テキスト</ClampedText>);
+    const inner = screen.getByText('テキスト');
+    expect(inner).toHaveClass('overflow-hidden');
+    expect(inner).toHaveStyle({ display: '-webkit-box' });
+  });
+});

--- a/frontend/src/components/ClampedText.tsx
+++ b/frontend/src/components/ClampedText.tsx
@@ -1,0 +1,28 @@
+import { type ComponentPropsWithoutRef, type CSSProperties, useMemo } from 'react';
+import { useLineClamp } from '@/hooks/useLineClamp';
+
+interface ClampedTextProps extends Omit<ComponentPropsWithoutRef<'div'>, 'children'> {
+  children: string;
+}
+
+/**
+ * 利用可能な高さに収まる行数だけ折り返して表示し、あふれたら末尾に … で省略するテキスト。
+ * 行数は useLineClamp が外側ラッパーの高さから算出するため、外側ラッパーは
+ * className 等で利用可能高さいっぱいに伸ばすこと(self-stretch 等)。
+ * className を含む div の属性はそのまま外側ラッパーに渡る。
+ */
+export function ClampedText({ children, ...divProps }: ClampedTextProps) {
+  const { ref, lineClamp } = useLineClamp();
+  const clampStyle = useMemo<CSSProperties>(
+    () => ({ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: lineClamp }),
+    [lineClamp]
+  );
+
+  return (
+    <div ref={ref} {...divProps}>
+      <div className='overflow-hidden' style={clampStyle}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/blocks/edit/BlockScheduleEdit.css
+++ b/frontend/src/components/blocks/edit/BlockScheduleEdit.css
@@ -32,3 +32,102 @@
     font-size: 10px !important;
   }
 }
+
+/* 時間(横並び)とタイトルを上下2行に分けてタイトルの横幅を確保する。
+   - モバイル(ウィンドウ < 40rem)はブロック幅によらず常に縦2行
+   - ブロック幅が狭い(< 16rem)場合は PC でも縦2行
+   高さが不足する短いブロックでも時間しか見えなくなるのを防ぐため高さ条件は設けない。
+   タイトルは折り返して複数行表示し、はみ出しはブロック下端でクリップする。 */
+@media (width < 40rem) {
+  .BlockScheduleEdit .schedule-layout {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+      "time .     info"
+      "title title title";
+    align-items: center;
+    row-gap: 0.125rem;
+  }
+
+  .BlockScheduleEdit .schedule-time-wrapper {
+    grid-area: time;
+    /* 時間は横並び表示 */
+    flex-direction: row;
+
+    .vertical-divider {
+      display: block;
+    }
+
+    .horizontal-divider {
+      display: none;
+    }
+  }
+
+  .BlockScheduleEdit .schedule-title {
+    grid-area: title;
+  }
+
+  .BlockScheduleEdit .schedule-info-btn {
+    grid-area: info;
+    margin-left: 0;
+  }
+}
+
+@container (width < 16rem) {
+  .BlockScheduleEdit .schedule-layout {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+      "time .     info"
+      "title title title";
+    align-items: center;
+    row-gap: 0.125rem;
+  }
+
+  .BlockScheduleEdit .schedule-time-wrapper {
+    grid-area: time;
+    /* 時間は横並び表示 */
+    flex-direction: row;
+
+    .vertical-divider {
+      display: block;
+    }
+
+    .horizontal-divider {
+      display: none;
+    }
+  }
+
+  .BlockScheduleEdit .schedule-title {
+    grid-area: title;
+  }
+
+  .BlockScheduleEdit .schedule-info-btn {
+    grid-area: info;
+    margin-left: 0;
+  }
+}
+
+/* 縦2行レイアウト時、上段(time + info)が収まらず i がはみ出すのを防ぐため段階的に時刻を縮める。
+   時刻表示と i ボタンはほぼ固定幅(時刻 ~6rem + ギャップ + i 20px + 左右パディング)なので閾値は算出可能。
+   PC でもブロック幅(@container)で判定するため、列分割で細くなったブロックに反応する。
+   1段目: まずパディングと time↔i のギャップを詰める。
+   2段目: それでも狭い場合は時刻の文字も小さくする。
+   さらに収まらない極小幅は親の overflow:hidden でクリップする。 */
+@container (width < 12rem) {
+  .BlockScheduleEdit .schedule-layout {
+    column-gap: 0.125rem;
+  }
+
+  .BlockScheduleEdit .schedule-time-wrapper {
+    padding-inline: 0.125rem;
+  }
+}
+
+@container (width < 10rem) {
+  .BlockScheduleEdit .schedule-time-wrapper {
+    font-size: 10px !important;
+  }
+}

--- a/frontend/src/components/blocks/edit/BlockScheduleEdit.tsx
+++ b/frontend/src/components/blocks/edit/BlockScheduleEdit.tsx
@@ -1,7 +1,8 @@
-import dayjs from 'dayjs';
 import circleInfoIcon from '@/assets/icons/circle-info.svg';
+import { ClampedText } from '@/components/ClampedText';
 import { cn } from '@/lib/utils';
 import type { ScheduleBlockComponentProps } from '../types';
+import { BlockTimeLabel } from './BlockTimeLabel';
 import './BlockScheduleEdit.css';
 
 interface BlockScheduleEditProps extends ScheduleBlockComponentProps {}
@@ -10,31 +11,26 @@ export function BlockScheduleEdit({ block, className }: BlockScheduleEditProps) 
   return (
     <div
       className={cn(
-        'BlockScheduleEdit flex h-full w-full flex-row items-center gap-2 rounded-lg bg-linear-to-r from-teal-400 to-teal-500 px-2 py-2 [container-type:size] sm:px-4',
+        'BlockScheduleEdit h-full w-full overflow-hidden rounded-lg bg-linear-to-r from-teal-400 to-teal-500 px-2 py-2 [container-type:size] sm:px-4',
         className
       )}
     >
-      <div className='schedule-time-wrapper flex items-center justify-center rounded-lg bg-teal-50 px-4 py-1 text-16px sm:text-18px'>
-        {block.endTime ? (
-          <>
-            <div className='font-medium text-neutral-700'>{String(dayjs(block.startTime).format('HH:mm'))}</div>
-            <div className='-my-1 horizontal-divider text-center text-gray-400 text-xs leading-none'>|</div>
-            <div className='vertical-divider text-center text-gray-400 text-xs leading-none'>—</div>
-            <div className='font-medium text-neutral-700'>{String(dayjs(block.endTime).format('HH:mm'))}</div>
-          </>
-        ) : (
-          <div className='font-medium text-neutral-700'>{dayjs(block.startTime).format('HH:mm')}</div>
-        )}
-      </div>
+      <div className='schedule-layout flex h-full w-full flex-row items-center gap-1 sm:gap-2'>
+        <div className='schedule-time-wrapper flex shrink-0 items-center justify-center rounded bg-teal-50 px-1 py-0.5 text-16px sm:px-4 sm:py-1 sm:text-18px'>
+          <BlockTimeLabel startTime={block.startTime} endTime={block.endTime} />
+        </div>
 
-      <div className='font-bold text-14px text-white sm:text-16px'>{block.title || 'タイトル未設定'}</div>
-      <button
-        type='button'
-        className='ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded-full hover:bg-black/10 sm:h-6 sm:w-6'
-        aria-label='info'
-      >
-        <img src={circleInfoIcon} alt='info' className='h-4 w-4 shrink-0 sm:h-5 sm:w-5' />
-      </button>
+        <ClampedText className='schedule-title flex min-w-0 flex-1 items-center self-stretch font-bold text-14px text-white leading-snug sm:text-16px'>
+          {block.title || 'タイトル未設定'}
+        </ClampedText>
+        <button
+          type='button'
+          className='schedule-info-btn ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded-full hover:bg-black/10 sm:h-6 sm:w-6'
+          aria-label='詳細'
+        >
+          <img src={circleInfoIcon} alt='' aria-hidden='true' className='h-4 w-4 shrink-0 sm:h-5 sm:w-5' />
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/blocks/edit/BlockTimeLabel.stories.tsx
+++ b/frontend/src/components/blocks/edit/BlockTimeLabel.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BlockTimeLabel } from './BlockTimeLabel';
+
+const meta: Meta<typeof BlockTimeLabel> = {
+  title: 'Components/Blocks/Edit/BlockTimeLabel',
+  component: BlockTimeLabel,
+  tags: ['autodocs'],
+  // 実際の利用箇所(.schedule-time-wrapper 等)を模した時刻表示用の背景ボックスに収めて表示する。
+  decorators: [
+    Story => (
+      <div className='inline-flex flex-row items-center justify-center rounded bg-teal-50 px-4 py-1 text-18px'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StartAndEnd: Story = {
+  args: {
+    startTime: new Date(2024, 0, 1, 9, 0),
+    endTime: new Date(2024, 0, 1, 21, 30),
+  },
+};
+
+export const StartOnly: Story = {
+  args: {
+    startTime: new Date(2024, 0, 1, 9, 0),
+    endTime: null,
+  },
+};

--- a/frontend/src/components/blocks/edit/BlockTimeLabel.test.tsx
+++ b/frontend/src/components/blocks/edit/BlockTimeLabel.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BlockTimeLabel } from './BlockTimeLabel';
+
+describe('BlockTimeLabel', () => {
+  it('endTime が null のとき開始時刻のみ表示する', () => {
+    render(<BlockTimeLabel startTime={new Date(2024, 0, 1, 9, 0)} endTime={null} />);
+    expect(screen.getByText('09:00')).toBeInTheDocument();
+    expect(screen.queryByText('|')).not.toBeInTheDocument();
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+  });
+
+  it('endTime があるとき 開始〜終了 と両方の区切りを描画する', () => {
+    render(<BlockTimeLabel startTime={new Date(2024, 0, 1, 9, 0)} endTime={new Date(2024, 0, 1, 21, 30)} />);
+    expect(screen.getByText('09:00')).toBeInTheDocument();
+    expect(screen.getByText('21:30')).toBeInTheDocument();
+    // 横並び用「|」と縦並び用「—」の両区切りを描画し、表示切替は CSS（flex 方向）に委ねる
+    expect(screen.getByText('|')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/blocks/edit/BlockTimeLabel.tsx
+++ b/frontend/src/components/blocks/edit/BlockTimeLabel.tsx
@@ -1,0 +1,26 @@
+import dayjs from 'dayjs';
+
+interface BlockTimeLabelProps {
+  startTime: Date;
+  endTime: Date | null;
+}
+
+/**
+ * 予定/移動ブロック共通の時刻表示。開始のみ、または 開始〜終了 を表示する。
+ * 親ラッパー(.schedule-time-wrapper / .transport-time-wrapper)の flex 方向に応じて
+ * 区切り(横「|」/縦「—」)が CSS で切り替わる。
+ */
+export function BlockTimeLabel({ startTime, endTime }: BlockTimeLabelProps) {
+  if (endTime == null) {
+    return <div className='font-medium text-neutral-700'>{dayjs(startTime).format('HH:mm')}</div>;
+  }
+
+  return (
+    <>
+      <div className='font-medium text-neutral-700'>{dayjs(startTime).format('HH:mm')}</div>
+      <div className='-my-1 horizontal-divider text-center text-gray-400 text-xs leading-none'>|</div>
+      <div className='vertical-divider text-center text-gray-400 text-xs leading-none'>—</div>
+      <div className='font-medium text-neutral-700'>{dayjs(endTime).format('HH:mm')}</div>
+    </>
+  );
+}

--- a/frontend/src/components/blocks/edit/BlockTransportationEdit.css
+++ b/frontend/src/components/blocks/edit/BlockTransportationEdit.css
@@ -32,3 +32,121 @@
     font-size: 10px !important;
   }
 }
+
+/* 時間(横並び)とタイトルを上下2行に分けてタイトルの横幅を確保する。
+   - モバイル(ウィンドウ < 40rem)はブロック幅によらず常に縦2行
+   - ブロック幅が狭い(< 16rem)場合は PC でも縦2行
+   高さが不足する短いブロックでも時間しか見えなくなるのを防ぐため高さ条件は設けない。
+   タイトルは折り返して複数行表示し、はみ出しはブロック下端でクリップする。 */
+@media (width < 40rem) {
+  .BlockTransportationEdit .transport-layout {
+    display: grid;
+    grid-template-columns: auto auto 1fr auto;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+      "time icon .     info"
+      "title title title title";
+    align-items: center;
+    row-gap: 0.125rem;
+  }
+
+  .BlockTransportationEdit .transport-time-wrapper {
+    grid-area: time;
+    /* 時間は横並び表示 */
+    flex-direction: row;
+
+    .vertical-divider {
+      display: block;
+    }
+
+    .horizontal-divider {
+      display: none;
+    }
+  }
+
+  .BlockTransportationEdit .transport-icon {
+    grid-area: icon;
+    /* 縦2行レイアウトではアイコンを 20px に固定する。
+       PC 既定の 32px(sm:w-8) のままだと、グリッドの auto トラックが幅不足で潰れた際に
+       img がスケール縮小されて「極端に小さく」見えてしまうため、明示サイズで固定して防ぐ。 */
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .BlockTransportationEdit .transport-title {
+    grid-area: title;
+  }
+
+  .BlockTransportationEdit .transport-info-btn {
+    grid-area: info;
+    margin-left: 0;
+  }
+}
+
+@container (width < 16rem) {
+  .BlockTransportationEdit .transport-layout {
+    display: grid;
+    grid-template-columns: auto auto 1fr auto;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+      "time icon .     info"
+      "title title title title";
+    align-items: center;
+    row-gap: 0.125rem;
+  }
+
+  .BlockTransportationEdit .transport-time-wrapper {
+    grid-area: time;
+    /* 時間は横並び表示 */
+    flex-direction: row;
+
+    .vertical-divider {
+      display: block;
+    }
+
+    .horizontal-divider {
+      display: none;
+    }
+  }
+
+  .BlockTransportationEdit .transport-icon {
+    grid-area: icon;
+    /* 縦2行レイアウトではアイコンを 20px に固定する。
+       PC 既定の 32px(sm:w-8) のままだと、グリッドの auto トラックが幅不足で潰れた際に
+       img がスケール縮小されて「極端に小さく」見えてしまうため、明示サイズで固定して防ぐ。 */
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .BlockTransportationEdit .transport-title {
+    grid-area: title;
+  }
+
+  .BlockTransportationEdit .transport-info-btn {
+    grid-area: info;
+    margin-left: 0;
+  }
+}
+
+/* 縦2行レイアウト時、上段(time + icon + info)が収まらず i がはみ出すのを防ぐため段階的に時刻を縮める。
+   各要素はほぼ固定幅(時刻 ~6rem + アイコン 20px + i 20px + ギャップ + 左右パディング)なので閾値は算出可能。
+   予定ブロックより移動手段アイコン 1 列分(20px + ギャップ)だけ閾値を広めに取る。
+   PC でもブロック幅(@container)で判定するため、列分割で細くなったブロックに反応する。
+   1段目: まずパディングと各要素のギャップを詰める。
+   2段目: それでも狭い場合は時刻の文字も小さくする。
+   さらに収まらない極小幅は親の overflow:hidden でクリップする。 */
+@container (width < 13rem) {
+  .BlockTransportationEdit .transport-layout {
+    column-gap: 0.125rem;
+  }
+
+  .BlockTransportationEdit .transport-time-wrapper {
+    padding-inline: 0.125rem;
+  }
+}
+
+@container (width < 11rem) {
+  .BlockTransportationEdit .transport-time-wrapper {
+    font-size: 10px !important;
+  }
+}

--- a/frontend/src/components/blocks/edit/BlockTransportationEdit.css
+++ b/frontend/src/components/blocks/edit/BlockTransportationEdit.css
@@ -69,8 +69,8 @@
     /* 縦2行レイアウトではアイコンを 20px に固定する。
        PC 既定の 32px(sm:w-8) のままだと、グリッドの auto トラックが幅不足で潰れた際に
        img がスケール縮小されて「極端に小さく」見えてしまうため、明示サイズで固定して防ぐ。 */
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1.5rem;
+    height: 1.5rem;
   }
 
   .BlockTransportationEdit .transport-title {
@@ -114,8 +114,8 @@
     /* 縦2行レイアウトではアイコンを 20px に固定する。
        PC 既定の 32px(sm:w-8) のままだと、グリッドの auto トラックが幅不足で潰れた際に
        img がスケール縮小されて「極端に小さく」見えてしまうため、明示サイズで固定して防ぐ。 */
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1.5rem;
+    height: 1.5rem;
   }
 
   .BlockTransportationEdit .transport-title {

--- a/frontend/src/components/blocks/edit/BlockTransportationEdit.tsx
+++ b/frontend/src/components/blocks/edit/BlockTransportationEdit.tsx
@@ -1,8 +1,9 @@
-import dayjs from 'dayjs';
 import circleInfoIcon from '@/assets/icons/circle-info.svg';
 import { TransportationIcon } from '@/components/blocks/TransportationIcon';
+import { ClampedText } from '@/components/ClampedText';
 import { cn } from '@/lib/utils';
 import type { TransportationBlockComponentProps } from '../types';
+import { BlockTimeLabel } from './BlockTimeLabel';
 import './BlockTransportationEdit.css';
 
 interface BlockTransportationEditProps extends TransportationBlockComponentProps {}
@@ -11,37 +12,33 @@ export function BlockTransportationEdit({ block, className }: BlockTransportatio
   return (
     <div
       className={cn(
-        'BlockTransportationEdit flex h-full w-full flex-row items-center gap-2 rounded-lg bg-linear-to-r from-neutral-400 to-neutral-500 px-2 py-2 [container-type:size] sm:px-4',
+        'BlockTransportationEdit h-full w-full overflow-hidden rounded-lg bg-linear-to-r from-neutral-400 to-neutral-500 px-2 py-2 [container-type:size] sm:px-4',
         className
       )}
     >
-      <div className='transport-time-wrapper flex items-center justify-center rounded-lg bg-neutral-100 px-4 py-1 text-16px sm:text-18px'>
-        {block.endTime ? (
-          <>
-            <div className='font-medium text-neutral-700'>{String(dayjs(block.startTime).format('HH:mm'))}</div>
-            <div className='-my-1 horizontal-divider text-center text-gray-400 text-xs leading-none'>|</div>
-            <div className='vertical-divider text-center text-gray-400 text-xs leading-none'>—</div>
-            <div className='font-medium text-neutral-700'>{String(dayjs(block.endTime).format('HH:mm'))}</div>
-          </>
-        ) : (
-          <div className='font-medium text-neutral-700'>{dayjs(block.startTime).format('HH:mm')}</div>
+      <div className='transport-layout flex h-full w-full flex-row items-center gap-1 sm:gap-2'>
+        <div className='transport-time-wrapper flex shrink-0 items-center justify-center rounded bg-neutral-100 px-1 py-0.5 text-16px sm:px-4 sm:py-1 sm:text-18px'>
+          <BlockTimeLabel startTime={block.startTime} endTime={block.endTime} />
+        </div>
+
+        {block.transportationType && (
+          <TransportationIcon
+            type={block.transportationType}
+            className='transport-icon h-5 w-5 shrink-0 brightness-0 invert'
+          />
         )}
-      </div>
+        <ClampedText className='transport-title flex min-w-0 flex-1 items-center self-stretch font-bold text-14px text-white leading-snug sm:text-16px'>
+          {block.title || 'タイトル未設定'}
+        </ClampedText>
 
-      {block.transportationType && (
-        <TransportationIcon type={block.transportationType} className='h-5 w-5 shrink-0 brightness-0 invert' />
-      )}
-      <div className='min-w-0 flex-1 truncate font-bold text-14px text-white sm:text-16px'>
-        {block.title || 'タイトル未設定'}
+        <button
+          type='button'
+          className='transport-info-btn ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded-full hover:bg-black/10 sm:h-6 sm:w-6'
+          aria-label='詳細'
+        >
+          <img src={circleInfoIcon} alt='' aria-hidden='true' className='h-4 w-4 shrink-0 sm:h-5 sm:w-5' />
+        </button>
       </div>
-
-      <button
-        type='button'
-        className='ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded-full hover:bg-black/10 sm:h-6 sm:w-6'
-        aria-label='info'
-      >
-        <img src={circleInfoIcon} alt='info' className='h-4 w-4 shrink-0 sm:h-5 sm:w-5' />
-      </button>
     </div>
   );
 }

--- a/frontend/src/hooks/useLineClamp.test.ts
+++ b/frontend/src/hooks/useLineClamp.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// useResizeObserver をモックし、登録された resize コールバックを捕捉して任意に発火させる。
+// これにより ResizeObserver（jsdom 非対応）に依存せず行数計算ロジックだけを検証する。
+let capturedCallback: ((entry: ResizeObserverEntry) => void) | undefined;
+
+vi.mock('./useResizeObserver', () => ({
+  useResizeObserver: (cb: (entry: ResizeObserverEntry) => void) => {
+    capturedCallback = cb;
+    return { current: null };
+  },
+}));
+
+import { useLineClamp } from './useLineClamp';
+
+const mockComputedStyle = (fontSize: string, lineHeight: string) => {
+  vi.spyOn(window, 'getComputedStyle').mockReturnValue({ fontSize, lineHeight } as CSSStyleDeclaration);
+};
+
+const fireResize = (height: number) => {
+  const entry = {
+    target: document.createElement('div'),
+    contentRect: { height } as DOMRectReadOnly,
+  } as unknown as ResizeObserverEntry;
+  act(() => {
+    capturedCallback?.(entry);
+  });
+};
+
+describe('useLineClamp', () => {
+  beforeEach(() => {
+    capturedCallback = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('初期値は1行', () => {
+    const { result } = renderHook(() => useLineClamp());
+    expect(result.current.lineClamp).toBe(1);
+  });
+
+  it('利用可能高さ ÷ 行高 の行数を返す', () => {
+    mockComputedStyle('16px', '24px');
+    const { result } = renderHook(() => useLineClamp());
+    fireResize(72);
+    expect(result.current.lineClamp).toBe(3);
+  });
+
+  it('端数は切り捨てる', () => {
+    mockComputedStyle('16px', '24px');
+    const { result } = renderHook(() => useLineClamp());
+    fireResize(80); // 80 / 24 = 3.33 -> 3
+    expect(result.current.lineClamp).toBe(3);
+  });
+
+  it('行高より低い高さでも最低1行を返す', () => {
+    mockComputedStyle('16px', '24px');
+    const { result } = renderHook(() => useLineClamp());
+    fireResize(10);
+    expect(result.current.lineClamp).toBe(1);
+  });
+
+  it('line-height が px で取得できない場合は fontSize * 1.4 をフォールバックに使う', () => {
+    mockComputedStyle('20px', 'normal'); // フォールバック行高 = 28px
+    const { result } = renderHook(() => useLineClamp());
+    fireResize(84); // 84 / 28 = 3
+    expect(result.current.lineClamp).toBe(3);
+  });
+});

--- a/frontend/src/hooks/useLineClamp.ts
+++ b/frontend/src/hooks/useLineClamp.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react';
+import { useResizeObserver } from './useResizeObserver';
+
+/**
+ * 要素の利用可能な高さから表示可能な行数を算出し、-webkit-line-clamp 用の行数を返すフック。
+ *
+ * タイトルなどを「高さに収まる分だけ折り返して複数行表示し、あふれたら末尾に … 」で
+ * 省略させたいが、-webkit-line-clamp は固定の行数を要求するため、
+ * 利用可能高さ ÷ 行の高さ から行数を計算する。
+ * ブロックのドラッグ/リサイズや画面回転で高さが変わるため ResizeObserver で再計算する
+ * （監視・クリーンアップは共通の useResizeObserver に委譲）。
+ *
+ * 対象要素は align-self: stretch 等で利用可能領域いっぱいに伸ばしておくこと
+ * （contentRect.height = 利用可能高さ となるようにするため）。
+ */
+export function useLineClamp() {
+  const [lineClamp, setLineClamp] = useState(1);
+
+  const handleResize = useCallback((entry: ResizeObserverEntry) => {
+    const style = getComputedStyle(entry.target);
+    const fontSize = Number.parseFloat(style.fontSize);
+    let lineHeight = Number.parseFloat(style.lineHeight);
+    // line-height が "normal" など px で取れない場合のフォールバック
+    if (Number.isNaN(lineHeight) || lineHeight <= 0) {
+      lineHeight = fontSize * 1.4;
+    }
+    const lines = Math.max(1, Math.floor(entry.contentRect.height / lineHeight));
+    setLineClamp(lines);
+  }, []);
+
+  const ref = useResizeObserver(handleResize);
+
+  return { ref, lineClamp };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -187,6 +187,17 @@
   .fc-day-today {
     background: none !important;
   }
+
+  /* ブロック（イベント）の幅を制限し、右側に新規ブロックを追加・選択しやすい余白を作る。
+     .fc-timegrid-col-events はイベント群のコンテナで、デフォルトは margin: 0 2.5% 0 2px。
+     右マージンを広げることで全イベントが一括で細くなり、空いた右側は .fc-timegrid-col の
+     ままなので select（新規ブロック追加）操作のターゲットとして機能する。
+     .fc.fc-direction-ltr で specificity を上げ、FullCalendar 既定値を上書きする。
+     clamp で下限/上限を設け、モバイル（列幅が狭い）でもタップ領域を確保しつつ、
+     デスクトップ（列幅が広い）で余白が広がりすぎないようにする。 */
+  &.fc-direction-ltr .fc-timegrid-col-events {
+    margin-right: clamp(24px, 12.5%, 48px);
+  }
 }
 
 @layer base {

--- a/frontend/src/pages/TripPage/EditTripLayout.tsx
+++ b/frontend/src/pages/TripPage/EditTripLayout.tsx
@@ -227,6 +227,8 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
           editable
           longPressDelay={300}
           unselectAuto={false}
+          // 重なるブロックはかぶさず、きれいに横並びの列に分割する
+          slotEventOverlap={false}
           // データとイベントハンドラ
           events={events}
           select={handleSelect}


### PR DESCRIPTION
## 概要

Closes #144

旅程編集画面のブロック（イベント）が列幅いっぱいに広がり、右側に新規ブロックを追加する余白が選択しづらい問題を解消する。あわせて、狭幅・モバイルでブロックのタイトルが見えづらい問題も改善した。

## 対応内容

**1. ブロック幅の制限と重なり表示**
- FullCalendar の `.fc-timegrid-col-events` の右マージンを `clamp(24px, 12.5%, 48px)` に拡張し、右側に新規追加用の余白を確保（CSS 1ルールで全ブロックに一括適用）
- `slotEventOverlap={false}` で重なるブロックをかぶせず横並びの列に分割

**2. タイトル表示の改善（共通コンポーネント化）**
- `ClampedText` / `useLineClamp`: 利用可能高さから行数を算出し、折り返し＋末尾省略（…）表示
- `BlockTimeLabel`: 予定/移動ブロック共通の時刻表示を抽出
- 単体テスト・Storybook を追加

**3. 編集UIの縦2行レイアウト**
- 時刻とタイトルをグリッドで上下2行に分割しタイトル幅を確保
- モバイル（< 40rem）は常に縦2行、PCでも幅が狭い（< 16rem）場合は縦2行

## スクリーンショット

|  | 修正前 | 修正後 |
| --- | --- | --- |
| **PC** | <img width="1080" height="1189" alt="Screenshot_20260607-180352" src="https://github.com/user-attachments/assets/a5931ebe-5b2b-46ee-b299-233824ae7e5f" /> | <img width="1080" height="1175" alt="Screenshot_20260607-180420" src="https://github.com/user-attachments/assets/85a30d9c-9565-4cff-b527-2991d68a5b06" />|
| **モバイル** | <img width="1080" height="843" alt="Screenshot_20260607-180741" src="https://github.com/user-attachments/assets/0831cd27-c0c7-41af-8cb1-99d50c799824" /> | <img width="1080" height="857" alt="Screenshot_20260607-180828" src="https://github.com/user-attachments/assets/ff4e03d7-6ae8-43b6-be5c-e53199695a7e" /> |

## 確認方法

1. 編集画面でカレンダーを開く
2. ブロック右側に余白が空き、タップ/ドラッグで新規追加ダイアログが開ける
3. 狭幅・モバイルでブロックのタイトルが折り返し表示され、潰れて見えなくならない

## レビュー観点

- [ ] 余白量・ブレイクポイントが PC / モバイル双方で適切か（値は調整可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 長いテキストの自動省略表示（ClampedText）を追加
  * 時刻表示コンポーネント（開始/終了表示）を追加
  * Storybook に各コンポーネントの表示例を追加
* **改善**
  * スケジュール／交通編集画面のレスポンシブ改善（小画面対応のレイアウト調整）
  * カレンダー表示の重複ブロック描画を改善
* **テスト**
  * 新規コンポーネントと行数算出ユーティリティのテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
