### PR TITLE
fix(ci): Node.js を 24.18.0 にアップグレードして firebase deploy の偽陽性失敗を解消

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.18.0'
           cache: 'pnpm'
       - run: pnpm run install:all && pnpm run build:stg
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.18.0'
           cache: 'pnpm'
       - run: pnpm run install:all && pnpm run build:stg
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/firebase-hosting-release.yml
+++ b/.github/workflows/firebase-hosting-release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.18.0'
           cache: 'pnpm'
       - run: pnpm run install:all && pnpm run build:prod
       - uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION
## Summary

- `actions/setup-node` の `node-version` を `'22'` → `'24.18.0'` に変更（3つの workflow 共通）
- preview / merge / release 全ての firebase deploy job で観測される **偽陽性失敗** を根本治療

## 背景

`Deploy to Firebase Hosting on PR` job が、実際は deploy 成功しているのに必ず failure 扱いになる現象が PR #151 で発生していた。

### 失敗フロー

\`\`\`
T+0.0s   POST /releases?versionName=<新version>     (1回目)
T+0.8s   apiv2: "retrying ... after a premature close error"
T+1.8s   POST /releases?versionName=<同じ新version>  (リトライ)
T+2.5s   <<< 400 "supplied version <X> is the current active version"
\`\`\`

1回目で release は成功しチャンネル更新済み。premature close でレスポンス取りこぼした firebase-tools の apiv2 が冪等でない POST を再送 → Firebase が `FAILED_PRECONDITION 400` を返す → job 失敗。

## 根本原因

**Node.js v24.17.0 で導入された keep-alive socket 再利用タイミング変更** ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)) による node-fetch@2 の `ERR_STREAM_PREMATURE_CLOSE` バグ。firebase-tools のバージョンアップが原因ではない。

| Node.js | premature close |
|------|------|
| v24.16.0 | ❌ 発生しない |
| v24.17.0 | ✅ 発生 |
| **v24.18.0** | ❌ **修正済み** ([nodejs/node#64004](https://github.com/nodejs/node/pull/64004)) |
| v22.23.0 | ✅ 発生 |
| v22.23.1+ | ❌ 修正済み（同じ upstream fix） |

`actions/setup-node@v4` で `node-version: '22'` を指定していたが、22.x の最新が引かれていたため premature close 発生バージョンを踏んでいた。

## なぜ firebase-tools のバージョン pin では直らないか

firebase-tools 最新 v15.22.3 の [PR #10697](https://github.com/firebase/firebase-tools/pull/10697)（"Retry without keep-alive after a premature close error"）は、本文で明示的に:

> The normal path keeps using keep-alive, so **flows like deploy are unaffected**

deploy フローには適用されないため、firebase-tools 側で patch を待っても解消されない。Node.js 側で premature close を起こさないことが根本治療。

## 関連 issue / 参照

- Node.js [#63989](https://github.com/nodejs/node/issues/63989) - 元 issue
- Node.js [#64004](https://github.com/nodejs/node/pull/64004) - 修正 PR (v24.18.0 / v22.23.1 取り込み)
- firebase-tools [#10692](https://github.com/firebase/firebase-tools/issues/10692) - 影響観測

## Test plan

- [ ] PR の preview deploy job が緑になる
- [ ] preview URL が PR コメントに投稿される（action-hosting-deploy のデフォルト挙動が維持される）
- [ ] 複数回 rerun しても安定して緑になる（過去なら premature close を踏んでいたタイミング）
- [ ] preview URL を `curl -I` で叩いて 200 + 最新の last-modified を確認
- [ ] develop マージ後、`firebase-hosting-merge.yml` の staging deploy が成功
- [ ] main へのリリース時、`firebase-hosting-release.yml` の production deploy が成功

## Fallback

万一 Node 24 で別の問題が発生した場合は、`node-version: '22.22.0'` への pin で対応する（22.23.0 を踏まないバージョン）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)