### PR TITLE
fix: モバイルでタブ切り替え時のオフライン誤検知を防止 (#137)

### DIFF
--- a/frontend/src/lib/networkDetection.test.ts
+++ b/frontend/src/lib/networkDetection.test.ts
@@ -1,7 +1,7 @@
 import { createStore } from 'jotai';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isOfflineAtom } from '@/atoms/network';
-import { checkNetworkStatus, evaluateNetwork, thresholdManager } from './networkDetection';
+import { checkNetworkStatus, evaluateNetwork, RESUME_RETRY_DELAY_MS, thresholdManager } from './networkDetection';
 
 const mockNavigatorOnLine = (value: boolean) => {
   vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(value);
@@ -185,5 +185,99 @@ describe('evaluateNetwork', () => {
 
     expect(store.get(isOfflineAtom)).toBe(false);
     expect(thresholdManager.get()).toBe(5000); // 変更なし
+  });
+});
+
+describe('evaluateNetwork - タブ復帰時の誤検知対策 (allowRetry)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+    thresholdManager.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allowRetry: 初回 rtt-exceeded でも再判定でオンラインなら誤オフライン判定しない', async () => {
+    mockNavigatorOnLine(true);
+    // 1回目: しきい値超過で返らない / 2回目: 即成功
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockReturnValueOnce(
+      new Promise(() => {
+        // 1回目は解決しない（しきい値タイマーが先に発火）
+      })
+    );
+    fetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    // 2回目の RTT 計測用
+    vi.spyOn(performance, 'now').mockReturnValue(0);
+
+    const store = createStore();
+    store.set(isOfflineAtom, false); // 以前はオンライン
+
+    const promise = evaluateNetwork(store, { allowRetry: true });
+    // 1回目の RTT しきい値(5000ms) 超過 → 待機(1500ms) → 2回目チェック
+    await vi.advanceTimersByTimeAsync(5000 + 1500);
+    await promise;
+
+    expect(store.get(isOfflineAtom)).toBe(false); // 誤オフラインにならない
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('allowRetry: 再判定でも失敗すれば最終的にオフライン判定する', async () => {
+    mockNavigatorOnLine(true);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Network error'));
+
+    const store = createStore();
+    store.set(isOfflineAtom, false);
+
+    const promise = evaluateNetwork(store, { allowRetry: true });
+    await vi.advanceTimersByTimeAsync(RESUME_RETRY_DELAY_MS);
+    await promise;
+
+    expect(store.get(isOfflineAtom)).toBe(true);
+  });
+
+  it('allowRetry: 待機中に navigator.onLine が false になればオフライン確定', async () => {
+    const onLineSpy = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Network error'));
+
+    const store = createStore();
+    store.set(isOfflineAtom, false);
+
+    const promise = evaluateNetwork(store, { allowRetry: true });
+    // 待機中にブラウザがオフライン確定
+    onLineSpy.mockReturnValue(false);
+    await vi.advanceTimersByTimeAsync(RESUME_RETRY_DELAY_MS);
+    await promise;
+
+    expect(store.get(isOfflineAtom)).toBe(true);
+  });
+
+  it('allowRetry: navigator-offline は再判定せず即オフライン', async () => {
+    mockNavigatorOnLine(false);
+    const fetchSpy = mockFetchSuccess();
+
+    const store = createStore();
+    store.set(isOfflineAtom, false);
+
+    await evaluateNetwork(store, { allowRetry: true });
+
+    expect(store.get(isOfflineAtom)).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('allowRetry: 以前オフラインだった場合は再判定しない（オフライン→オフライン）', async () => {
+    mockNavigatorOnLine(true);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockRejectedValue(new TypeError('Network error'));
+
+    const store = createStore();
+    store.set(isOfflineAtom, true); // 以前からオフライン
+
+    await evaluateNetwork(store, { allowRetry: true });
+
+    expect(store.get(isOfflineAtom)).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // 再判定なし（1回のみ）
   });
 });

--- a/frontend/src/lib/networkDetection.ts
+++ b/frontend/src/lib/networkDetection.ts
@@ -11,6 +11,11 @@ const DEBUG_DELAY_PARAM =
     : null;
 const INITIAL_RTT_THRESHOLD_MS = 5000;
 const RELAXED_RTT_THRESHOLD_MS = 10000;
+// タブ復帰・再接続直後はモバイル無線の再接続遅延で初回ヘルスチェックが失敗しやすい。
+// 一度だけ待ってから緩和しきい値で再判定するための待機時間。
+export const RESUME_RETRY_DELAY_MS = 1500;
+
+const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
 // --- 型 ---
 
@@ -39,7 +44,8 @@ export const thresholdManager = (() => {
 // --- 2段階判定ロジック ---
 
 export const checkNetworkStatus = async (
-  baseUrl: string = import.meta.env.VITE_API_BASE_URL ?? ''
+  baseUrl: string = import.meta.env.VITE_API_BASE_URL ?? '',
+  thresholdMs?: number
 ): Promise<NetworkCheckResult> => {
   // Step 1: navigator.onLine チェック
   if (!navigator.onLine) {
@@ -48,7 +54,7 @@ export const checkNetworkStatus = async (
 
   // Step 2: fetch と RTTしきい値タイマーを Promise.race で競わせる
   const controller = new AbortController();
-  const rttThresholdMs = thresholdManager.get();
+  const rttThresholdMs = thresholdMs ?? thresholdManager.get();
   const start = performance.now();
 
   const healthUrl = DEBUG_DELAY_PARAM
@@ -89,9 +95,32 @@ export const checkNetworkStatus = async (
 
 // --- atom 更新 ---
 
-export const evaluateNetwork = async (store: ReturnType<typeof createStore>): Promise<void> => {
+export type EvaluateNetworkOptions = {
+  /**
+   * タブ復帰(visibilitychange)・再接続(online)など、ネットワークが不安定に
+   * なりやすいタイミングで true にする。オンライン→オフラインへ反転しそうな
+   * 場合に、緩和しきい値で1度だけ再判定してから確定させ、誤検知を防ぐ。
+   */
+  allowRetry?: boolean;
+};
+
+export const evaluateNetwork = async (
+  store: ReturnType<typeof createStore>,
+  options: EvaluateNetworkOptions = {}
+): Promise<void> => {
   const wasPreviouslyOffline = store.get(isOfflineAtom);
-  const result = await checkNetworkStatus();
+  let result = await checkNetworkStatus();
+
+  // タブ復帰・再接続時の誤検知対策:
+  // それまでオンラインだったのに navigator.onLine は true のままヘルスチェックだけ
+  // 失敗した場合(モバイル無線の復帰遅延など)、少し待ってから緩和しきい値で再判定する。
+  // navigator-offline はブラウザ確定のオフラインなので再判定しない。
+  if (options.allowRetry && !wasPreviouslyOffline && result.isOffline && result.reason !== 'navigator-offline') {
+    await delay(RESUME_RETRY_DELAY_MS);
+    result = navigator.onLine
+      ? await checkNetworkStatus(undefined, RELAXED_RTT_THRESHOLD_MS)
+      : { isOffline: true, reason: 'navigator-offline' };
+  }
 
   const changed = wasPreviouslyOffline !== result.isOffline;
   if (changed) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -39,13 +39,13 @@ window.addEventListener('offline', () => {
 
 window.addEventListener('online', () => {
   if (jotaiStore.get(isForcedOfflineAtom)) return;
-  evaluateNetwork(jotaiStore);
+  evaluateNetwork(jotaiStore, { allowRetry: true });
 });
 
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'visible') {
     if (jotaiStore.get(isForcedOfflineAtom)) return;
-    evaluateNetwork(jotaiStore);
+    evaluateNetwork(jotaiStore, { allowRetry: true });
   }
 });
 


### PR DESCRIPTION
## 概要

Issue #137 の修正。モバイルでブラウザのタブを切り替えて戻ると、実際はオンラインなのにオフラインモードになってしまう（自動判定の誤検知）事象を防ぐ。

## 根本原因

- タブ復帰時 `visibilitychange`(visible) で `evaluateNetwork()` が実行される
- このとき RTT しきい値は初回値の **5000ms**。モバイルの無線復帰直後は `/health` への fetch RTT がこれを超えやすく、`rtt-exceeded` で誤オフライン判定される
- iOS Safari 等で `online` イベントが発火しないケースでは `visibilitychange` だけが頼りになり、厳しい初回しきい値がそのまま効いてしまう

## 修正内容

- `evaluateNetwork(store, { allowRetry })` オプションを追加
- **オンライン→オフラインへ反転しそうな場合のみ**、`RESUME_RETRY_DELAY_MS`(1500ms) 待機してから緩和しきい値(**10000ms**)で **1度だけ再判定** してから状態を確定する
  - 待機中に `navigator.onLine` が `false` になった場合はオフライン確定（ブラウザ確定の信号を優先）
  - `navigator-offline`（ブラウザがオフライン確定）は再判定せず即オフライン
- `main.tsx` の `visibilitychange` / `online` ハンドラで `{ allowRetry: true }` を指定
- 起動時・`offline` イベントの挙動は従来通り（変更なし）
- ユーザーが手動設定する強制オフライン (`forcedOffline`) は別経路のため影響なし

## テスト

`networkDetection.test.ts` に allowRetry のケースを追加:
- 初回 `rtt-exceeded` でも再判定でオンラインなら誤オフライン判定しない
- 再判定でも失敗すれば最終的にオフライン判定する
- 待機中に `navigator.onLine` が false になればオフライン確定
- `navigator-offline` は再判定せず即オフライン
- 以前オフラインだった場合は再判定しない

## 確認

- `pnpm run type-check` ✅
- `pnpm run lint:check` ✅
- `pnpm run format:check` ✅
- `pnpm test` ✅ (15 files / 139 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* タブ復帰や再接続時のネットワーク状態判定を改善し、誤ったオフライン判定を減らしました。判定失敗時に一度待機してから再評価する仕組みを追加しました。

## Tests
* ネットワーク検出のリトライロジックと各種エッジケースに関するテストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->