### PR TITLE
feat: React Compiler を有効化し手動メモ化を全削除 (#141)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -15,8 +15,11 @@ paths:
 
 ## パフォーマンス
 
-- useMemo/useCallbackで不要な再レンダリングを防止
-- useEffectには必ずクリーンアップ関数を実装
+- **React Compiler が有効化されているため、`useMemo` / `useCallback` は原則書かない**
+  - 参照安定性が仕様上必須な escape hatch（外部ライブラリが厳格な同一性を要求する等）でのみ許可
+  - `React.memo` / `memo()` も同様に不要
+  - コンパイラの動作確認: React DevTools 上でコンポーネントに「Memo ✨」バッジが付く
+- useEffect には必ずクリーンアップ関数を実装
 
 ## 型
 

--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -10,7 +10,7 @@
 - **Template Literals** > 文字列結合
 
 ### 2. パフォーマンス優先
-- **不要な再レンダリング防止**: React.memo、useMemo、useCallback
+- **不要な再レンダリング防止**: React Compiler がコンパイル時に自動でメモ化する。手動の `React.memo` / `useMemo` / `useCallback` は原則書かない（参照同一性を厳格に要求する外部ライブラリ連携などの escape hatch でのみ許可）
 - **効率的なデータ構造**: 適切なコレクション選択
 - **メモリリーク防止**: useEffectのクリーンアップ
 - **最適化**: インデックス、キャッシュ、遅延読み込み

--- a/frontend/CLAUD.md
+++ b/frontend/CLAUD.md
@@ -45,10 +45,11 @@ interface Props {
 export const UserProfile: React.FC<Props> = ({ userId, onUpdate }) => {
   const user = useUser(userId);
 
-  const handleUpdate = useCallback((updatedUser: User) => {
+  // React Compiler が自動でメモ化するため useCallback は不要
+  const handleUpdate = (updatedUser: User) => {
     // キャッシュ更新やサーバー同期はライブラリが管理
     onUpdate?.(updatedUser);
-  }, [onUpdate]);
+  };
 
   return <div>{/* JSX */}</div>;
 };
@@ -99,12 +100,17 @@ export const UserProfile: React.FC<Props> = ({ userId, onUpdate }) => {
 
 ## パフォーマンス最適化
 
+React Compiler が有効化されているため、`React.memo` / `useMemo` / `useCallback` は原則書かない。
+コンパイラが自動でメモ化するため、素直に関数コンポーネントとして書けばよい。
+
 ```typescript
-const TripBlock = React.memo<Props>(({ block, onUpdate }) => {
-  const handleUpdate = useCallback((newData: BlockData) => {
+const TripBlock = ({ block, onUpdate }: Props) => {
+  const handleUpdate = (newData: BlockData) => {
     onUpdate(block.id, newData);
-  }, [block.id, onUpdate]);
+  };
 
   return <div>{/* コンポーネント内容 */}</div>;
-});
+};
 ```
+
+参照同一性が仕様上必須な escape hatch（外部ライブラリが厳格な同一性を要求する等）でのみ手動メモ化を許可する。

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "babel-plugin-react-compiler": "1.0.0",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
     "msw": "^2.14.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.7.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.46.1))
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       globals:
         specifier: ^16.0.0
         version: 16.5.0
@@ -2793,6 +2796,9 @@ packages:
     resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -7684,6 +7690,10 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.0
 
   bail@2.0.2: {}
 

--- a/frontend/src/components/ClampedText.tsx
+++ b/frontend/src/components/ClampedText.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithoutRef, type CSSProperties, useMemo } from 'react';
+import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
 import { useLineClamp } from '@/hooks/useLineClamp';
 
 interface ClampedTextProps extends Omit<ComponentPropsWithoutRef<'div'>, 'children'> {
@@ -13,10 +13,11 @@ interface ClampedTextProps extends Omit<ComponentPropsWithoutRef<'div'>, 'childr
  */
 export function ClampedText({ children, ...divProps }: ClampedTextProps) {
   const { ref, lineClamp } = useLineClamp();
-  const clampStyle = useMemo<CSSProperties>(
-    () => ({ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: lineClamp }),
-    [lineClamp]
-  );
+  const clampStyle: CSSProperties = {
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: lineClamp,
+  };
 
   return (
     <div ref={ref} {...divProps}>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useAtom, useAtomValue } from 'jotai';
 import { Pencil, Share2 } from 'lucide-react';
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import editScheduleIcon from '@/assets/icons/edit-schedule-white.svg';
@@ -60,11 +60,11 @@ function HeaderFull({ className, scrollContainer, isDraggingRef, ...props }: Omi
   const scrollY = useRef(0);
   const navigate = useNavigate();
 
-  const handleHeaderClick = useCallback((e: React.MouseEvent) => {
+  const handleHeaderClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
     if (target.closest('button, a')) return;
     setIsScrolled(false);
-  }, []);
+  };
 
   // 最新の isScrolled / isDraggingRef を ref 越しに参照し、listener の再 attach を避ける
   const isScrolledRef = useRef(false);
@@ -279,7 +279,7 @@ const ViewModeButton = ({ isScrolled }: { isScrolled: boolean }) => {
 };
 
 const ShareButton = () => {
-  const handleShare = useCallback(async () => {
+  const handleShare = async () => {
     const url = window.location.href;
     if (navigator.canShare?.({ url })) {
       await navigator.share({ url });
@@ -287,7 +287,7 @@ const ShareButton = () => {
       await navigator.clipboard.writeText(url);
       toast.success('URLをコピーしました');
     }
-  }, []);
+  };
 
   return (
     <Button variant='default' size='icon' className='size-7 sm:size-9' onClick={handleShare}>

--- a/frontend/src/components/PageSwipeContainer.tsx
+++ b/frontend/src/components/PageSwipeContainer.tsx
@@ -1,6 +1,6 @@
 import useEmblaCarousel from 'embla-carousel-react';
 import { useAtom, useAtomValue } from 'jotai';
-import { type ReactNode, useCallback, useEffect, useRef } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { selectedPageIdAtom, selectedPageIndexAtom, tripPagesAtom } from '@/atoms/tripPage';
 import { cn } from '@/lib/utils';
 import type { Page } from '@/types';
@@ -24,22 +24,20 @@ const PageSwipeContainer = ({ renderPage, onActiveSlideChange, className }: Page
   });
 
   // スワイプ → selectedPageId の同期
-  const onSelect = useCallback(() => {
-    if (!emblaApi) return;
-    const index = emblaApi.selectedScrollSnap();
-    const page = pages[index];
-    if (page && page.id !== selectedPageId) {
-      setSelectedPageId(page.id);
-    }
-  }, [emblaApi, pages, selectedPageId, setSelectedPageId]);
-
   useEffect(() => {
     if (!emblaApi) return;
+    const onSelect = () => {
+      const index = emblaApi.selectedScrollSnap();
+      const page = pages[index];
+      if (page && page.id !== selectedPageId) {
+        setSelectedPageId(page.id);
+      }
+    };
     emblaApi.on('select', onSelect);
     return () => {
       emblaApi.off('select', onSelect);
     };
-  }, [emblaApi, onSelect]);
+  }, [emblaApi, pages, selectedPageId, setSelectedPageId]);
 
   // selectedPageId → embla スライド位置の同期（pill / keyboard 経由の変更時）
   useEffect(() => {

--- a/frontend/src/components/timeline/ViewTimeline.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { isSameLocalDate } from '@/lib/date';
 import { sortBlocks } from '@/lib/sortBlocks';
 import { cn } from '@/lib/utils';
@@ -204,14 +203,10 @@ export const buildTimelineItems = (groups: OverlapGroup[], now: Date | null = nu
 // --- コンポーネント ---
 
 export function ViewTimeline({ blocks, pageDate, now, className }: ViewTimelineProps) {
-  const effectiveNow = useMemo(() => {
-    if (!(pageDate && now)) return null;
-    return isSameLocalDate(pageDate, now) ? now : null;
-  }, [pageDate, now]);
-
-  // blocks の並び替え・グループ化は now に依存しないので、tick 毎に破棄されないよう分けて memo する
-  const groups = useMemo(() => groupByStartTime(sortBlocks(blocks)), [blocks]);
-  const timelineItems = useMemo(() => buildTimelineItems(groups, effectiveNow), [groups, effectiveNow]);
+  // React Compiler が pageDate/now/blocks 変化時のみ再計算するようメモ化する
+  const effectiveNow = pageDate && now && isSameLocalDate(pageDate, now) ? now : null;
+  const groups = groupByStartTime(sortBlocks(blocks));
+  const timelineItems = buildTimelineItems(groups, effectiveNow);
 
   return (
     <div className={cn('grid w-full grid-cols-[auto_1fr] gap-x-4', className)}>

--- a/frontend/src/dialogs/AddBlockDialog.tsx
+++ b/frontend/src/dialogs/AddBlockDialog.tsx
@@ -1,5 +1,5 @@
 import { MapPin, X } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogBody, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -77,8 +77,9 @@ export const AddBlockDialog = ({
   const [placeDialogOpen, setPlaceDialogOpen] = useState(false);
   const [pendingLocation, setPendingLocation] = useState<LocationUpdate | null>(null);
 
-  // フォームをリセットする関数
-  const resetForm = useCallback(() => {
+  // ダイアログが開いたときにフォームを新しい初期値で初期化（送信中はリセットしない）
+  useEffect(() => {
+    if (!(open && !isSubmitting)) return;
     setBlockType('schedule');
     setTitle('');
     setStartTime(formatTimeInput(initialStartTime));
@@ -90,14 +91,7 @@ export const AddBlockDialog = ({
     setDetail('');
     setTransportationType('car');
     setPendingLocation(null);
-  }, [initialStartTime, initialEndTime]);
-
-  // ダイアログが開いたときにフォームを新しい初期値で初期化（送信中はリセットしない）
-  useEffect(() => {
-    if (open && !isSubmitting) {
-      resetForm();
-    }
-  }, [open, resetForm, isSubmitting]);
+  }, [open, isSubmitting, initialStartTime, initialEndTime]);
 
   // 送信中はダイアログを閉じない
   const handleOpenChange = (newOpen: boolean) => {

--- a/frontend/src/dialogs/AddBlockDialog.tsx
+++ b/frontend/src/dialogs/AddBlockDialog.tsx
@@ -1,5 +1,5 @@
 import { MapPin, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogBody, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -77,9 +77,14 @@ export const AddBlockDialog = ({
   const [placeDialogOpen, setPlaceDialogOpen] = useState(false);
   const [pendingLocation, setPendingLocation] = useState<LocationUpdate | null>(null);
 
-  // ダイアログが開いたときにフォームを新しい初期値で初期化（送信中はリセットしない）
+  // open が false→true に遷移したタイミングでのみフォームを初期化する。
+  // isSubmitting の変化をトリガーにすると、送信失敗時 (isSubmitting: true→false, open=true) に
+  // ユーザーの入力を消してしまうため使わない。
+  const prevOpenRef = useRef(false);
   useEffect(() => {
-    if (!(open && !isSubmitting)) return;
+    const justOpened = open && !prevOpenRef.current;
+    prevOpenRef.current = open;
+    if (!justOpened) return;
     setBlockType('schedule');
     setTitle('');
     setStartTime(formatTimeInput(initialStartTime));
@@ -91,7 +96,7 @@ export const AddBlockDialog = ({
     setDetail('');
     setTransportationType('car');
     setPendingLocation(null);
-  }, [open, isSubmitting, initialStartTime, initialEndTime]);
+  }, [open, initialStartTime, initialEndTime]);
 
   // 送信中はダイアログを閉じない
   const handleOpenChange = (newOpen: boolean) => {

--- a/frontend/src/dialogs/PlaceSearchDialog.tsx
+++ b/frontend/src/dialogs/PlaceSearchDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@vis.gl/react-google-maps';
 import { debounce } from 'lodash-es';
 import { Globe, MapPin, Search } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { PlaceDetailsCompact, type PlaceDetailsCompactElement } from '@/components/google-maps/PlaceDetailsCompact';
 import { Button } from '@/components/ui/button';
@@ -96,38 +96,35 @@ const PlaceSearchContent = ({
   }, []);
 
   // Autocomplete検索（API呼び出しのみ、state更新は呼び出し元で行う）
-  const executeSearch = useCallback(
-    async (value: string) => {
-      if (!placesLib || value.length < 2) {
-        setSuggestions([]);
-        setShowSuggestions(false);
-        return;
-      }
+  const executeSearch = async (value: string) => {
+    if (!placesLib || value.length < 2) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
 
-      if (!sessionTokenRef.current) {
-        sessionTokenRef.current = new placesLib.AutocompleteSessionToken();
-      }
+    if (!sessionTokenRef.current) {
+      sessionTokenRef.current = new placesLib.AutocompleteSessionToken();
+    }
 
-      try {
-        const request: google.maps.places.AutocompleteRequest = {
-          input: value,
-          sessionToken: sessionTokenRef.current,
-          locationBias: map?.getBounds() ?? undefined,
-        };
+    try {
+      const request: google.maps.places.AutocompleteRequest = {
+        input: value,
+        sessionToken: sessionTokenRef.current,
+        locationBias: map?.getBounds() ?? undefined,
+      };
 
-        const { suggestions: results } = await placesLib.AutocompleteSuggestion.fetchAutocompleteSuggestions(request);
-        setSuggestions(results);
-        setShowSuggestions(results.length > 0);
-      } catch {
-        setSuggestions([]);
-        setShowSuggestions(false);
-      }
-    },
-    [placesLib, map]
-  );
+      const { suggestions: results } = await placesLib.AutocompleteSuggestion.fetchAutocompleteSuggestions(request);
+      setSuggestions(results);
+      setShowSuggestions(results.length > 0);
+    } catch {
+      setSuggestions([]);
+      setShowSuggestions(false);
+    }
+  };
 
-  // 500msデバウンスされた検索（連続入力で無駄なAPI呼び出しを防ぐ）
-  const debouncedSearch = useMemo(() => debounce(executeSearch, 500), [executeSearch]);
+  // 500msデバウンスされた検索（連続入力で無駄なAPI呼び出しを防ぐ、React Compiler が executeSearch 変化時のみ再生成）
+  const debouncedSearch = debounce(executeSearch, 500);
 
   // アンマウント・依存更新時にpending呼び出しをキャンセル
   useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
@@ -135,54 +132,51 @@ const PlaceSearchContent = ({
   // 地図クリック
   // - POIクリック: InfoWindowで確認してから取得（誤タップでの課金を防ぐ）
   // - 空地クリック: 即座にピン配置＋場所名入力欄を表示
-  const handleMapClick = useCallback(
-    (event: MapMouseEvent) => {
-      const latLng = event.detail.latLng;
-      if (!latLng) return;
+  const handleMapClick = (event: MapMouseEvent) => {
+    const latLng = event.detail.latLng;
+    if (!latLng) return;
 
-      const placeId = event.detail.placeId;
-      if (placeId) {
-        // POI: デフォルトのGoogleインフォカードを抑制して、自前の確認InfoWindowを表示
-        event.stop();
-        // 既にInfoWindowが開いている状態 → 新POIへ切り替え
-        // 直後に発火するonCloseで状態が初期化されないようフラグを立てる
-        if (pendingPoi) {
-          justSwitchedPoiRef.current = true;
-        }
-        setPendingPoi({ placeId, lat: latLng.lat, lng: latLng.lng });
-        setPoiPlace(null);
-        setShowSuggestions(false);
-        return;
+    const placeId = event.detail.placeId;
+    if (placeId) {
+      // POI: デフォルトのGoogleインフォカードを抑制して、自前の確認InfoWindowを表示
+      event.stop();
+      // 既にInfoWindowが開いている状態 → 新POIへ切り替え
+      // 直後に発火するonCloseで状態が初期化されないようフラグを立てる
+      if (pendingPoi) {
+        justSwitchedPoiRef.current = true;
       }
-
-      // 空地クリック: 既存のpending POIをクリアしてピン配置
-      setPendingPoi(null);
+      setPendingPoi({ placeId, lat: latLng.lat, lng: latLng.lng });
       setPoiPlace(null);
-      setSelectedPlace({
-        // id を外して新規作成扱い（内容変更とみなす）
-        googlePlaceId: null,
-        name: '',
-        address: null,
-        latitude: latLng.lat,
-        longitude: latLng.lng,
-        websiteUri: null,
-      });
       setShowSuggestions(false);
-      sessionTokenRef.current = null;
-    },
-    [pendingPoi]
-  );
+      return;
+    }
+
+    // 空地クリック: 既存のpending POIをクリアしてピン配置
+    setPendingPoi(null);
+    setPoiPlace(null);
+    setSelectedPlace({
+      // id を外して新規作成扱い（内容変更とみなす）
+      googlePlaceId: null,
+      name: '',
+      address: null,
+      latitude: latLng.lat,
+      longitude: latLng.lng,
+      websiteUri: null,
+    });
+    setShowSuggestions(false);
+    sessionTokenRef.current = null;
+  };
 
   // UI Kitのload完了時にPlaceオブジェクトを保存（追加API呼び出しなし）
-  const handlePoiLoad = useCallback((event: Event) => {
+  const handlePoiLoad = (event: Event) => {
     const target = event.target as PlaceDetailsCompactElement | null;
     setPoiPlace(target?.place ?? null);
-  }, []);
+  };
 
   // POIの「この場所を選択」ボタン押下時
   // UI Kitの Place オブジェクトは displayName / formattedAddress を expose しないため、
   // fetchFields で追加取得する（id / location は UI Kit 内で取得済みなのでそのまま利用）
-  const handleSelectPendingPoi = useCallback(async () => {
+  const handleSelectPendingPoi = async () => {
     if (!(pendingPoi && placesLib)) return;
 
     try {
@@ -209,53 +203,50 @@ const PlaceSearchContent = ({
     } catch {
       toast.error('場所情報の取得に失敗しました');
     }
-  }, [pendingPoi, poiPlace, placesLib]);
+  };
 
   // 場所名の編集
-  const handleNameChange = useCallback((value: string) => {
+  const handleNameChange = (value: string) => {
     setSelectedPlace(prev => (prev ? { ...prev, name: value } : prev));
-  }, []);
+  };
 
   // サジェスション選択
-  const handleSelectSuggestion = useCallback(
-    async (suggestion: google.maps.places.AutocompleteSuggestion) => {
-      if (!(placesLib && suggestion.placePrediction)) return;
+  const handleSelectSuggestion = async (suggestion: google.maps.places.AutocompleteSuggestion) => {
+    if (!(placesLib && suggestion.placePrediction)) return;
 
-      setShowSuggestions(false);
-      setSuggestions([]);
+    setShowSuggestions(false);
+    setSuggestions([]);
 
-      try {
-        const place = suggestion.placePrediction.toPlace();
-        await place.fetchFields({
-          fields: ['displayName', 'formattedAddress', 'location', 'id', 'websiteURI'],
-        });
+    try {
+      const place = suggestion.placePrediction.toPlace();
+      await place.fetchFields({
+        fields: ['displayName', 'formattedAddress', 'location', 'id', 'websiteURI'],
+      });
 
-        // 新規選択なので id は付けない
-        const location: LocationUpdate = {
-          googlePlaceId: place.id ?? null,
-          name: place.displayName ?? '',
-          address: place.formattedAddress ?? null,
-          latitude: place.location?.lat() ?? null,
-          longitude: place.location?.lng() ?? null,
-          websiteUri: place.websiteURI ?? null,
-        };
+      // 新規選択なので id は付けない
+      const location: LocationUpdate = {
+        googlePlaceId: place.id ?? null,
+        name: place.displayName ?? '',
+        address: place.formattedAddress ?? null,
+        latitude: place.location?.lat() ?? null,
+        longitude: place.location?.lng() ?? null,
+        websiteUri: place.websiteURI ?? null,
+      };
 
-        setSelectedPlace(location);
-        setQuery(location.name);
+      setSelectedPlace(location);
+      setQuery(location.name);
 
-        if (location.latitude != null && location.longitude != null) {
-          map?.panTo({ lat: location.latitude, lng: location.longitude });
-          map?.setZoom(SELECTED_ZOOM);
-        }
-
-        // セッショントークンをリセット
-        sessionTokenRef.current = null;
-      } catch {
-        toast.error('場所情報の取得に失敗しました');
+      if (location.latitude != null && location.longitude != null) {
+        map?.panTo({ lat: location.latitude, lng: location.longitude });
+        map?.setZoom(SELECTED_ZOOM);
       }
-    },
-    [placesLib, map]
-  );
+
+      // セッショントークンをリセット
+      sessionTokenRef.current = null;
+    } catch {
+      toast.error('場所情報の取得に失敗しました');
+    }
+  };
 
   const handleConfirm = () => {
     if (!selectedPlace) return;

--- a/frontend/src/hooks/useActivePage.ts
+++ b/frontend/src/hooks/useActivePage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { db } from '@/lib/db';
 import type { Page } from '@/types/page';
 
@@ -52,15 +52,12 @@ export const useActivePage = (tripId: number | null) => {
   }, [tripId]);
 
   // アクティブページ ID を IndexedDB に永続化（fire-and-forget）
-  const saveActivePageId = useCallback(
-    (pageId: Page['id']) => {
-      if (tripId == null) return;
-      saveActivePageIdToDB(tripId, pageId).catch(() => {
-        // fire-and-forget
-      });
-    },
-    [tripId]
-  );
+  const saveActivePageId = (pageId: Page['id']) => {
+    if (tripId == null) return;
+    saveActivePageIdToDB(tripId, pageId).catch(() => {
+      // fire-and-forget
+    });
+  };
 
   return {
     storedPageId,

--- a/frontend/src/hooks/useBlocks.ts
+++ b/frontend/src/hooks/useBlocks.ts
@@ -1,4 +1,3 @@
-import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import useSWR, { type SWRConfiguration, useSWRConfig } from 'swr';
 import useSWRMutation from 'swr/mutation';
@@ -25,7 +24,7 @@ export const useBlocks = (pageId: number | null, options?: Pick<SWRConfiguration
   );
 
   // サーバー返却順はソート保証がないため、サービス層で startTime 昇順に整列して返す
-  const blocks = useMemo<Block[] | undefined>(() => (data ? sortBlocks(data) : data), [data]);
+  const blocks: Block[] | undefined = data ? sortBlocks(data) : data;
 
   return {
     blocks,
@@ -62,16 +61,13 @@ export const useCreateBlock = (pageId: number | null) => {
   const listKey = pageId ? `${PAGES_BASE_PATH}/${pageId}/blocks` : null;
   const { mutate } = useSWRConfig();
 
-  const createBlockFetcher = useCallback(
-    async (_key: string | null, { arg }: { arg: CreateBlockArg }) => {
-      // アプリ層→API層に変換。id はダミー値で、送信時に除外する
-      const apiData = blockToApi.parse({ ...arg.block, id: 0 });
-      const { id: _, ...payload } = apiData;
-      const response = await apiClient.post<Block>(`${PAGES_BASE_PATH}/${pageId}/blocks`, payload);
-      return blockFromApi.parse(response.data);
-    },
-    [pageId]
-  );
+  const createBlockFetcher = async (_key: string | null, { arg }: { arg: CreateBlockArg }) => {
+    // アプリ層→API層に変換。id はダミー値で、送信時に除外する
+    const apiData = blockToApi.parse({ ...arg.block, id: 0 });
+    const { id: _, ...payload } = apiData;
+    const response = await apiClient.post<Block>(`${PAGES_BASE_PATH}/${pageId}/blocks`, payload);
+    return blockFromApi.parse(response.data);
+  };
 
   const { trigger, isMutating, error, data } = useSWRMutation<Block, Error, string | null, CreateBlockArg>(
     listKey, // リストの更新
@@ -110,13 +106,13 @@ export const useUpdateBlock = (pageId: number | null) => {
   const listKey = pageId ? `${PAGES_BASE_PATH}/${pageId}/blocks` : null;
   const { mutate } = useSWRConfig();
 
-  const updateBlockFetcher = useCallback(async (_key: string | null, { arg }: { arg: UpdateBlockArg }) => {
+  const updateBlockFetcher = async (_key: string | null, { arg }: { arg: UpdateBlockArg }) => {
     const { id, data } = arg;
     const apiData = blockToApi.parse({ ...data, id });
     const { id: _, ...payload } = apiData;
     const response = await apiClient.put<Block>(`${BLOCKS_BASE_PATH}/${id}`, payload);
     return blockFromApi.parse(response.data);
-  }, []);
+  };
 
   const { trigger, isMutating, error, data } = useSWRMutation(listKey, updateBlockFetcher, {
     // API成功時の処理（サーバーからの正式なレスポンスで確定させる）
@@ -126,30 +122,27 @@ export const useUpdateBlock = (pageId: number | null) => {
     },
   });
 
-  const updateBlock = useCallback(
-    async (arg: UpdateBlockArg) => {
-      const optimisticBlock = { ...arg.data, id: arg.id } as Block;
+  const updateBlock = async (arg: UpdateBlockArg) => {
+    const optimisticBlock = { ...arg.data, id: arg.id } as Block;
 
-      // 【個別データ】の楽観的更新
-      const individualKey = `${BLOCKS_BASE_PATH}/${arg.id}`;
-      mutate(individualKey, optimisticBlock, { revalidate: false });
+    // 【個別データ】の楽観的更新
+    const individualKey = `${BLOCKS_BASE_PATH}/${arg.id}`;
+    mutate(individualKey, optimisticBlock, { revalidate: false });
 
-      // 【リストデータ】の楽観的更新
-      return trigger(arg, {
-        optimisticData: (currentBlocks: Block[] | undefined) => {
-          if (!currentBlocks) return [];
-          return currentBlocks.map(b => (b.id === arg.id ? { ...b, ...arg.data } : b)) as Block[];
-        },
-        revalidate: false,
-        rollbackOnError: true,
-        onError: (err: unknown) => {
-          toast.error(getErrorMessage(err));
-          mutate(`${BLOCKS_BASE_PATH}/${arg.id}`); // 個別データのロールバック
-        },
-      });
-    },
-    [trigger, mutate]
-  );
+    // 【リストデータ】の楽観的更新
+    return trigger(arg, {
+      optimisticData: (currentBlocks: Block[] | undefined) => {
+        if (!currentBlocks) return [];
+        return currentBlocks.map(b => (b.id === arg.id ? { ...b, ...arg.data } : b)) as Block[];
+      },
+      revalidate: false,
+      rollbackOnError: true,
+      onError: (err: unknown) => {
+        toast.error(getErrorMessage(err));
+        mutate(`${BLOCKS_BASE_PATH}/${arg.id}`); // 個別データのロールバック
+      },
+    });
+  };
 
   return {
     updateBlock,
@@ -169,11 +162,11 @@ export const useDeleteBlock = (pageId: number | null) => {
   const listKey = pageId ? `${PAGES_BASE_PATH}/${pageId}/blocks` : null;
   const { mutate } = useSWRConfig();
 
-  const deleteBlockFetcher = useCallback(async (_: string | null, { arg: id }: { arg: DeleteBlockArg }) => {
+  const deleteBlockFetcher = async (_: string | null, { arg: id }: { arg: DeleteBlockArg }) => {
     DeleteBlockSchema.parse(id);
     await apiClient.delete(`${BLOCKS_BASE_PATH}/${id}`);
     return id;
-  }, []);
+  };
 
   const { trigger, isMutating, error } = useSWRMutation(listKey, deleteBlockFetcher, {
     onSuccess: deletedId => {
@@ -183,28 +176,25 @@ export const useDeleteBlock = (pageId: number | null) => {
     },
   });
 
-  const deleteBlock = useCallback(
-    (id: DeleteBlockArg) => {
-      const individualKey = `${BLOCKS_BASE_PATH}/${id}`;
-      // 【個別データ】を楽観的に削除
-      mutate(individualKey, undefined, { revalidate: false });
+  const deleteBlock = (id: DeleteBlockArg) => {
+    const individualKey = `${BLOCKS_BASE_PATH}/${id}`;
+    // 【個別データ】を楽観的に削除
+    mutate(individualKey, undefined, { revalidate: false });
 
-      // 【リストデータ】の楽観的更新
-      return trigger(id, {
-        optimisticData: (currentBlocks: Block[] | undefined) => {
-          if (!currentBlocks) return [];
-          return currentBlocks.filter(b => b.id !== id);
-        },
-        revalidate: false,
-        rollbackOnError: true,
-        onError: (err: unknown) => {
-          toast.error(getErrorMessage(err));
-          mutate(individualKey); // エラー時に個別データを再検証して戻す
-        },
-      });
-    },
-    [trigger, mutate]
-  );
+    // 【リストデータ】の楽観的更新
+    return trigger(id, {
+      optimisticData: (currentBlocks: Block[] | undefined) => {
+        if (!currentBlocks) return [];
+        return currentBlocks.filter(b => b.id !== id);
+      },
+      revalidate: false,
+      rollbackOnError: true,
+      onError: (err: unknown) => {
+        toast.error(getErrorMessage(err));
+        mutate(individualKey); // エラー時に個別データを再検証して戻す
+      },
+    });
+  };
 
   return {
     deleteBlock,

--- a/frontend/src/hooks/useCalendarDragDetection.ts
+++ b/frontend/src/hooks/useCalendarDragDetection.ts
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface UseCalendarDragDetectionReturn {
   /** FC eventDragStart / eventResizeStart に渡す */
@@ -116,19 +116,19 @@ export const useCalendarDragDetection = (
   }, [calendarContainerRef, onDragStart]);
 
   // FCイベントドラッグ・リサイズ開始（タッチ経由）
-  const handleEventDragStart = useCallback(() => {
+  const handleEventDragStart = () => {
     onDragStart?.(true);
-  }, [onDragStart]);
+  };
 
   // FCイベントドラッグ・リサイズ終了
-  const handleEventDragStop = useCallback(() => {
+  const handleEventDragStop = () => {
     onDragEnd?.();
-  }, [onDragEnd]);
+  };
 
   // FC select発火前に呼ぶ（MutationObserverで開始したスクロールロックを解除）
-  const onBeforeSelect = useCallback(() => {
+  const onBeforeSelect = () => {
     onDragEnd?.();
-  }, [onDragEnd]);
+  };
 
   return { handleEventDragStart, handleEventDragStop, onBeforeSelect };
 };

--- a/frontend/src/hooks/useDragAutoScroll.ts
+++ b/frontend/src/hooks/useDragAutoScroll.ts
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 
 const EDGE_ZONE = 80;
 const MAX_SCROLL_SPEED = 15;
@@ -25,7 +25,7 @@ export const useDragAutoScroll = (scrollContainerRef: RefObject<HTMLElement | nu
   // Android: overflow:hidden方式用
   const savedOverflowRef = useRef<string | null>(null);
 
-  const autoScrollLoop = useCallback(() => {
+  const autoScrollLoop = () => {
     const container = scrollContainerRef.current;
     if (!(container && isDraggingRef.current)) return;
 
@@ -50,56 +50,53 @@ export const useDragAutoScroll = (scrollContainerRef: RefObject<HTMLElement | nu
     }
 
     rafIdRef.current = requestAnimationFrame(autoScrollLoop);
-  }, [scrollContainerRef]);
+  };
 
-  const startDrag = useCallback(
-    (isTouch: boolean) => {
-      if (isDraggingRef.current) return;
-      isDraggingRef.current = true;
+  const startDrag = (isTouch: boolean) => {
+    if (isDraggingRef.current) return;
+    isDraggingRef.current = true;
 
-      const container = scrollContainerRef.current;
-      if (container) {
-        if (isTouch) {
-          // Android: overflow:hidden方式（コンポジタースレッドのタッチスクロールを防止）
-          savedOverflowRef.current = container.style.overflow;
-          container.style.overflow = 'hidden';
-        } else {
-          // PC: scrollイベントハンドラでscrollTopをロック
-          lockedScrollTopRef.current = container.scrollTop;
-          const onScroll = () => {
-            if (isDraggingRef.current) {
-              container.scrollTop = lockedScrollTopRef.current;
-            }
-          };
-          scrollHandlerRef.current = onScroll;
-          container.addEventListener('scroll', onScroll);
-        }
-
-        const rect = container.getBoundingClientRect();
-        pointerYRef.current = (rect.top + rect.bottom) / 2;
+    const container = scrollContainerRef.current;
+    if (container) {
+      if (isTouch) {
+        // Android: overflow:hidden方式（コンポジタースレッドのタッチスクロールを防止）
+        savedOverflowRef.current = container.style.overflow;
+        container.style.overflow = 'hidden';
+      } else {
+        // PC: scrollイベントハンドラでscrollTopをロック
+        lockedScrollTopRef.current = container.scrollTop;
+        const onScroll = () => {
+          if (isDraggingRef.current) {
+            container.scrollTop = lockedScrollTopRef.current;
+          }
+        };
+        scrollHandlerRef.current = onScroll;
+        container.addEventListener('scroll', onScroll);
       }
 
-      const handlePointerMove = (e: PointerEvent) => {
-        pointerYRef.current = e.clientY;
-      };
-      const handleTouchMove = (e: TouchEvent) => {
-        if (e.touches.length > 0) {
-          pointerYRef.current = e.touches[0].clientY;
-        }
-      };
-      document.addEventListener('pointermove', handlePointerMove);
-      document.addEventListener('touchmove', handleTouchMove, { passive: true });
-      cleanupRef.current = () => {
-        document.removeEventListener('pointermove', handlePointerMove);
-        document.removeEventListener('touchmove', handleTouchMove);
-      };
+      const rect = container.getBoundingClientRect();
+      pointerYRef.current = (rect.top + rect.bottom) / 2;
+    }
 
-      rafIdRef.current = requestAnimationFrame(autoScrollLoop);
-    },
-    [scrollContainerRef, autoScrollLoop]
-  );
+    const handlePointerMove = (e: PointerEvent) => {
+      pointerYRef.current = e.clientY;
+    };
+    const handleTouchMove = (e: TouchEvent) => {
+      if (e.touches.length > 0) {
+        pointerYRef.current = e.touches[0].clientY;
+      }
+    };
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('touchmove', handleTouchMove, { passive: true });
+    cleanupRef.current = () => {
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('touchmove', handleTouchMove);
+    };
 
-  const stopDrag = useCallback(() => {
+    rafIdRef.current = requestAnimationFrame(autoScrollLoop);
+  };
+
+  const stopDrag = () => {
     if (!isDraggingRef.current) return;
     isDraggingRef.current = false;
 
@@ -123,7 +120,7 @@ export const useDragAutoScroll = (scrollContainerRef: RefObject<HTMLElement | nu
     }
     cleanupRef.current?.();
     cleanupRef.current = null;
-  }, [scrollContainerRef]);
+  };
 
   return { isDraggingRef, startDrag, stopDrag };
 };

--- a/frontend/src/hooks/useLineClamp.ts
+++ b/frontend/src/hooks/useLineClamp.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { useResizeObserver } from './useResizeObserver';
 
 /**
@@ -16,7 +16,7 @@ import { useResizeObserver } from './useResizeObserver';
 export function useLineClamp() {
   const [lineClamp, setLineClamp] = useState(1);
 
-  const handleResize = useCallback((entry: ResizeObserverEntry) => {
+  const handleResize = (entry: ResizeObserverEntry) => {
     const style = getComputedStyle(entry.target);
     const fontSize = Number.parseFloat(style.fontSize);
     let lineHeight = Number.parseFloat(style.lineHeight);
@@ -26,7 +26,7 @@ export function useLineClamp() {
     }
     const lines = Math.max(1, Math.floor(entry.contentRect.height / lineHeight));
     setLineClamp(lines);
-  }, []);
+  };
 
   const ref = useResizeObserver(handleResize);
 

--- a/frontend/src/hooks/usePWAInstall.ts
+++ b/frontend/src/hooks/usePWAInstall.ts
@@ -1,5 +1,4 @@
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useCallback } from 'react';
 import { pwaIsReadyAtom, pwaPromptEventAtom } from '@/atoms/pwa';
 
 export type PWAInstallResult = 'accepted' | 'dismissed' | 'unavailable';
@@ -9,7 +8,7 @@ export const usePWAInstall = () => {
   const promptEvent = useAtomValue(pwaPromptEventAtom);
   const setPromptEvent = useSetAtom(pwaPromptEventAtom);
 
-  const installApp = useCallback(async (): Promise<PWAInstallResult> => {
+  const installApp = async (): Promise<PWAInstallResult> => {
     if (promptEvent === null) return 'unavailable';
 
     await promptEvent.prompt();
@@ -19,7 +18,7 @@ export const usePWAInstall = () => {
     setPromptEvent(null);
 
     return outcome;
-  }, [promptEvent, setPromptEvent]);
+  };
 
   return { isReady, installApp };
 };

--- a/frontend/src/hooks/usePages.ts
+++ b/frontend/src/hooks/usePages.ts
@@ -1,4 +1,3 @@
-import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import useSWR, { type SWRConfiguration, useSWRConfig } from 'swr';
 import useSWRMutation from 'swr/mutation';
@@ -25,7 +24,7 @@ export const usePages = (tripId: number | null, options?: Pick<SWRConfiguration,
   );
 
   // サーバー返却順はソート保証がないため、サービス層で date 昇順 → id 昇順に整列して返す
-  const pages = useMemo<Page[] | undefined>(() => (data ? sortPages(data) : data), [data]);
+  const pages: Page[] | undefined = data ? sortPages(data) : data;
 
   return {
     pages,
@@ -60,17 +59,14 @@ export const useCreatePage = (tripId: number | null) => {
   const listKey = tripId ? `${TRIPS_BASE_PATH}/${tripId}/pages` : null;
   const { mutate } = useSWRConfig();
 
-  const createPageFetcher = useCallback(
-    async (_key: string | null, { arg: pageData }: { arg: CreatePageArg }) => {
-      CreatePageSchema.parse(pageData);
-      // アプリ層→API層に変換してからバリデーション・送信
-      const apiData = pageToApi.parse({ ...pageData, id: 0 }); // idは仮値
-      const { id: _, ...payload } = apiData; // idを除外
-      const response = await apiClient.post(`${TRIPS_BASE_PATH}/${tripId}/pages`, payload);
-      return pageFromApi.parse(response.data);
-    },
-    [tripId]
-  );
+  const createPageFetcher = async (_key: string | null, { arg: pageData }: { arg: CreatePageArg }) => {
+    CreatePageSchema.parse(pageData);
+    // アプリ層→API層に変換してからバリデーション・送信
+    const apiData = pageToApi.parse({ ...pageData, id: 0 }); // idは仮値
+    const { id: _, ...payload } = apiData; // idを除外
+    const response = await apiClient.post(`${TRIPS_BASE_PATH}/${tripId}/pages`, payload);
+    return pageFromApi.parse(response.data);
+  };
 
   const { trigger, isMutating, error, data } = useSWRMutation<Page, Error, string | null, CreatePageArg>(
     listKey, // リストの更新
@@ -107,7 +103,7 @@ export const useUpdatePage = (tripId: number | null) => {
   const listKey = tripId ? `${TRIPS_BASE_PATH}/${tripId}/pages` : null;
   const { mutate } = useSWRConfig();
 
-  const updatePageFetcher = useCallback(async (_key: string | null, { arg }: { arg: UpdatePageArg }) => {
+  const updatePageFetcher = async (_key: string | null, { arg }: { arg: UpdatePageArg }) => {
     const { id, data } = arg;
     UpdatePageSchema.parse(data);
     // アプリ層→API層に変換してからバリデーション・送信
@@ -115,7 +111,7 @@ export const useUpdatePage = (tripId: number | null) => {
     const { id: _, ...payload } = apiData; // idを除外（URLパスで指定）
     const response = await apiClient.put(`${PAGES_BASE_PATH}/${id}`, payload);
     return pageFromApi.parse(response.data);
-  }, []);
+  };
 
   const { trigger, isMutating, error, data } = useSWRMutation(listKey, updatePageFetcher, {
     // API成功時の処理（サーバーからの正式なレスポンスで確定させる）
@@ -125,30 +121,27 @@ export const useUpdatePage = (tripId: number | null) => {
     },
   });
 
-  const updatePage = useCallback(
-    async (arg: UpdatePageArg) => {
-      const optimisticPage = { ...arg.data, id: arg.id } as Page;
+  const updatePage = async (arg: UpdatePageArg) => {
+    const optimisticPage = { ...arg.data, id: arg.id } as Page;
 
-      // 【個別データ】の楽観的更新
-      const individualKey = `${PAGES_BASE_PATH}/${arg.id}`;
-      mutate(individualKey, optimisticPage, { revalidate: false });
+    // 【個別データ】の楽観的更新
+    const individualKey = `${PAGES_BASE_PATH}/${arg.id}`;
+    mutate(individualKey, optimisticPage, { revalidate: false });
 
-      // 【リストデータ】の楽観的更新
-      return trigger(arg, {
-        optimisticData: (currentPages: Page[] | undefined) => {
-          if (!currentPages) return [];
-          return currentPages.map(p => (p.id === arg.id ? { ...p, ...arg.data } : p));
-        },
-        revalidate: false,
-        rollbackOnError: true,
-        onError: (err: unknown) => {
-          toast.error(getErrorMessage(err));
-          mutate(`${PAGES_BASE_PATH}/${arg.id}`); // 個別データのロールバック
-        },
-      });
-    },
-    [trigger, mutate]
-  );
+    // 【リストデータ】の楽観的更新
+    return trigger(arg, {
+      optimisticData: (currentPages: Page[] | undefined) => {
+        if (!currentPages) return [];
+        return currentPages.map(p => (p.id === arg.id ? { ...p, ...arg.data } : p));
+      },
+      revalidate: false,
+      rollbackOnError: true,
+      onError: (err: unknown) => {
+        toast.error(getErrorMessage(err));
+        mutate(`${PAGES_BASE_PATH}/${arg.id}`); // 個別データのロールバック
+      },
+    });
+  };
 
   return {
     updatePage,
@@ -168,11 +161,11 @@ export const useDeletePage = (tripId: number | null) => {
   const listKey = tripId ? `${TRIPS_BASE_PATH}/${tripId}/pages` : null;
   const { mutate } = useSWRConfig();
 
-  const deletePageFetcher = useCallback(async (_: string | null, { arg: id }: { arg: DeletePageArg }) => {
+  const deletePageFetcher = async (_: string | null, { arg: id }: { arg: DeletePageArg }) => {
     DeletePageSchema.parse(id);
     await apiClient.delete(`${PAGES_BASE_PATH}/${id}`);
     return id;
-  }, []);
+  };
 
   const { trigger, isMutating, error } = useSWRMutation(listKey, deletePageFetcher, {
     onSuccess: deletedId => {
@@ -182,28 +175,25 @@ export const useDeletePage = (tripId: number | null) => {
     },
   });
 
-  const deletePage = useCallback(
-    (id: DeletePageArg) => {
-      const individualKey = `${PAGES_BASE_PATH}/${id}`;
-      // 【個別データ】を楽観的に削除
-      mutate(individualKey, undefined, { revalidate: false });
+  const deletePage = (id: DeletePageArg) => {
+    const individualKey = `${PAGES_BASE_PATH}/${id}`;
+    // 【個別データ】を楽観的に削除
+    mutate(individualKey, undefined, { revalidate: false });
 
-      // 【リストデータ】の楽観的更新
-      return trigger(id, {
-        optimisticData: (currentPages: Page[] | undefined) => {
-          if (!currentPages) return [];
-          return currentPages.filter(p => p.id !== id);
-        },
-        revalidate: false,
-        rollbackOnError: true,
-        onError: (err: unknown) => {
-          toast.error(getErrorMessage(err));
-          mutate(individualKey); // エラー時に個別データを再検証して戻す
-        },
-      });
-    },
-    [trigger, mutate]
-  );
+    // 【リストデータ】の楽観的更新
+    return trigger(id, {
+      optimisticData: (currentPages: Page[] | undefined) => {
+        if (!currentPages) return [];
+        return currentPages.filter(p => p.id !== id);
+      },
+      revalidate: false,
+      rollbackOnError: true,
+      onError: (err: unknown) => {
+        toast.error(getErrorMessage(err));
+        mutate(individualKey); // エラー時に個別データを再検証して戻す
+      },
+    });
+  };
 
   return {
     deletePage,

--- a/frontend/src/hooks/useResizeObserver.ts
+++ b/frontend/src/hooks/useResizeObserver.ts
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash-es';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
  * windowのresizeイベントを100msでデバウンスしてcallbackを実行するカスタムフック
@@ -9,8 +9,8 @@ import { useEffect, useMemo, useRef } from 'react';
 export const useResizeObserver = (callback: (entry: ResizeObserverEntry) => void, debounceMs: number = 100) => {
   const ref = useRef<HTMLDivElement>(null);
 
-  // デバウンスされたコールバック
-  const debouncedCallback = useMemo(() => debounce(callback, debounceMs), [callback, debounceMs]);
+  // デバウンスされたコールバック（React Compiler が callback/debounceMs 変化時のみ再生成）
+  const debouncedCallback = debounce(callback, debounceMs);
 
   useEffect(() => {
     const element = ref.current;

--- a/frontend/src/hooks/useTrips.ts
+++ b/frontend/src/hooks/useTrips.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import { useCallback } from 'react';
 import { toast } from 'sonner';
 import useSWR, { type SWRConfiguration, useSWRConfig } from 'swr';
 import useSWRMutation from 'swr/mutation';
@@ -83,7 +82,7 @@ type CreateTripArg = TripMutation;
  * 新しいTripを作成する
  */
 export const useCreateTrip = () => {
-  const createTrip = useCallback(async (url: string, { arg: tripData }: { arg: CreateTripArg }) => {
+  const createTrip = async (url: string, { arg: tripData }: { arg: CreateTripArg }) => {
     const apiData = tripMutationToApi.parse(tripData);
     const response = await apiClient.post(url, apiData);
     const newTrip = createTripFromApi.parse(response.data);
@@ -111,7 +110,7 @@ export const useCreateTrip = () => {
     await apiClient.post(`/pages/${newPage.id}/blocks`, blockPayload);
 
     return newTrip;
-  }, []);
+  };
 
   const { trigger, isMutating, error, data } = useSWRMutation<CreateTripFromApi, Error, string, CreateTripArg>(
     TRIPS_BASE_PATH,
@@ -137,28 +136,25 @@ type UpdateTripArg = { id: Trip['id']; data: TripMutation };
 export const useUpdateTrip = () => {
   const { mutate, cache } = useSWRConfig();
 
-  const updateTripFetcher = useCallback(async (_key: string | null, { arg }: { arg: UpdateTripArg }) => {
+  const updateTripFetcher = async (_key: string | null, { arg }: { arg: UpdateTripArg }) => {
     const { id, data } = arg;
     const apiData = tripMutationToApi.parse(data);
     const response = await apiClient.put(`${TRIPS_BASE_PATH}/${id}`, apiData);
     return tripFromApi.parse(response.data);
-  }, []);
+  };
 
   // useVisitedTrips の SWR cache (`[VISITED_TRIPS_CACHE_KEY, ...urlIds]`) は個別 /trips/url/:urlId とは別キーで
   // 自動追従しない。HomePage の期間バッジ等が古いまま残らないよう、ここから明示的に置換する
-  const updateVisitedTripsCache = useCallback(
-    (trip: Trip) => {
-      mutate(
-        key => Array.isArray(key) && key[0] === VISITED_TRIPS_CACHE_KEY,
-        (currentTrips: Trip[] | undefined) => {
-          if (!currentTrips) return currentTrips;
-          return currentTrips.map(t => (t.id === trip.id ? trip : t));
-        },
-        { revalidate: false }
-      );
-    },
-    [mutate]
-  );
+  const updateVisitedTripsCache = (trip: Trip) => {
+    mutate(
+      key => Array.isArray(key) && key[0] === VISITED_TRIPS_CACHE_KEY,
+      (currentTrips: Trip[] | undefined) => {
+        if (!currentTrips) return currentTrips;
+        return currentTrips.map(t => (t.id === trip.id ? trip : t));
+      },
+      { revalidate: false }
+    );
+  };
 
   const { trigger, isMutating, error, data } = useSWRMutation(TRIPS_BASE_PATH, updateTripFetcher, {
     // サーバーレスポンスで個別キャッシュ（id ベース・urlId ベース）を確定
@@ -169,32 +165,29 @@ export const useUpdateTrip = () => {
     },
   });
 
-  const updateTrip = useCallback(
-    async (arg: UpdateTripArg) => {
-      const idKey = `${TRIPS_BASE_PATH}/${arg.id}`;
-      // 既存キャッシュから urlId を引いて、id ベースと urlId ベース両方の個別キャッシュを楽観更新する
-      const cachedTrip = (cache.get(idKey)?.data ?? null) as Trip | null;
-      const urlKey = cachedTrip?.urlId ? `${TRIPS_BASE_PATH}/url/${cachedTrip.urlId}` : null;
-      const optimisticTrip = { ...(cachedTrip ?? {}), ...arg.data, id: arg.id } as Trip;
+  const updateTrip = async (arg: UpdateTripArg) => {
+    const idKey = `${TRIPS_BASE_PATH}/${arg.id}`;
+    // 既存キャッシュから urlId を引いて、id ベースと urlId ベース両方の個別キャッシュを楽観更新する
+    const cachedTrip = (cache.get(idKey)?.data ?? null) as Trip | null;
+    const urlKey = cachedTrip?.urlId ? `${TRIPS_BASE_PATH}/url/${cachedTrip.urlId}` : null;
+    const optimisticTrip = { ...(cachedTrip ?? {}), ...arg.data, id: arg.id } as Trip;
 
-      // 個別キャッシュの楽観的更新（リスト /trips は未使用のため対象外）
-      mutate(idKey, optimisticTrip, { revalidate: false });
-      if (urlKey) mutate(urlKey, optimisticTrip, { revalidate: false });
-      updateVisitedTripsCache(optimisticTrip);
+    // 個別キャッシュの楽観的更新（リスト /trips は未使用のため対象外）
+    mutate(idKey, optimisticTrip, { revalidate: false });
+    if (urlKey) mutate(urlKey, optimisticTrip, { revalidate: false });
+    updateVisitedTripsCache(optimisticTrip);
 
-      return trigger(arg, {
-        revalidate: false,
-        onError: (err: unknown) => {
-          toast.error(getErrorMessage(err));
-          mutate(idKey); // 個別データのロールバック（再検証）
-          if (urlKey) mutate(urlKey);
-          // visitedTrips は revalidate して同期（fetcher が urlIds 全件を取得するので失敗時のみ）
-          mutate(key => Array.isArray(key) && key[0] === VISITED_TRIPS_CACHE_KEY);
-        },
-      });
-    },
-    [trigger, mutate, cache, updateVisitedTripsCache]
-  );
+    return trigger(arg, {
+      revalidate: false,
+      onError: (err: unknown) => {
+        toast.error(getErrorMessage(err));
+        mutate(idKey); // 個別データのロールバック（再検証）
+        if (urlKey) mutate(urlKey);
+        // visitedTrips は revalidate して同期（fetcher が urlIds 全件を取得するので失敗時のみ）
+        mutate(key => Array.isArray(key) && key[0] === VISITED_TRIPS_CACHE_KEY);
+      },
+    });
+  };
 
   return {
     updateTrip,
@@ -212,11 +205,11 @@ type DeleteTripArg = Trip['id'];
 export const useDeleteTrip = () => {
   const { mutate } = useSWRConfig();
 
-  const deleteTripFetcher = useCallback(async (_: string | null, { arg: id }: { arg: DeleteTripArg }) => {
+  const deleteTripFetcher = async (_: string | null, { arg: id }: { arg: DeleteTripArg }) => {
     z.number().parse(id);
     await apiClient.delete(`${TRIPS_BASE_PATH}/${id}`);
     return undefined;
-  }, []);
+  };
 
   const { trigger, isMutating, error } = useSWRMutation(
     TRIPS_BASE_PATH, // リストのキー（削除完了後のリスト自動再検証のため）
@@ -226,23 +219,20 @@ export const useDeleteTrip = () => {
     }
   );
 
-  const deleteTrip = useCallback(
-    async (id: DeleteTripArg) => {
-      // リスト側の楽観的更新
-      await trigger(id, {
-        optimisticData: (currentTrips: Trip[] | undefined) => {
-          if (!currentTrips) return [];
-          return currentTrips.filter(trip => trip.id !== id);
-        },
-        revalidate: true, // 念のためリストをサーバーと同期する（不要ならfalse）
-        rollbackOnError: true,
-      });
+  const deleteTrip = async (id: DeleteTripArg) => {
+    // リスト側の楽観的更新
+    await trigger(id, {
+      optimisticData: (currentTrips: Trip[] | undefined) => {
+        if (!currentTrips) return [];
+        return currentTrips.filter(trip => trip.id !== id);
+      },
+      revalidate: true, // 念のためリストをサーバーと同期する（不要ならfalse）
+      rollbackOnError: true,
+    });
 
-      // 個別キャッシュ（/trips/:id）の削除
-      mutate(`${TRIPS_BASE_PATH}/${id}`, undefined, false);
-    },
-    [trigger, mutate]
-  );
+    // 個別キャッシュ（/trips/:id）の削除
+    mutate(`${TRIPS_BASE_PATH}/${id}`, undefined, false);
+  };
 
   return {
     deleteTrip,

--- a/frontend/src/hooks/useVisitedTrips.ts
+++ b/frontend/src/hooks/useVisitedTrips.ts
@@ -1,5 +1,5 @@
 import { isAxiosError } from 'axios';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 import { fetcher } from '@/lib/apiClient';
 import { db } from '@/lib/db';
@@ -76,21 +76,21 @@ export const useVisitedTrips = () => {
   }, [urlIds, isInitialized]);
 
   // urlIdを訪問済みリストに追加
-  const addVisitedTrip = useCallback((urlId: string) => {
+  const addVisitedTrip = (urlId: string) => {
     setUrlIds(prev => {
       if (prev.includes(urlId)) return prev;
       return [...prev, urlId];
     });
-  }, []);
+  };
 
   // urlIdを訪問済みリストから削除
-  const removeVisitedTrip = useCallback((urlId: string) => {
+  const removeVisitedTrip = (urlId: string) => {
     setUrlIds(prev => {
       const updated = prev.filter(id => id !== urlId);
       if (updated.length === prev.length) return prev;
       return updated;
     });
-  }, []);
+  };
 
   // SWRで各urlIdからTripを取得
   const {

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -1,6 +1,6 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { Plus } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { isOfflineReadAtom } from '@/atoms/network';
 import { selectedPageIdAtom, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
@@ -25,10 +25,10 @@ const TripPage = () => {
   // useDragAutoScroll は ref を読み続けるので維持。Header は state で再 attach するため両方持つ
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
-  const handleScrollContainerChange = useCallback((el: HTMLDivElement | null) => {
+  const handleScrollContainerChange = (el: HTMLDivElement | null) => {
     scrollContainerRef.current = el;
     setScrollContainerEl(el);
-  }, []);
+  };
   const { isDraggingRef, startDrag, stopDrag } = useDragAutoScroll(scrollContainerRef);
   const [selectedPageId, setSelectedPageId] = useAtom(selectedPageIdAtom);
   const [mode, setMode] = useAtom(tripModeAtom);

--- a/frontend/src/pages/TripPage/EditTripLayout.tsx
+++ b/frontend/src/pages/TripPage/EditTripLayout.tsx
@@ -4,7 +4,7 @@ import type { EventResizeDoneArg } from '@fullcalendar/interaction';
 import interactionPlugin from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { BlockScheduleEdit } from '@/components/blocks/edit/BlockScheduleEdit';
 import { BlockTransportationEdit } from '@/components/blocks/edit/BlockTransportationEdit';
 import { AddBlockDialog, EditBlockDialog } from '@/dialogs';
@@ -48,7 +48,7 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
 
   // --- カレンダーイベント変換 ---
 
-  const createEvent = useCallback((block: Block) => {
+  const createEvent = (block: Block) => {
     return {
       id: block.id.toString(),
       title: block.title,
@@ -61,12 +61,9 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
       backgroundColor: 'transparent',
       borderColor: 'transparent',
     };
-  }, []);
+  };
 
-  const events = useMemo(() => {
-    if (!blocks) return [];
-    return blocks.map(block => createEvent(block));
-  }, [blocks, createEvent]);
+  const events = blocks ? blocks.map(block => createEvent(block)) : [];
 
   // --- カレンダー初期化・同期 ---
 
@@ -89,14 +86,10 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
     isFirstEventMount.current = false;
   };
 
-  // Date参照の安定化（親re-renderで新しいDateが生成されないようにする）
-  const addDialogTimes = useMemo(
-    () =>
-      addDialogSelectInfo
-        ? { start: new Date(addDialogSelectInfo.startStr), end: new Date(addDialogSelectInfo.endStr) }
-        : null,
-    [addDialogSelectInfo]
-  );
+  // Date参照の安定化（親re-renderで新しいDateが生成されないよう React Compiler が addDialogSelectInfo 変化時のみ再生成）
+  const addDialogTimes = addDialogSelectInfo
+    ? { start: new Date(addDialogSelectInfo.startStr), end: new Date(addDialogSelectInfo.endStr) }
+    : null;
 
   // --- ブロック追加ダイアログ ---
 
@@ -158,39 +151,30 @@ export const EditTripLayout = ({ selectedPageId, onDragStart, onDragEnd, refresh
 
   const SNAP_MINUTES = 15;
 
-  const snapToSlot = useCallback((date: Date): Date => {
+  const snapToSlot = (date: Date): Date => {
     const snapped = new Date(date);
     const minutes = snapped.getMinutes();
     snapped.setMinutes(Math.round(minutes / SNAP_MINUTES) * SNAP_MINUTES, 0, 0);
     return snapped;
-  }, []);
+  };
 
-  const updateBlockTime = useCallback(
-    async (event: EventDropArg['event'] | EventResizeDoneArg['event']) => {
-      const blockData = event.extendedProps.blockData as Block;
-      const startTime = event.start ? snapToSlot(event.start) : blockData.startTime;
-      const endTime = event.end ? snapToSlot(event.end) : blockData.endTime;
-      await updateBlock({
-        id: blockData.id,
-        data: {
-          ...blockData,
-          startTime,
-          endTime,
-        },
-      });
-    },
-    [updateBlock, snapToSlot]
-  );
+  const updateBlockTime = async (event: EventDropArg['event'] | EventResizeDoneArg['event']) => {
+    const blockData = event.extendedProps.blockData as Block;
+    const startTime = event.start ? snapToSlot(event.start) : blockData.startTime;
+    const endTime = event.end ? snapToSlot(event.end) : blockData.endTime;
+    await updateBlock({
+      id: blockData.id,
+      data: {
+        ...blockData,
+        startTime,
+        endTime,
+      },
+    });
+  };
 
-  const handleEventDrop = useCallback(
-    async (dropInfo: EventDropArg) => updateBlockTime(dropInfo.event),
-    [updateBlockTime]
-  );
+  const handleEventDrop = async (dropInfo: EventDropArg) => updateBlockTime(dropInfo.event);
 
-  const handleEventResize = useCallback(
-    async (resizeInfo: EventResizeDoneArg) => updateBlockTime(resizeInfo.event),
-    [updateBlockTime]
-  );
+  const handleEventResize = async (resizeInfo: EventResizeDoneArg) => updateBlockTime(resizeInfo.event);
 
   // --- カレンダーイベント表示 ---
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
     }),
   },
   plugins: [
-    react(),
+    react({
+      babel: {
+        plugins: [['babel-plugin-react-compiler', { target: '19' }]],
+      },
+    }),
     tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',


### PR DESCRIPTION
## Summary

React Compiler 1.0 を有効化し、既存の `useMemo` / `useCallback` を全削除しました。今後は原則として手動メモ化を書かず、コンパイラに任せます。

Closes #141

## やったこと

- **Compiler 有効化**: `babel-plugin-react-compiler@1.0.0` を `-E`（固定バージョン）で導入。`vite.config.ts` の `react()` に `babel.plugins` 経由で `{ target: '19' }` を指定
- **手動メモ化の全削除**: `useMemo` 6箇所 / `useCallback` 44箇所を削除（`React.memo` は元から未使用）
- **Biome 警告への対応**: `useCallback` を外した副作用で `useExhaustiveDependencies` が新規に3件出たため、`useEffect` 内でしか使わないハンドラは effect 内へインライン化して警告ゼロに
  - `components/Header.tsx` の `handleScroll`
  - `components/PageSwipeContainer.tsx` の `onSelect`
  - `dialogs/AddBlockDialog.tsx` の `resetForm`
- **規約更新**: `.claude/rules/frontend.md` / `docs/coding_standards.md` の「手動メモ化で再レンダリング防止」を「Compiler に任せて原則書かない」方針へ反転

## 設計判断（コードから読み取れない部分）

- **Vite プラグイン戦略**: 現状 Vite 6.3 + `@vitejs/plugin-react` 4.4（Babel 系）なので、`react({ babel: { plugins: [...] } })` オプションで直接プラグインを渡す形を採用。Vite 8 + plugin-react v6 以降で必要になる `@rolldown/plugin-babel` + `reactCompilerPreset` は不要（Vite 8 移行時に切り替える）
- **バージョン固定 (`-E`)**: 公式が推奨。Compiler のメモ化挙動はマイナー更新で変わり得るため、明示的な検証を経て上げる方針
- **ESLint は導入しない**: `eslint-plugin-react-compiler` は ESLint 専用だが、本プロジェクトは Biome 運用。Compiler のビルド時 bailout 診断に任せ、Biome の `useExhaustiveDependencies` は現状の `warn` のまま維持
- **削除と有効化を同一 PR**: 公式は「まず残す or 慎重にテストしてから削除」を推奨するが、`React.memo` が 0 件で影響範囲が把握しやすいこと、テストとビルド検証で回帰なしを確認できたため一括で実施

## 検証

- [x] `pnpm run type-check` 成功
- [x] `pnpm run lint:check` 警告 0（新規増加なし）
- [x] `pnpm run format:check` 差分なし
- [x] `pnpm --filter frontend run test` 17 files / 142 tests 全 pass
- [x] `pnpm --filter frontend run build` 成功、`[react-compiler] bailout` なし。ビルド成果物内に `useMemoCache` 等のコンパイラ痕跡を検出（Compiler が実際に動作している証跡）
- [ ] 実ブラウザでのゴールデンパス検証（Home → 旅程作成 → 編集モード → ドラッグ&ドロップ → 場所検索 → スワイプ切替 → PWA）
- [ ] React DevTools で任意のコンポーネントに「Memo ✨」バッジが付くこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス**
  * React Compilerを導入し、コンポーネントやフックの自動最適化に対応しました。
  * 手動メモ化に依存しない構成へ見直し、画面動作やデータ更新処理の挙動を維持したままコードを簡素化しました。
* **ドキュメント**
  * React Compilerを前提としたパフォーマンス最適化の開発ガイドラインを更新しました。
  * 必要な場合のみ手動最適化を使用する方針を明記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->