### PR TITLE
fix: HomePage 初期表示で空状態がちらつく問題を修正 (#159)

### DIFF
--- a/frontend/src/hooks/useVisitedTrips.test.ts
+++ b/frontend/src/hooks/useVisitedTrips.test.ts
@@ -160,4 +160,18 @@ describe('useVisitedTrips', () => {
       expect(result.current).toBeDefined();
     });
   });
+
+  it('IndexedDB 読み込み中は isLoading が true で、完了後に false になる', async () => {
+    mockDbGet.mockResolvedValue({ key: 'visitedTripUrlIds', value: [] });
+
+    const { result } = renderHook(() => useVisitedTrips());
+
+    // マウント直後（IndexedDB 読み込み中）は isLoading が true
+    expect(result.current.isLoading).toBe(true);
+
+    // 初期化完了後は false（urlIds が空なので SWR も走らない）
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
 });

--- a/frontend/src/hooks/useVisitedTrips.ts
+++ b/frontend/src/hooks/useVisitedTrips.ts
@@ -93,27 +93,31 @@ export const useVisitedTrips = () => {
   }, []);
 
   // SWRで各urlIdからTripを取得
-  const { data, error, isLoading } = useSWR<Trip[]>(
-    isInitialized && urlIds.length > 0 ? [VISITED_TRIPS_CACHE_KEY, ...urlIds] : null,
-    async () => {
-      const results = await Promise.all(
-        urlIds.map(async urlId => {
-          try {
-            const res = await fetcher(`/trips/url/${urlId}`);
-            return tripFromApi.parse(res);
-          } catch (err) {
-            // 404 "Trip not found" の場合は訪問済みリストから除去
-            if (isAxiosError(err) && err.response?.status === 404 && err.response.data?.detail === 'Trip not found') {
-              const current = await getUrlIdsFromDB();
-              await saveUrlIdsToDB(current.filter(id => id !== urlId));
-            }
-            return null;
+  const {
+    data,
+    error,
+    isLoading: swrIsLoading,
+  } = useSWR<Trip[]>(isInitialized && urlIds.length > 0 ? [VISITED_TRIPS_CACHE_KEY, ...urlIds] : null, async () => {
+    const results = await Promise.all(
+      urlIds.map(async urlId => {
+        try {
+          const res = await fetcher(`/trips/url/${urlId}`);
+          return tripFromApi.parse(res);
+        } catch (err) {
+          // 404 "Trip not found" の場合は訪問済みリストから除去
+          if (isAxiosError(err) && err.response?.status === 404 && err.response.data?.detail === 'Trip not found') {
+            const current = await getUrlIdsFromDB();
+            await saveUrlIdsToDB(current.filter(id => id !== urlId));
           }
-        })
-      );
-      return results.filter((trip): trip is Trip => trip !== null);
-    }
-  );
+          return null;
+        }
+      })
+    );
+    return results.filter((trip): trip is Trip => trip !== null);
+  });
+
+  // IndexedDB 読み込み中も consumer 側で「ロード中」と扱えるようにする
+  const isLoading = !isInitialized || swrIsLoading;
 
   return {
     trips: data,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useAtomValue } from 'jotai';
+import { LoaderCircle } from 'lucide-react';
 import type React from 'react';
 import { useId, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
@@ -32,6 +33,12 @@ const HomePage = () => {
               + 新しく旅に出る
             </Button>
           </div>
+
+          {isLoading && (
+            <div className='mt-8 flex justify-center'>
+              <LoaderCircle className='size-8 animate-spin text-gray-400' aria-label='読み込み中' />
+            </div>
+          )}
 
           {!(isLoading || hasTrips) && (
             <div className='relative flex flex-col items-center px-24 sm:px-0'>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -34,12 +34,6 @@ const HomePage = () => {
             </Button>
           </div>
 
-          {isLoading && (
-            <div className='mt-8 flex justify-center'>
-              <LoaderCircle className='size-8 animate-spin text-gray-400' aria-label='読み込み中' />
-            </div>
-          )}
-
           {!(isLoading || hasTrips) && (
             <div className='relative flex flex-col items-center px-24 sm:px-0'>
               <p className='relative mt-8 w-full text-center text-gray-500'>
@@ -54,6 +48,12 @@ const HomePage = () => {
 
           {/* PWAインストールバナー */}
           <PwaInstallBanner className='mt-4 mb-2' />
+
+          {isLoading && (
+            <div className='mt-8 flex justify-center'>
+              <LoaderCircle className='size-8 animate-spin text-gray-400' aria-label='読み込み中' />
+            </div>
+          )}
 
           {/* Trip一覧 */}
           {!isLoading && hasTrips && (


### PR DESCRIPTION
## Summary

Closes #159

`HomePage` を開いた直後に「旅程がまだありません。共有してもらうか新しく作りましょう！」の空表示が一瞬描画され、その後 Trip 一覧に差し替わるちらつきを修正しました。

## 根本原因

`useVisitedTrips` はマウント直後、`isInitialized=false` の状態で SWR の key が `null` となるため `isLoading=false` を返していました。この結果、IndexedDB からの読み込み完了前でも `HomePage` 側の空表示条件 `!(isLoading || hasTrips)` が真となり、空状態が瞬間的に描画されていました。

## 変更点

- **`useVisitedTrips.ts`**: 返却する `isLoading` に IndexedDB 初期化フェーズを含める（`!isInitialized || swrIsLoading`）。
- **`HomePage.tsx`**: `isLoading` 中は `LoaderCircle` によるローディングサークルを表示。既存の空表示条件は維持。
- **`useVisitedTrips.test.ts`**: 初期化中に `isLoading=true`、完了後に `false` になることを検証するテストを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)