### PR TITLE
change: 環境構築スクリプトの改善

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
+    "ghcr.io/itsmechlark/features/postgresql:1": {
+      "version": "1.9.0",
+      "resolved": "ghcr.io/itsmechlark/features/postgresql@sha256:356d919ede2f7dce3f921b424301f965eeeb63e67840afec26eeb362998f08f9",
+      "integrity": "sha256:356d919ede2f7dce3f921b424301f965eeeb63e67840afec26eeb362998f08f9"
+    },
+    "ghcr.io/va-h/devcontainers-features/uv:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",
+      "integrity": "sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,12 @@
 {
   "name": "Tabishare",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "containerEnv": {
-    "UV_PROJECT_ENVIRONMENT": "/usr/local/python/current/"
+    "UV_PROJECT_ENVIRONMENT": "/usr/local/python/current/",
+    "PNPM_HOME": "/home/vscode/.local/share/pnpm"
+  },
+  "remoteEnv": {
+    "PATH": "/home/vscode/.local/share/pnpm:${containerEnv:PATH}"
   },
   "features": {
     "ghcr.io/devcontainers/features/python:1": {

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -37,32 +37,3 @@ fi
 # アプリケーション固有のセットアップ（依存関係のインストール、マイグレーションなど）を実行する
 echo "🚀 Starting application setup..."
 ./scripts/setup.sh
-
-
-# --- データベースのセットアップ ---
-# データベースの起動、ユーザー作成、データベース作成、マイグレーションを行うスクリプトを実行する
-echo "🚀 Starting database setup..."
-sh ./scripts/setup_database.sh
-
-# Claude Code
-pnpm add -g @anthropic-ai/claude-code
-uv tool install claude-monitor
-
-# Gemini CLI
-pnpm add -g @google/gemini-cli
-echo "🎉 All setup steps completed successfully!"
-
-# Firebase CLI Tools
-pnpm add -g firebase-tools
-
-# AI検索用にripgrepをインストール
-sudo apt-get update
-sudo apt-get install -y ripgrep libnss3-tools
-echo "🔍 ripgrep installed for AI search functionality."
-
-# PWA開発用のmkcertをインストール
-curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
-chmod +x mkcert-v*-linux-amd64
-sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
-mkcert -install
-echo "🔒 mkcert installed for local HTTPS development."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,31 @@ echo "📦 パッケージをインストール中..."
 cd "$ROOT_DIR"
 pnpm run sync
 
+# --- データベースのセットアップ ---
+# データベースの起動、ユーザー作成、データベース作成、マイグレーションを行うスクリプトを実行する
+# setup_database.sh の失敗を握り潰さず、ここでセットアップ全体を中断する
+echo "🚀 Starting database setup..."
+if ! sh ./scripts/setup_database.sh; then
+  echo "❌ Error: database setup failed. Aborting setup." >&2
+  cd "$CURRENT_DIR"
+  exit 1
+fi
+
+# Claude Code
+curl -fsSL https://claude.ai/install.sh | bash
+uv tool install claude-monitor
+
+# Firebase CLI Tools
+pnpm add -g firebase-tools
+
+# PWA開発用のmkcertをインストール
+curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
+chmod +x mkcert-v*-linux-amd64
+sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+rm -f mkcert-v*-linux-amd64
+mkcert -install
+echo "🔒 mkcert installed for local HTTPS development."
+
 echo "✅ セットアップが完了しました！"
 echo ""
 echo "🎯 開発サーバーを起動するには:"

--- a/scripts/setup_database.sh
+++ b/scripts/setup_database.sh
@@ -61,7 +61,7 @@ run_migration() {
   local db_name=$1
   local db_type=$2
   echo "📦 Migrating ${db_type} database..."
-  if pnpm dotenvx run --env-file ../.env -- alembic -n "${db_name}" upgrade head; then
+  if pnpm dotenvx run --env-file .env -- sh -c "cd server && alembic -n \"${db_name}\" upgrade head"; then
     echo "✅ ${db_type} database migration completed successfully!"
     return 0
   else
@@ -73,10 +73,8 @@ run_migration() {
 
 # 開発用とテスト用のデータベースのマイグレーションの実行
 echo "🔄 Running database migrations..."
-cd server
-run_migration "devdb" "development" || { cd ..; exit 1; }
-run_migration "testdb" "test" || { cd ..; exit 1; }
-cd ..
+run_migration "devdb" "development" || exit 1
+run_migration "testdb" "test" || exit 1
 echo "✅ database migrations completed."
 
 echo "🐘 All database setups are complete."


### PR DESCRIPTION
## 概要

devcontainer の環境構築スクリプトを整理・改善する。

## 変更内容

- `.devcontainer/postCreateCommand.sh` に集約されていたセットアップ処理を整理し、アプリ固有のセットアップを `scripts/setup.sh` 側へ移動（`postCreateCommand.sh` は `./scripts/setup.sh` の呼び出しに一本化）
- `scripts/setup.sh` にDBセットアップ・Claude Code / claude-monitor / Firebase CLI / mkcert のインストール処理を集約
- Claude Code のインストールを `pnpm add -g @anthropic-ai/claude-code` から公式インストーラ (`curl -fsSL https://claude.ai/install.sh`) に変更
- Gemini CLI (`@google/gemini-cli`) のインストールを削除
- ripgrep / libnss3-tools の apt インストールを削除
- `.devcontainer/devcontainer.json` に `PNPM_HOME` (`containerEnv`) と pnpm グローバル bin を通す `PATH` (`remoteEnv`) を追加
- `.devcontainer/devcontainer-lock.json` を追加し、devcontainer features (node / python / postgresql / uv) のバージョンを固定
- mkcert のダウンロード成果物を `cp` 後に `rm -f` で削除し、リポジトリ直下に残らないように修正

## 確認事項

- devcontainer の再ビルドでセットアップが正常に完了すること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 開発コンテナの基盤イメージを更新し、各機能のバージョンとイメージ参照を固定化して再現性を向上しました。
  * PNPM_HOME を追加し、pnpm 実行パスを優先するよう環境変数を調整しました。
  * 初期セットアップ手順を整理・簡素化し、データベース準備や開発ツール（Claude関連、Firebase CLI、mkcert 等）の導入をセットアップスクリプトへ統合・堅牢化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
