### PR TITLE
fix: タイムライン初回スクロールのレースを修正 (#101)

### DIFF
--- a/frontend/src/pages/TripPage/EditTripLayout.tsx
+++ b/frontend/src/pages/TripPage/EditTripLayout.tsx
@@ -97,10 +97,8 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
   }, []);
 
   // 初回イベントマウント時にタイムラインを最初のイベントへスクロールする。
-  // eventDidMountはイベントごと・再レンダーごとに発火するため、ページごとに1度だけ実行する。
-  // blocksのロード完了前はイベントがDOMに存在せず発火しないため、ロード完了後の最初の
-  // マウントが確実なトリガーになる。スクロールはレイアウト確定後に行うようrAFで1フレーム待ち、
-  // 実際に実行されるまでフラグを落とさないことで「ロード未完→スクロール未発火」のレースを防ぐ。
+  // blocksのロード完了後の最初のマウントを確実なトリガーにし、rAFで1フレーム待ってから
+  // 実行することでレイアウト未確定によるスクロール失敗を防ぐ（ページごとに1度だけ実行）。
   const handleEventMount = (arg: ViewMountArg) => {
     if (hasScrolledToFirstEvent.current || scrollRafId.current != null) return;
     const eventEl = arg.el;

--- a/frontend/src/pages/TripPage/EditTripLayout.tsx
+++ b/frontend/src/pages/TripPage/EditTripLayout.tsx
@@ -80,9 +80,15 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
     }
   }, [blocks]);
 
-  // selectedPageId変更時にスクロールフラグをリセット
+  // selectedPageId変更時にスクロールフラグをリセット。
+  // 旧ページで予約済みのrAFが切替後に発火するとhasScrolledToFirstEventを再び立ててしまい
+  // 新ページの初回スクロールが潰されるため、ここでも明示的にキャンセルする。
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedPageId変更を検知してrefをリセットするための意図的な依存配列
   useEffect(() => {
+    if (scrollRafId.current != null) {
+      cancelAnimationFrame(scrollRafId.current);
+      scrollRafId.current = null;
+    }
     hasScrolledToFirstEvent.current = false;
   }, [selectedPageId]);
 

--- a/frontend/src/pages/TripPage/EditTripLayout.tsx
+++ b/frontend/src/pages/TripPage/EditTripLayout.tsx
@@ -26,7 +26,10 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
   const { deleteBlock } = useDeleteBlock(selectedPageId);
   const calendarRef = useRef<FullCalendar>(null);
   const calendarContainerRef = useRef<HTMLDivElement>(null);
-  const isFirstEventMount = useRef(true);
+  // ページごとに初回スクロールが完了したか。実際にスクロールが実行されるまでfalseのまま維持する
+  const hasScrolledToFirstEvent = useRef(false);
+  // 初回スクロール用に予約したrequestAnimationFrameのID（クリーンアップ用）
+  const scrollRafId = useRef<number | null>(null);
 
   // AddBlockDialog用のstate
   const [addDialogOpen, setAddDialogOpen] = useState(false);
@@ -80,13 +83,32 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
   // selectedPageId変更時にスクロールフラグをリセット
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedPageId変更を検知してrefをリセットするための意図的な依存配列
   useEffect(() => {
-    isFirstEventMount.current = true;
+    hasScrolledToFirstEvent.current = false;
   }, [selectedPageId]);
 
+  // アンマウント時に予約済みのスクロールrAFをクリーンアップする
+  useEffect(() => {
+    return () => {
+      if (scrollRafId.current != null) {
+        cancelAnimationFrame(scrollRafId.current);
+        scrollRafId.current = null;
+      }
+    };
+  }, []);
+
+  // 初回イベントマウント時にタイムラインを最初のイベントへスクロールする。
+  // eventDidMountはイベントごと・再レンダーごとに発火するため、ページごとに1度だけ実行する。
+  // blocksのロード完了前はイベントがDOMに存在せず発火しないため、ロード完了後の最初の
+  // マウントが確実なトリガーになる。スクロールはレイアウト確定後に行うようrAFで1フレーム待ち、
+  // 実際に実行されるまでフラグを落とさないことで「ロード未完→スクロール未発火」のレースを防ぐ。
   const handleEventMount = (arg: ViewMountArg) => {
-    if (!isFirstEventMount.current) return;
-    arg.el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-    isFirstEventMount.current = false;
+    if (hasScrolledToFirstEvent.current || scrollRafId.current != null) return;
+    const eventEl = arg.el;
+    scrollRafId.current = requestAnimationFrame(() => {
+      scrollRafId.current = null;
+      eventEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      hasScrolledToFirstEvent.current = true;
+    });
   };
 
   // Date参照の安定化（親re-renderで新しいDateが生成されないようにする）


### PR DESCRIPTION
## 概要

Issue #101「【フロントエンド】たまにタイムラインスクロールが発生しない」を修正します。

編集モード遷移時に、タイムラインへの初回スクロールが発生しない場合がある不具合を解消します。

## 原因（レースコンディション）

`EditTripLayout` の初回スクロールは FullCalendar の `eventDidMount` 内で `scrollIntoView` を実行し、直後に `isFirstEventMount` フラグを落としていました。

最初のイベントマウントが**親スクロールコンテナ／カレンダーのレイアウト確定前**に発生すると（キャッシュヒットでデータが即時に揃う場合や、表示日と一致するデータの場合など）、`scrollIntoView` は呼ばれても視覚的に効かないまま、フラグだけが落ちて再試行されませんでした。

## 修正内容

- 完了フラグ（`hasScrolledToFirstEvent`）を、**実際にスクロールが実行されるまで落とさない**ように変更
- スクロールを `requestAnimationFrame` で1フレーム遅延させ、**レイアウト確定後**に実行
- `eventDidMount` は複数回発火するため、ページごとに1度だけ実行（`scrollRafId` で多重予約を防止）
- `selectedPageId` 変更時にフラグをリセット（従来挙動を維持）
- アンマウント時に予約済みの rAF をクリーンアップ

`eventDidMount` は「イベントが DOM に存在する」確実なシグナルであり、ロード完了後の最初のマウントを確実なトリガーとして利用することで、キャッシュ有無どちらでも初回スクロールが発火するようになります。

## 確認

- [x] `pnpm run type-check`
- [x] `pnpm run lint:check`
- [x] `pnpm run format:check`

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 旅行ページのスクロール制御を改善し、ページ切り替え時の動作をより安定化させました。
  * メモリリークの可能性を排除するためクリーンアップ処理を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->