### PR TITLE
perf: DB 往復回数を削減して API レイテンシーを改善 (#124)

### DIFF
--- a/server/app/auth.py
+++ b/server/app/auth.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
-from app.db_connection import get_db_session
+from app.db_connection import get_read_db_session
 from app.errors import Forbidden, NotFound
 from app.models import Block, Page
 
@@ -112,7 +112,7 @@ def require_trip_access(trip_id: int, request: Request) -> int:
 async def require_page_access(
     page_id: int,
     request: Request,
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> int:
     """page_id から trip_id を解決し、アクセス権を検証する。"""
     result = await db.execute(select(Page.trip_id).where(Page.id == page_id))
@@ -129,7 +129,7 @@ async def require_page_access(
 async def require_block_access(
     block_id: int,
     request: Request,
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> int:
     """block_id から trip_id を解決し、アクセス権を検証する。"""
     result = await db.execute(

--- a/server/app/auth.py
+++ b/server/app/auth.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
-from app.db_connection import get_read_db_session
+from app.db_connection import get_db_session, get_read_db_session
 from app.errors import Forbidden, NotFound
 from app.models import Block, Page
 
@@ -109,39 +109,56 @@ def require_trip_access(trip_id: int, request: Request) -> int:
     return trip_id
 
 
-async def require_page_access(
-    page_id: int,
-    request: Request,
-    db: AsyncSession = Depends(get_read_db_session),
-) -> int:
-    """page_id から trip_id を解決し、アクセス権を検証する。"""
-    result = await db.execute(select(Page.trip_id).where(Page.id == page_id))
-    trip_id = result.scalar_one_or_none()
-    if trip_id is None:
-        raise NotFound(message="Page not found")
-
-    allowed = get_allowed_trip_ids(request)
-    if trip_id not in allowed:
-        raise Forbidden()
-    return trip_id
+# 認可 Depends はエンドポイント本体と同じセッション依存を使うことで、FastAPI の
+# 依存関係キャッシュにより 1 リクエスト 1 コネクションに収める。
+# 読み系エンドポイントには get_read_db_session 版、書き込み系には get_db_session 版を使う。
 
 
-async def require_block_access(
-    block_id: int,
-    request: Request,
-    db: AsyncSession = Depends(get_read_db_session),
-) -> int:
-    """block_id から trip_id を解決し、アクセス権を検証する。"""
-    result = await db.execute(
-        select(Page.trip_id)
-        .join(Block, Block.page_id == Page.id)
-        .where(Block.id == block_id)
-    )
-    trip_id = result.scalar_one_or_none()
-    if trip_id is None:
-        raise NotFound(message="Block not found")
+def _page_access_dependency(db_dependency):
+    async def _require_page_access(
+        page_id: int,
+        request: Request,
+        db: AsyncSession = Depends(db_dependency),
+    ) -> int:
+        """page_id から trip_id を解決し、アクセス権を検証する。"""
+        result = await db.execute(select(Page.trip_id).where(Page.id == page_id))
+        trip_id = result.scalar_one_or_none()
+        if trip_id is None:
+            raise NotFound(message="Page not found")
 
-    allowed = get_allowed_trip_ids(request)
-    if trip_id not in allowed:
-        raise Forbidden()
-    return trip_id
+        allowed = get_allowed_trip_ids(request)
+        if trip_id not in allowed:
+            raise Forbidden()
+        return trip_id
+
+    return _require_page_access
+
+
+def _block_access_dependency(db_dependency):
+    async def _require_block_access(
+        block_id: int,
+        request: Request,
+        db: AsyncSession = Depends(db_dependency),
+    ) -> int:
+        """block_id から trip_id を解決し、アクセス権を検証する。"""
+        result = await db.execute(
+            select(Page.trip_id)
+            .join(Block, Block.page_id == Page.id)
+            .where(Block.id == block_id)
+        )
+        trip_id = result.scalar_one_or_none()
+        if trip_id is None:
+            raise NotFound(message="Block not found")
+
+        allowed = get_allowed_trip_ids(request)
+        if trip_id not in allowed:
+            raise Forbidden()
+        return trip_id
+
+    return _require_block_access
+
+
+require_page_access = _page_access_dependency(get_read_db_session)
+require_page_access_write = _page_access_dependency(get_db_session)
+require_block_access = _block_access_dependency(get_read_db_session)
+require_block_access_write = _block_access_dependency(get_db_session)

--- a/server/app/cruds/blocks.py
+++ b/server/app/cruds/blocks.py
@@ -1,6 +1,6 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload
 
 from app.cruds import locations as locations_cruds
 from app.models import Block
@@ -9,9 +9,10 @@ from app.schemas.location import LocationCreate, LocationUpdate
 
 
 def _block_with_relations():
+    # joinedload で 1 クエリにまとめ、DB との往復回数を減らす（cruds/trips.py と同方針）
     return select(Block).options(
-        selectinload(Block.location),
-        selectinload(Block.destination_location),
+        joinedload(Block.location),
+        joinedload(Block.destination_location),
     )
 
 
@@ -59,15 +60,9 @@ async def create_block(db: AsyncSession, block: BlockCreate, page_id: int) -> Bl
 
     # レスポンス生成時の lazy='raise' エラーを回避するため、
     # location等のリレーションを事前取得(Eager Load)して返し直す
-    stmt = (
-        select(Block)
-        .options(
-            selectinload(Block.location),
-            selectinload(Block.destination_location)
-        )
-        .where(Block.id == db_block.id)
+    result = await db.execute(
+        _block_with_relations().where(Block.id == db_block.id)
     )
-    result = await db.execute(stmt)
 
     return result.scalar_one()
 

--- a/server/app/cruds/pages.py
+++ b/server/app/cruds/pages.py
@@ -45,8 +45,9 @@ async def find_pages(db: AsyncSession, trip_id: int) -> list[Page]:
     Returns:
         list[Page]: ページリスト
     """
+    # joinedload では返却順が JOIN 結果に依存し不定になるため、明示的に並び順を保証する
     result = await db.execute(
-        _page_with_relations().where(Page.trip_id == trip_id)
+        _page_with_relations().where(Page.trip_id == trip_id).order_by(Page.id)
     )
     return list(result.unique().scalars().all())
 

--- a/server/app/cruds/pages.py
+++ b/server/app/cruds/pages.py
@@ -1,16 +1,17 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload
 
 from app.models import Block, Page
 from app.schemas.page import PageCreate, PageUpdate
 
 
 def _page_with_relations():
+    # joinedload で 1 クエリにまとめ、DB との往復回数を減らす（cruds/trips.py と同方針）
     return select(Page).options(
-        selectinload(Page.blocks).options(
-            selectinload(Block.location),
-            selectinload(Block.destination_location),
+        joinedload(Page.blocks).options(
+            joinedload(Block.location),
+            joinedload(Block.destination_location),
         )
     )
 
@@ -47,7 +48,7 @@ async def find_pages(db: AsyncSession, trip_id: int) -> list[Page]:
     result = await db.execute(
         _page_with_relations().where(Page.trip_id == trip_id)
     )
-    return list(result.scalars().all())
+    return list(result.unique().scalars().all())
 
 
 async def get_page(db: AsyncSession, page_id: int) -> Page | None:
@@ -62,7 +63,7 @@ async def get_page(db: AsyncSession, page_id: int) -> Page | None:
         Page | None: 特定のページ、見つからない場合はNone
     """
     result = await db.execute(_page_with_relations().where(Page.id == page_id))
-    return result.scalar_one_or_none()
+    return result.unique().scalar_one_or_none()
 
 
 async def update_page(db: AsyncSession, page_id: int, page: PageUpdate) -> Page | None:

--- a/server/app/cruds/trips.py
+++ b/server/app/cruds/trips.py
@@ -45,7 +45,8 @@ async def find_trips(db: AsyncSession) -> list[Trip]:
     Returns:
         list[Trip]: すべての旅行プラン
     """
-    result = await db.execute(_trip_with_relations())
+    # joinedload では返却順が JOIN 結果に依存し不定になるため、明示的に並び順を保証する
+    result = await db.execute(_trip_with_relations().order_by(Trip.id))
     return list(result.unique().scalars().all())
 
 

--- a/server/app/cruds/trips.py
+++ b/server/app/cruds/trips.py
@@ -1,16 +1,18 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload
 
 from app.models import Block, Page, Trip
 from app.schemas.trip import TripCreateIn, TripUpdate
 
 
 def _trip_with_relations():
+    # joinedload で 1 クエリにまとめる: selectinload だとリレーション階層ごとに
+    # SELECT が逐次発行され、DB との RTT × クエリ数がそのままレイテンシーになる
     return select(Trip).options(
-        selectinload(Trip.pages).selectinload(Page.blocks).options(
-            selectinload(Block.location),
-            selectinload(Block.destination_location),
+        joinedload(Trip.pages).joinedload(Page.blocks).options(
+            joinedload(Block.location),
+            joinedload(Block.destination_location),
         )
     )
 
@@ -44,7 +46,7 @@ async def find_trips(db: AsyncSession) -> list[Trip]:
         list[Trip]: すべての旅行プラン
     """
     result = await db.execute(_trip_with_relations())
-    return list(result.scalars().all())
+    return list(result.unique().scalars().all())
 
 
 async def get_trip(db: AsyncSession, trip_id: int) -> Trip | None:
@@ -59,7 +61,7 @@ async def get_trip(db: AsyncSession, trip_id: int) -> Trip | None:
         Trip | None: 特定の旅行プラン、見つからない場合はNone
     """
     result = await db.execute(_trip_with_relations().where(Trip.id == trip_id))
-    return result.scalar_one_or_none()
+    return result.unique().scalar_one_or_none()
 
 
 async def get_trip_by_url_id(db: AsyncSession, url_id: str) -> Trip | None:
@@ -74,7 +76,7 @@ async def get_trip_by_url_id(db: AsyncSession, url_id: str) -> Trip | None:
         Trip | None: 特定の旅行プラン、見つからない場合はNone
     """
     result = await db.execute(_trip_with_relations().where(Trip.url_id == url_id))
-    return result.scalar_one_or_none()
+    return result.unique().scalar_one_or_none()
 
 
 async def update_trip(db: AsyncSession, trip_id: int, trip: TripUpdate) -> Trip | None:

--- a/server/app/db_connection.py
+++ b/server/app/db_connection.py
@@ -19,14 +19,22 @@ from app.config import get_settings
 settings = get_settings()
 
 # 非同期エンジンの作成
+# pool_pre_ping は使わない: DB (Neon us-east-1) との RTT が大きく、checkout ごとの
+# SELECT 1 が 1 往復分のレイテンシーになるため。stale 接続は pool_recycle で防ぐ
+# （接続先は Neon の pgbouncer pooler なので、コンピュートが suspend しても
+# クライアント側接続は原則有効なまま）
 engine: AsyncEngine = create_async_engine(
     settings.get_database_url(),
     echo=False,  # 本番環境では False
-    pool_pre_ping=True,  # 接続の健全性チェック
+    pool_recycle=300,  # 古い接続を作り直して stale 接続を回避
     pool_size=5,  # 接続プールサイズ
     max_overflow=10,  # 最大オーバーフロー接続数
     connect_args={"ssl": True} if settings.ssl_required else {},
 )
+
+# 読み取り専用エンジン: AUTOCOMMIT でトランザクションを張らず、
+# BEGIN / ROLLBACK の 2 往復分のレイテンシーを削減する（プールは engine と共有）
+read_engine: AsyncEngine = engine.execution_options(isolation_level="AUTOCOMMIT")
 
 # 非同期セッションファクトリ
 AsyncSessionLocal = async_sessionmaker(
@@ -34,6 +42,15 @@ AsyncSessionLocal = async_sessionmaker(
     class_=AsyncSession,
     expire_on_commit=False,  # コミット後もオブジェクトを使用可能
     autoflush=True,
+    autocommit=False,
+)
+
+# 読み取り専用セッションファクトリ（SELECT のみのエンドポイント用）
+ReadAsyncSessionLocal = async_sessionmaker(
+    read_engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autoflush=False,  # 読み取り専用のため flush 不要
     autocommit=False,
 )
 
@@ -49,6 +66,22 @@ async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
         AsyncSession: 非同期データベースセッション
     """
     async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.close()
+
+
+async def get_read_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """
+    読み取り専用（AUTOCOMMIT）セッションを生成する依存性注入用関数
+
+    SELECT のみのエンドポイントで使用し、BEGIN / ROLLBACK の往復を省略する。
+
+    Yields:
+        AsyncSession: 読み取り専用の非同期データベースセッション
+    """
+    async with ReadAsyncSessionLocal() as session:
         try:
             yield session
         finally:

--- a/server/app/routers/blocks.py
+++ b/server/app/routers/blocks.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_block_access, require_page_access
 from app.cruds import blocks as blocks_cruds
-from app.db_connection import get_db_session
+from app.db_connection import get_db_session, get_read_db_session
 from app.errors import NotFound
 from app.schemas.block import Block, BlockCreate, BlockUpdate
 
@@ -40,7 +40,7 @@ async def create_block(
 async def get_blocks(
     page_id: int,
     _: int = Depends(require_page_access),
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> list[Block]:
     """
     説明:
@@ -59,7 +59,7 @@ async def get_blocks(
 async def get_block(
     block_id: int,
     _: int = Depends(require_block_access),
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> Block:
     """
     説明:

--- a/server/app/routers/blocks.py
+++ b/server/app/routers/blocks.py
@@ -1,7 +1,12 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_block_access, require_page_access
+from app.auth import (
+    require_block_access,
+    require_block_access_write,
+    require_page_access,
+    require_page_access_write,
+)
 from app.cruds import blocks as blocks_cruds
 from app.db_connection import get_db_session, get_read_db_session
 from app.errors import NotFound
@@ -19,7 +24,7 @@ router = APIRouter(tags=["Blocks"])
 async def create_block(
     page_id: int,
     block: BlockCreate,
-    _: int = Depends(require_page_access),
+    _: int = Depends(require_page_access_write),
     db: AsyncSession = Depends(get_db_session),
 ) -> Block:
     """
@@ -82,7 +87,7 @@ async def get_block(
 async def update_block(
     block_id: int,
     block: BlockUpdate,
-    _: int = Depends(require_block_access),
+    _: int = Depends(require_block_access_write),
     db: AsyncSession = Depends(get_db_session),
 ) -> Block:
     """
@@ -107,7 +112,7 @@ async def update_block(
 )
 async def delete_block(
     block_id: int,
-    _: int = Depends(require_block_access),
+    _: int = Depends(require_block_access_write),
     db: AsyncSession = Depends(get_db_session),
 ) -> None:
     """

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_trip_access, require_page_access
+from app.auth import (
+    require_page_access,
+    require_page_access_write,
+    require_trip_access,
+)
 from app.cruds import pages as pages_cruds
 from app.db_connection import get_db_session, get_read_db_session
 from app.errors import NotFound
@@ -83,7 +87,7 @@ async def get_page(
 async def update_page(
     page_id: int,
     page: PageUpdate,
-    _: int = Depends(require_page_access),
+    _: int = Depends(require_page_access_write),
     db: AsyncSession = Depends(get_db_session),
 ) -> Page:
     """
@@ -106,7 +110,7 @@ async def update_page(
 )
 async def delete_page(
     page_id: int,
-    _: int = Depends(require_page_access),
+    _: int = Depends(require_page_access_write),
     db: AsyncSession = Depends(get_db_session),
 ):
     """

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_trip_access, require_page_access
 from app.cruds import pages as pages_cruds
-from app.db_connection import get_db_session
+from app.db_connection import get_db_session, get_read_db_session
 from app.errors import NotFound
 from app.schemas.page import Page, PageCreate, PageCreateResponse, PageUpdate
 
@@ -41,7 +41,7 @@ async def create_page(
 async def get_pages(
     trip_id: int,
     _: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> list[Page]:
     """
     説明:
@@ -60,7 +60,7 @@ async def get_pages(
 async def get_page(
     page_id: int,
     _: int = Depends(require_page_access),
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> Page:
     """
     説明:

--- a/server/app/routers/trips.py
+++ b/server/app/routers/trips.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import grant_trip_access, require_basic_auth, require_trip_access
 from app.cruds import trips as trips_cruds
-from app.db_connection import get_db_session
+from app.db_connection import get_db_session, get_read_db_session
 from app.errors import NotFound
 from app.schemas.trip import Trip, TripCreateIn, TripCreateOut, TripUpdate
 
@@ -47,7 +47,7 @@ async def create_trip(
 )
 async def list_trips(
     _: None = Depends(require_basic_auth),
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> list[Trip]:
     """
     説明:
@@ -66,7 +66,7 @@ async def list_trips(
 async def get_trip(
     trip_id: int,
     _: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> Trip:
     """
     説明:
@@ -90,7 +90,7 @@ async def get_trip_by_url_id(
     url_id: str,
     request: Request,
     response: Response,
-    db: AsyncSession = Depends(get_db_session),
+    db: AsyncSession = Depends(get_read_db_session),
 ) -> Trip:
     """
     説明:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -18,7 +18,7 @@ from app.config import get_settings
 from app.cruds import blocks as blocks_cruds
 from app.cruds import pages as pages_cruds
 from app.cruds import trips as trips_cruds
-from app.db_connection import Base, get_db_session
+from app.db_connection import Base, get_db_session, get_read_db_session
 from app.main import app
 from app.observability import setup_sqlalchemy_instrumentation
 from app.schemas.block import Block as BlockSchema
@@ -48,6 +48,15 @@ TestingAsyncSessionLocal = async_sessionmaker(
     autocommit=False,
 )
 
+# 本番と同様に読み取り専用（AUTOCOMMIT）セッションもテスト用に用意する
+TestingReadAsyncSessionLocal = async_sessionmaker(
+    test_engine.execution_options(isolation_level="AUTOCOMMIT"),
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autoflush=False,
+    autocommit=False,
+)
+
 
 async def override_get_db_session():
     """テスト用の非同期DBセッションを生成する関数"""
@@ -55,7 +64,14 @@ async def override_get_db_session():
         yield session
 
 
+async def override_get_read_db_session():
+    """テスト用の読み取り専用非同期DBセッションを生成する関数"""
+    async with TestingReadAsyncSessionLocal() as session:
+        yield session
+
+
 app.dependency_overrides[get_db_session] = override_get_db_session
+app.dependency_overrides[get_read_db_session] = override_get_read_db_session
 
 
 @pytest_asyncio.fixture(scope="function", autouse=True)


### PR DESCRIPTION
## 概要

#124 の対応。API レイテンシーの支配項が「DB (Neon us-east-1) との RTT (~150ms) × 1 リクエストあたりの逐次往復回数」であることを計装ログから特定し、往復回数を削減する。

関連 Issue: #124（マージ後の再計測が残るため自動クローズしない）

## 詳細

### 分析結果（staging 計装ログより）

- DB クエリ 1 本あたり 146〜234ms でほぼ一定 → クエリの重さではなくネットワーク RTT が支配
- `GET /trips/url/{url_id}`: クエリ 3〜5 本（selectinload のネスト分）で db_total 300〜460ms
- `total_ms − db_total_ms ≈ 300ms` が全リクエストで一定 → cursor イベントに現れない **BEGIN / ROLLBACK / pre_ping** の隠れ往復
- 非同期処理（asyncpg + AsyncSession）自体は正しく動作している（403 応答は 1ms、イベントループのブロッキングなし）

### 変更内容

1. **読み系クエリの 1 クエリ化**: `selectinload` のネスト（リレーション階層ごとに SELECT が逐次発行）→ `joinedload` チェーン（JOIN で 1 クエリ）。コレクションの joinedload に伴い `result.unique()` を追加し、一覧系は返却順が不定になるため ORDER BY を明示
2. **読み取り専用 AUTOCOMMIT セッションの導入**: GET エンドポイントと認可 Depends を `get_read_db_session` に切り替え、BEGIN / ROLLBACK の 2 往復を省略。プールは書き込み用エンジンと共有され、返却時に isolation はデフォルトへリセットされる（SQLAlchemy の connection characteristic 機構）
3. **`pool_pre_ping` 廃止 → `pool_recycle=300`**: asyncpg dialect の pre_ping は pgbouncer 対応（sqlalchemy#10226）のため BEGIN + SELECT + ROLLBACK に包まれており、checkout ごとに最大 3 往復を消費していた。接続先は Neon の pooler (pgbouncer) なのでコンピュート suspend 後もクライアント接続は原則有効であり、stale 接続は pool_recycle で緩和する
4. **認可 Depends の読み取り/書き込み分離**（レビュー指摘対応）: エンドポイント本体と同じセッション依存を使い、FastAPI の依存関係キャッシュで 1 リクエスト 1 コネクションに統一

### 期待効果

| パス | Before | After（見込み） |
|---|---|---|
| GET /trips/url/{url_id} | 600〜770ms（5〜8 往復） | 〜250ms（1〜2 往復） |
| GET /pages/{id}/blocks | 690〜740ms | 〜400ms（1 クエリ + 認可 1 往復） |

### 残課題（別 Issue / PR 候補）

- 書き込み系（特に PUT /blocks/{id} の location 置換）は flush / commit で依然 5〜6 往復
- 認可 Depends の trip_id 解決クエリを本体クエリに JOIN 統合すればさらに 1 往復削減可
- 根本対策としては DB の東京近傍への移設（RTT 150ms → 数 ms）が最大のレバー

## 動作確認

- バックエンドのみの変更（フロントエンドの変更なし）のため画像なし
- CI テストスイート 102 件パス（読み系・書き込み系・認可の回帰を網羅）
- ruff / mypy で新規エラーなし
- マージ後、staging の計装ログ（`jsonPayload.type="request"`）で before/after の p50/p95 と 500 発生率を再計測する

## 確認項目
- [x] 動作確認を実施している
- [ ] issueはPRページ右下のDevelopmentからissueが紐づいている

🤖 Generated with [Claude Code](https://claude.com/claude-code)