### PR TITLE
feat: フォントを Noto Sans JP に固定 (#156)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
+    "@fontsource/noto-sans-jp": "^5.2.9",
     "@fullcalendar/core": "^6.1.20",
     "@fullcalendar/daygrid": "^6.1.20",
     "@fullcalendar/interaction": "^6.1.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
-    "@fontsource/noto-sans-jp": "^5.2.9",
+    "@fontsource-variable/noto-sans-jp": "^5.2.10",
     "@fullcalendar/core": "^6.1.20",
     "@fullcalendar/daygrid": "^6.1.20",
     "@fullcalendar/interaction": "^6.1.20",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.4)
-      '@fontsource/noto-sans-jp':
-        specifier: ^5.2.9
-        version: 5.2.9
+      '@fontsource-variable/noto-sans-jp':
+        specifier: ^5.2.10
+        version: 5.2.10
       '@fullcalendar/core':
         specifier: ^6.1.20
         version: 6.1.20
@@ -1054,8 +1054,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fontsource/noto-sans-jp@5.2.9':
-    resolution: {integrity: sha512-6yVGiofnrnbiJjU8ch4JGSs2HqyozxMvsVyVmFwOnDH3u//qQKLqmKM4n0lqN0637uaJNzUW9nIJqbbMgHVQzw==}
+  '@fontsource-variable/noto-sans-jp@5.2.10':
+    resolution: {integrity: sha512-m0XfZ38rZtCaGAuAQL0cBPQ6fc/RguYEOqw66zvuLOV9vNRUBf9MFqyoazTu2JVCRIcnkrxbwF29UUaHHgTKdg==}
 
   '@fullcalendar/core@6.1.20':
     resolution: {integrity: sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==}
@@ -5941,7 +5941,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fontsource/noto-sans-jp@5.2.9': {}
+  '@fontsource-variable/noto-sans-jp@5.2.10': {}
 
   '@fullcalendar/core@6.1.20':
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      '@fontsource/noto-sans-jp':
+        specifier: ^5.2.9
+        version: 5.2.9
       '@fullcalendar/core':
         specifier: ^6.1.20
         version: 6.1.20
@@ -1050,6 +1053,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/noto-sans-jp@5.2.9':
+    resolution: {integrity: sha512-6yVGiofnrnbiJjU8ch4JGSs2HqyozxMvsVyVmFwOnDH3u//qQKLqmKM4n0lqN0637uaJNzUW9nIJqbbMgHVQzw==}
 
   '@fullcalendar/core@6.1.20':
     resolution: {integrity: sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==}
@@ -5934,6 +5940,8 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/noto-sans-jp@5.2.9': {}
 
   '@fullcalendar/core@6.1.20':
     dependencies:

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,6 @@
+@import "@fontsource/noto-sans-jp/400.css";
+@import "@fontsource/noto-sans-jp/500.css";
+@import "@fontsource/noto-sans-jp/700.css";
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -48,7 +51,7 @@
   --sidebar-accent-foreground: oklch(0.2046 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.709 0 0);
-  --font-sans: Geist, sans-serif;
+  --font-sans: "Noto Sans JP", sans-serif;
   --font-serif: Georgia, serif;
   --font-mono: Geist Mono, monospace;
   --shadow-2xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);
@@ -96,7 +99,7 @@
   --sidebar-accent-foreground: oklch(0.9851 0 0);
   --sidebar-border: oklch(1 0 0);
   --sidebar-ring: oklch(0.5555 0 0);
-  --font-sans: Geist, sans-serif;
+  --font-sans: "Noto Sans JP", sans-serif;
   --font-serif: Georgia, serif;
   --font-mono: Geist Mono, monospace;
   --shadow-2xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,4 @@
-@import "@fontsource/noto-sans-jp/400.css";
-@import "@fontsource/noto-sans-jp/500.css";
-@import "@fontsource/noto-sans-jp/700.css";
+@import "@fontsource-variable/noto-sans-jp";
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -51,7 +49,7 @@
   --sidebar-accent-foreground: oklch(0.2046 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.709 0 0);
-  --font-sans: "Noto Sans JP", sans-serif;
+  --font-sans: "Noto Sans JP Variable", sans-serif;
   --font-serif: Georgia, serif;
   --font-mono: Geist Mono, monospace;
   --shadow-2xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);
@@ -99,7 +97,7 @@
   --sidebar-accent-foreground: oklch(0.9851 0 0);
   --sidebar-border: oklch(1 0 0);
   --sidebar-ring: oklch(0.5555 0 0);
-  --font-sans: "Noto Sans JP", sans-serif;
+  --font-sans: "Noto Sans JP Variable", sans-serif;
   --font-serif: Georgia, serif;
   --font-mono: Geist Mono, monospace;
   --shadow-2xs: 0px 1px 2px 0px hsl(0 0% 0% / 0.09);


### PR DESCRIPTION
## Summary
- ユーザーのPC環境に依存しないよう、フォントを Noto Sans JP に固定
- `@fontsource/noto-sans-jp` を導入し、weight 400 / 500 / 700 を読み込み
- `index.css` の `--font-sans` を `"Noto Sans JP", sans-serif` に変更（light/dark 両方）
- Storybook (`.storybook/preview.ts`) も同じ `index.css` を読み込んでいるため、`@import` を CSS 側に書く形で本体・Storybook 共通化

## 実装方針メモ
- `400.css` / `500.css` / `700.css` は unicode-range で subset 分割されており、ブラウザは画面に出現する文字に該当する woff2 のみを遅延ダウンロードする
- CSS バンドルサイズは増加するが、実際のフォント転送は必要分のみ

## 確認結果
- `pnpm run type-check`: ✅
- `pnpm run lint:check`: ✅
- `pnpm run build`: ✅
- ブラウザ実機:
  - `getComputedStyle(document.body).fontFamily` → `"Noto Sans JP", sans-serif`
  - `document.fonts.check('16px "Noto Sans JP"')` → `true`
  - Network タブで `noto-sans-jp-*.woff2` がダウンロードされていることを確認

Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 日本語向けのサンセリフフォントとして **Noto Sans JP（Variable）** の利用を追加しました。
  * ライト/ダーク両テーマで参照するサンセリフフォントを切り替え、文字の見た目が更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->