### PR TITLE
fix: 初期表示ページの不整合を修正しアクティブページを永続化 (#147)

### DIFF
--- a/frontend/src/components/timeline/ViewTimeline.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { sortBlocks } from '@/lib/sortBlocks';
 import { cn } from '@/lib/utils';
 import type { Block } from '@/types/block';
 import { ViewTimelineItem } from './ViewTimelineItem';
@@ -24,20 +25,6 @@ interface ViewTimelineProps {
   blocks: Block[];
   className?: string;
 }
-
-// --- ソート ---
-
-const sortBlocks = (blocks: Block[]): Block[] => {
-  return [...blocks].sort((a, b) => {
-    const startDiff = a.startTime.getTime() - b.startTime.getTime();
-    if (startDiff !== 0) return startDiff;
-    // startTime が同じ場合: endTime 昇順（null 先頭）
-    if (a.endTime === null && b.endTime === null) return 0;
-    if (a.endTime === null) return -1;
-    if (b.endTime === null) return 1;
-    return a.endTime.getTime() - b.endTime.getTime();
-  });
-};
 
 // --- グループ化 ---
 

--- a/frontend/src/hooks/useActivePage.test.ts
+++ b/frontend/src/hooks/useActivePage.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+const mockDbGet = vi.fn();
+const mockDbPut = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    swrCache: {},
+    userSettings: {
+      get: (...args: unknown[]) => mockDbGet(...args),
+      put: (...args: unknown[]) => mockDbPut(...args),
+    },
+  },
+}));
+
+import { useActivePage } from '@/hooks/useActivePage';
+
+describe('useActivePage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockDbGet.mockResolvedValue(undefined);
+    mockDbPut.mockResolvedValue(undefined);
+  });
+
+  it('初期化時にIndexedDBから保存済みのアクティブページIDを読み込む', async () => {
+    mockDbGet.mockResolvedValue({ key: 'activePageId_1', value: 42 });
+
+    const { result } = renderHook(() => useActivePage(1));
+
+    await waitFor(() => {
+      expect(result.current.isActivePageInitialized).toBe(true);
+    });
+    expect(mockDbGet).toHaveBeenCalledWith('activePageId_1');
+    expect(result.current.storedPageId).toBe(42);
+  });
+
+  it('保存済みデータが無い場合は storedPageId が null になる', async () => {
+    mockDbGet.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useActivePage(1));
+
+    await waitFor(() => {
+      expect(result.current.isActivePageInitialized).toBe(true);
+    });
+    expect(result.current.storedPageId).toBeNull();
+  });
+
+  it('saveActivePageId() で tripId に紐づくキーへ保存される', async () => {
+    const { result } = renderHook(() => useActivePage(1));
+
+    await waitFor(() => {
+      expect(result.current.isActivePageInitialized).toBe(true);
+    });
+
+    act(() => {
+      result.current.saveActivePageId(7);
+    });
+
+    await waitFor(() => {
+      expect(mockDbPut).toHaveBeenCalledWith({ key: 'activePageId_1', value: 7 });
+    });
+  });
+
+  it('tripId が null の場合は読み込みも保存も行わない', async () => {
+    const { result } = renderHook(() => useActivePage(null));
+
+    await waitFor(() => {
+      expect(result.current.storedPageId).toBeNull();
+    });
+    expect(mockDbGet).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.saveActivePageId(7);
+    });
+
+    expect(mockDbPut).not.toHaveBeenCalled();
+  });
+
+  it('IndexedDB読み込みエラー時も初期化完了状態になりクラッシュしない', async () => {
+    mockDbGet.mockRejectedValue(new Error('DB error'));
+
+    const { result } = renderHook(() => useActivePage(1));
+
+    await waitFor(() => {
+      expect(result.current.isActivePageInitialized).toBe(true);
+    });
+    expect(result.current.storedPageId).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useActivePage.ts
+++ b/frontend/src/hooks/useActivePage.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+import { db } from '@/lib/db';
+import type { Page } from '@/types/page';
+
+/** IndexedDB の userSettings キープレフィックス（Trip ごとにアクティブページを保持） */
+const ACTIVE_PAGE_KEY_PREFIX = 'activePageId_';
+
+/** tripId からアクティブページ保存用のキーを生成 */
+const buildActivePageKey = (tripId: number): string => `${ACTIVE_PAGE_KEY_PREFIX}${tripId}`;
+
+/** IndexedDB から Trip のアクティブページ ID を取得 */
+const getActivePageIdFromDB = async (tripId: number): Promise<Page['id'] | null> => {
+  const entry = await db.userSettings.get(buildActivePageKey(tripId));
+  return typeof entry?.value === 'number' ? entry.value : null;
+};
+
+/** IndexedDB に Trip のアクティブページ ID を保存 */
+const saveActivePageIdToDB = async (tripId: number, pageId: Page['id']): Promise<void> => {
+  await db.userSettings.put({ key: buildActivePageKey(tripId), value: pageId });
+};
+
+/**
+ * Trip ごとに最後に表示していたページ（アクティブページ）を IndexedDB で永続化し、
+ * 再訪時に復帰できるようにするフック。
+ */
+export const useActivePage = (tripId: number | null) => {
+  const [storedPageId, setStoredPageId] = useState<Page['id'] | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // tripId 確定時に IndexedDB から保存済みのアクティブページ ID を読み込む
+  useEffect(() => {
+    if (tripId == null) {
+      setStoredPageId(null);
+      setIsInitialized(false);
+      return;
+    }
+
+    let cancelled = false;
+    const init = async () => {
+      const id = await getActivePageIdFromDB(tripId);
+      if (cancelled) return;
+      setStoredPageId(id);
+      setIsInitialized(true);
+    };
+    init().catch(() => {
+      if (!cancelled) setIsInitialized(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tripId]);
+
+  // アクティブページ ID を IndexedDB に永続化（fire-and-forget）
+  const saveActivePageId = useCallback(
+    (pageId: Page['id']) => {
+      if (tripId == null) return;
+      saveActivePageIdToDB(tripId, pageId).catch(() => {
+        // fire-and-forget
+      });
+    },
+    [tripId]
+  );
+
+  return {
+    storedPageId,
+    isActivePageInitialized: isInitialized,
+    saveActivePageId,
+  };
+};

--- a/frontend/src/hooks/useBlocks.ts
+++ b/frontend/src/hooks/useBlocks.ts
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import useSWR, { type SWRConfiguration, useSWRConfig } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { z } from 'zod';
 import { apiClient, fetcher } from '@/lib/apiClient';
 import { getErrorMessage } from '@/lib/errors';
+import { sortBlocks } from '@/lib/sortBlocks';
 import { type Block, BlockSchema, blockFromApi, blockToApi } from '@/types/block';
 
 const PAGES_BASE_PATH = '/pages';
@@ -23,8 +24,11 @@ export const useBlocks = (pageId: number | null, options?: Pick<SWRConfiguration
     options
   );
 
+  // サーバー返却順はソート保証がないため、サービス層で startTime 昇順に整列して返す
+  const blocks = useMemo<Block[] | undefined>(() => (data ? sortBlocks(data) : data), [data]);
+
   return {
-    blocks: data,
+    blocks,
     error,
     isLoading,
   };

--- a/frontend/src/hooks/usePages.ts
+++ b/frontend/src/hooks/usePages.ts
@@ -1,8 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import useSWR, { type SWRConfiguration, useSWRConfig } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { z } from 'zod';
+import { sortPages } from '@/atoms/tripPage';
 import { apiClient, fetcher } from '@/lib/apiClient';
 import { getErrorMessage } from '@/lib/errors';
 import { type Page, PageSchema, pageFromApi, pageToApi } from '@/types/page';
@@ -23,8 +24,11 @@ export const usePages = (tripId: number | null, options?: Pick<SWRConfiguration,
     options
   );
 
+  // サーバー返却順はソート保証がないため、サービス層で date 昇順 → id 昇順に整列して返す
+  const pages = useMemo<Page[] | undefined>(() => (data ? sortPages(data) : data), [data]);
+
   return {
-    pages: data,
+    pages,
     error,
     isLoading,
   };

--- a/frontend/src/lib/sortBlocks.test.ts
+++ b/frontend/src/lib/sortBlocks.test.ts
@@ -1,0 +1,52 @@
+import { sortBlocks } from '@/lib/sortBlocks';
+import type { Block, ScheduleBlock } from '@/types/block';
+
+/** テスト用の最小 ScheduleBlock を生成 */
+const makeBlock = (id: number, start: string, end: string | null): ScheduleBlock => ({
+  id,
+  type: 'schedule',
+  title: `block-${id}`,
+  startTime: new Date(start),
+  endTime: end != null ? new Date(end) : null,
+  detail: null,
+  pageId: 1,
+  location: null,
+});
+
+describe('sortBlocks', () => {
+  it('startTime 昇順に並び替える', () => {
+    const blocks: Block[] = [
+      makeBlock(1, '2026-01-01T12:00:00Z', '2026-01-01T13:00:00Z'),
+      makeBlock(2, '2026-01-01T09:00:00Z', '2026-01-01T10:00:00Z'),
+      makeBlock(3, '2026-01-01T10:30:00Z', '2026-01-01T11:00:00Z'),
+    ];
+
+    const sorted = sortBlocks(blocks);
+
+    expect(sorted.map(b => b.id)).toEqual([2, 3, 1]);
+  });
+
+  it('startTime が同じ場合は endTime=null を先頭にする', () => {
+    const blocks: Block[] = [
+      makeBlock(1, '2026-01-01T09:00:00Z', '2026-01-01T11:00:00Z'),
+      makeBlock(2, '2026-01-01T09:00:00Z', null),
+      makeBlock(3, '2026-01-01T09:00:00Z', '2026-01-01T10:00:00Z'),
+    ];
+
+    const sorted = sortBlocks(blocks);
+
+    expect(sorted.map(b => b.id)).toEqual([2, 3, 1]);
+  });
+
+  it('元の配列を破壊しない（非破壊ソート）', () => {
+    const blocks: Block[] = [
+      makeBlock(1, '2026-01-01T12:00:00Z', null),
+      makeBlock(2, '2026-01-01T09:00:00Z', null),
+    ];
+
+    const sorted = sortBlocks(blocks);
+
+    expect(blocks.map(b => b.id)).toEqual([1, 2]);
+    expect(sorted).not.toBe(blocks);
+  });
+});

--- a/frontend/src/lib/sortBlocks.test.ts
+++ b/frontend/src/lib/sortBlocks.test.ts
@@ -39,10 +39,7 @@ describe('sortBlocks', () => {
   });
 
   it('元の配列を破壊しない（非破壊ソート）', () => {
-    const blocks: Block[] = [
-      makeBlock(1, '2026-01-01T12:00:00Z', null),
-      makeBlock(2, '2026-01-01T09:00:00Z', null),
-    ];
+    const blocks: Block[] = [makeBlock(1, '2026-01-01T12:00:00Z', null), makeBlock(2, '2026-01-01T09:00:00Z', null)];
 
     const sorted = sortBlocks(blocks);
 

--- a/frontend/src/lib/sortBlocks.ts
+++ b/frontend/src/lib/sortBlocks.ts
@@ -1,0 +1,18 @@
+import type { Block } from '@/types/block';
+
+/**
+ * Block を startTime 昇順 → endTime 昇順（null 先頭）で並び替える。
+ *
+ * サーバー返却順はソート保証がないため、サービス層（useBlocks）と表示層で
+ * 一貫した時系列順を担保するために使用する。
+ */
+export const sortBlocks = (blocks: Block[]): Block[] =>
+  [...blocks].sort((a, b) => {
+    const startDiff = a.startTime.getTime() - b.startTime.getTime();
+    if (startDiff !== 0) return startDiff;
+    // startTime が同じ場合: endTime 昇順（null 先頭）
+    if (a.endTime === null && b.endTime === null) return 0;
+    if (a.endTime === null) return -1;
+    if (b.endTime === null) return 1;
+    return a.endTime.getTime() - b.endTime.getTime();
+  });

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -2,13 +2,14 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { isOfflineReadAtom } from '@/atoms/network';
-import { selectedPageIdAtom, sortPages, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
+import { selectedPageIdAtom, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
 import { FetchErrorView } from '@/components/FetchErrorView';
 import { Header } from '@/components/Header';
 import { HeaderSkeleton } from '@/components/HeaderSkeleton';
 import { PageSwipeContainer } from '@/components/PageSwipeContainer';
 import { Title } from '@/components/Title';
 import { TimelineSkeleton } from '@/components/timeline';
+import { useActivePage } from '@/hooks/useActivePage';
 import { useDragAutoScroll } from '@/hooks/useDragAutoScroll';
 import { usePages } from '@/hooks/usePages';
 import { useTripByUrlId } from '@/hooks/useTrips';
@@ -37,6 +38,7 @@ const TripPage = () => {
   const { trip, error: tripError, isLoading: isTripLoading } = useTripByUrlId(urlId ?? null, { refreshInterval });
   const { pages, error: pagesError, isLoading: isPagesLoading } = usePages(trip?.id ?? null, { refreshInterval });
   const { addVisitedTrip } = useVisitedTrips();
+  const { storedPageId, isActivePageInitialized, saveActivePageId } = useActivePage(trip?.id ?? null);
 
   const isLoading = isTripLoading || isPagesLoading || !minLoadingComplete;
   const isError = tripError || pagesError;
@@ -56,8 +58,9 @@ const TripPage = () => {
     if (trip) setTripAtom(trip);
   }, [trip, setTripAtom]);
 
+  // usePages がソート済みで返すため、そのまま atom に同期する
   useEffect(() => {
-    if (pages) setTripPages(sortPages(pages));
+    if (pages) setTripPages(pages);
   }, [pages, setTripPages]);
 
   // 1秒間の最小ローディング表示を管理
@@ -68,11 +71,21 @@ const TripPage = () => {
     return () => clearTimeout(timer);
   }, []);
 
+  // 初期表示ページの決定: IndexedDB の保存値が現存ページに含まれれば復帰、なければソート済み先頭
   useEffect(() => {
-    if (selectedPageId == null && pages != null && pages.length > 0) {
-      setSelectedPageId(pages[0].id);
-    }
-  }, [pages, selectedPageId, setSelectedPageId]);
+    if (selectedPageId != null) return;
+    if (pages == null || pages.length === 0) return;
+    if (!isActivePageInitialized) return;
+
+    const restoredId =
+      storedPageId != null && pages.some(page => page.id === storedPageId) ? storedPageId : pages[0].id;
+    setSelectedPageId(restoredId);
+  }, [pages, selectedPageId, storedPageId, isActivePageInitialized, setSelectedPageId]);
+
+  // 表示中ページが変わるたびに IndexedDB へ永続化（再訪時に復帰するため）
+  useEffect(() => {
+    if (selectedPageId != null) saveActivePageId(selectedPageId);
+  }, [selectedPageId, saveActivePageId]);
 
   useEffect(() => {
     if (mode === 'view') {


### PR DESCRIPTION
## 概要

Issue #147「日時導入で最初に表示されるページが不正になる」を修正します。

日付導入後、「ページ一覧は日付順」「内部的にはサーバー返却順」という不整合により、**最初に表示されるページが一覧の先頭ページと一致しない**不具合が発生していました。

## 原因

- `usePages` はサーバー返却順のまま（ソートなし）で `Page[]` を返していた
- 一覧用 `tripPagesAtom` には `sortPages(pages)` 済みを格納していた一方、初期ページ選択は**未ソートの** `pages[0].id` を使っていた
- → 一覧の先頭と初期表示ページが食い違う

## 変更内容

1. **サービス層でソート済みにして返す**
   - `usePages` が `sortPages`（date昇順 → id昇順、date null は末尾）で整列した `Page[]` を返すよう変更（`useMemo` で再計算を抑制）
   - `TripPage` の初期ページ選択をソート済み先頭基準に統一（`tripPagesAtom` への同期も二重ソートを排除）

2. **アクティブページの永続化（再訪時に復帰）**
   - `useActivePage` フックを追加。表示中ページを IndexedDB（`db.userSettings`、キー `activePageId_<tripId>`）に保存し、再訪時に復帰
   - 保存値が現存ページに含まれない場合はソート済み先頭にフォールバック
   - 既存の `useVisitedTrips` と同じ `db.userSettings` パターンを踏襲

## テスト

- `useActivePage.test.ts` を追加（読み込み/保存/tripId=null/エラー耐性、5ケース）
- `pnpm run type-check` / `lint:check` / `format:check` 全てパス
- 既存テスト全 134 + 新規 5 = 全パス

## 確認観点

- 日付ありページが日付順に並び、先頭が初期表示される
- ページを切り替えてリロード/再訪すると最後に見ていたページが復帰する

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: ブロック並び順も整合（同一原因の横展開）

ページと同じく、ブロックも「サーバー返却順はソート保証なし」で扱われていたため整合させました。

- `sortBlocks`（startTime昇順、同時刻は endTime昇順・null先頭）を `ViewTimeline` から `lib/sortBlocks.ts` に切り出して共通化
- `useBlocks` がソート済みの `Block[]` を返すよう変更（`useMemo`）
- 編集モードの初期カレンダー位置 `gotoDate(blocks[0].startTime)` がサーバー返却順の先頭に依存していた潜在バグを解消（最も早いブロックへ移動）
- View モードは従来 `ViewTimeline` 内で独自ソートしていたが、共通化により重複を排除
- `sortBlocks.test.ts` を追加（3ケース）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 最後に開いていたページをページごとに保存し、再訪時に自動で復元できるようになりました。
  * タイムライン、ブロック、ページの表示順が安定し、常に一貫した順序で表示されるようになりました。

* **Bug Fixes**
  * ページやブロックの並び順が取得順に左右される問題を改善しました。
  * ページ選択の初期表示が、保存済みの状態を優先するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->