### PR TITLE
feat: 閲覧タイムラインに現在時刻インジケータを追加

### DIFF
--- a/frontend/src/components/blocks/types.ts
+++ b/frontend/src/components/blocks/types.ts
@@ -1,12 +1,13 @@
 import type { ScheduleBlock, TransportationBlock } from '@/types';
 
-// 共通で必須のpropsがあればここに追加
 export interface TransportationBlockComponentProps {
   block: TransportationBlock;
+  isNow?: boolean;
   className?: string;
 }
 
 export interface ScheduleBlockComponentProps {
   block: ScheduleBlock;
+  isNow?: boolean;
   className?: string;
 }

--- a/frontend/src/components/blocks/view/BlockScheduleView.tsx
+++ b/frontend/src/components/blocks/view/BlockScheduleView.tsx
@@ -1,6 +1,7 @@
 import { Globe, MapPin } from 'lucide-react';
 import { useRef, useState } from 'react';
 import angleDownIcon from '@/assets/icons/angle-down-white.svg';
+import { BlockNowBadge } from '@/components/timeline/NowIndicator';
 import { MarkdownViewer } from '@/components/ui/markdown';
 import { useResizeObserver } from '@/hooks/useResizeObserver';
 import { cn, getDomain } from '@/lib/utils';
@@ -22,7 +23,7 @@ const buildGoogleMapsUrl = (location: {
   return `https://www.google.com/maps/search/?api=1&query=${query}${placeIdParam}`;
 };
 
-export function BlockScheduleView({ block, className }: BlockScheduleViewProps) {
+export function BlockScheduleView({ block, isNow, className }: BlockScheduleViewProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isOverflowDetail, setIsOverflowDetail] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -55,12 +56,14 @@ export function BlockScheduleView({ block, className }: BlockScheduleViewProps) 
     <div
       ref={resizeRef}
       className={cn(
-        'flex w-full flex-col gap-2 rounded-lg bg-linear-to-r from-teal-400 px-4 py-2',
+        'relative flex w-full flex-col gap-2 rounded-lg bg-linear-to-r from-teal-400 px-4 py-2',
         isHovered ? 'to-teal-400' : 'to-teal-500',
         isHovered ? 'drop-shadow-xl' : 'drop-shadow-lg',
+        isNow && 'ring-2 ring-red-500',
         className
       )}
     >
+      {isNow && <BlockNowBadge />}
       <div className='font-bold text-14px text-white sm:text-16px'>{block.title}</div>
       {block.location && (
         <div className='flex flex-col gap-0.5'>

--- a/frontend/src/components/blocks/view/BlockTransportationView.tsx
+++ b/frontend/src/components/blocks/view/BlockTransportationView.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import angleDownIcon from '@/assets/icons/angle-down.svg';
+import { BlockNowBadge } from '@/components/timeline/NowIndicator';
 import { MarkdownViewer } from '@/components/ui/markdown';
 import { useResizeObserver } from '@/hooks/useResizeObserver';
 import { calculateDuration, cn } from '@/lib/utils';
@@ -10,7 +11,7 @@ interface BlockTransportationViewProps extends TransportationBlockComponentProps
 
 const MAX_DETAIL_HEIGHT = 72;
 
-export function BlockTransportationView({ block, className }: BlockTransportationViewProps) {
+export function BlockTransportationView({ block, isNow, className }: BlockTransportationViewProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isOverflowDetail, setIsOverflowDetail] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -45,12 +46,14 @@ export function BlockTransportationView({ block, className }: BlockTransportatio
     <div
       ref={resizeRef}
       className={cn(
-        'flex w-full flex-col gap-2 rounded-lg bg-gradient-to-r from-sky-50 px-2 py-2 sm:px-4',
+        'relative flex w-full flex-col gap-2 rounded-lg bg-gradient-to-r from-sky-50 px-2 py-2 sm:px-4',
         isHovered ? 'to-sky-50' : 'to-sky-100',
         isHovered ? 'drop-shadow-xl' : 'drop-shadow-lg',
+        isNow && 'ring-2 ring-red-500',
         className
       )}
     >
+      {isNow && <BlockNowBadge />}
       <div className='flex items-center gap-2'>
         <TransportationIcon type={block.transportationType} />
         <div className='font-bold text-14px text-neutral-800 sm:text-16px'>{block.title}</div>

--- a/frontend/src/components/timeline/GroupTimelineRow.tsx
+++ b/frontend/src/components/timeline/GroupTimelineRow.tsx
@@ -8,25 +8,35 @@ import type { OverlapGroup } from './ViewTimeline';
 interface GroupTimelineRowProps {
   group: OverlapGroup;
   isConnectedWithNext: boolean;
-  isLastItem: boolean;
+  /** この group より後ろに別の group が存在するか。endTime=null ブロックの trailing DottedLine 判定に使う。 */
+  hasFollowingGroup: boolean;
+  /** 現在時刻を含むブロックの id 集合。指定されたブロックに赤 ring / NOW バッジが付与される。 */
+  nowBlockIds?: ReadonlySet<number>;
 }
 
-const renderBlock = (block: Block) => {
+const renderBlock = (block: Block, isNow: boolean) => {
   switch (block.type) {
     case 'schedule':
-      return <BlockScheduleView block={block} />;
+      return <BlockScheduleView block={block} isNow={isNow} />;
     case 'transportation':
-      return <BlockTransportationView block={block} />;
+      return <BlockTransportationView block={block} isNow={isNow} />;
     default:
       return null;
   }
 };
 
-export function GroupTimelineRow({ group, isConnectedWithNext, isLastItem }: GroupTimelineRowProps) {
+export function GroupTimelineRow({
+  group,
+  isConnectedWithNext,
+  hasFollowingGroup,
+  nowBlockIds,
+}: GroupTimelineRowProps) {
   const hasSchedule = group.blocks.some(b => b.type === 'schedule');
   const themeColor = hasSchedule ? 'bg-teal-400' : 'bg-sky-200';
   // 2件以上のときだけグルーピングコンテナで囲む（単一ブロックはそのまま表示）
   const useContainer = group.blocks.length >= 2;
+
+  const isNow = (id: number) => nowBlockIds?.has(id) ?? false;
 
   return (
     <div className='contents'>
@@ -34,11 +44,11 @@ export function GroupTimelineRow({ group, isConnectedWithNext, isLastItem }: Gro
         startTime={group.groupStart}
         endTime={group.groupEnd}
         isConnectedWithNext={isConnectedWithNext}
-        isLastItem={isLastItem}
+        hasFollowingGroup={hasFollowingGroup}
         themeColor={themeColor}
       />
       <div className='flex flex-col gap-2 pb-4'>
-        {group.headerBlock && renderBlock(group.headerBlock)}
+        {group.headerBlock && renderBlock(group.headerBlock, isNow(group.headerBlock.id))}
 
         {group.containerBlocks.length > 0 &&
           (useContainer ? (
@@ -49,12 +59,12 @@ export function GroupTimelineRow({ group, isConnectedWithNext, isLastItem }: Gro
                     {formatTime(block.startTime)}
                     {block.endTime && `–${formatTime(block.endTime)}`}
                   </div>
-                  {renderBlock(block)}
+                  {renderBlock(block, isNow(block.id))}
                 </div>
               ))}
             </div>
           ) : (
-            group.containerBlocks.map(block => <div key={block.id}>{renderBlock(block)}</div>)
+            group.containerBlocks.map(block => <div key={block.id}>{renderBlock(block, isNow(block.id))}</div>)
           ))}
       </div>
     </div>

--- a/frontend/src/components/timeline/NowIndicator.stories.tsx
+++ b/frontend/src/components/timeline/NowIndicator.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NowIndicator } from './NowIndicator';
+
+const meta: Meta<typeof NowIndicator> = {
+  title: 'Components/Timeline/NowIndicator',
+  component: NowIndicator,
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    Story => (
+      <div className='grid w-full grid-cols-[auto_1fr] gap-x-4'>
+        <div className='text-neutral-400 text-sm'>[axis]</div>
+        <div className='text-neutral-400 text-sm'>[content]</div>
+        <div className='col-span-2'>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  argTypes: {
+    ratio: {
+      control: { type: 'range', min: 0, max: 1, step: 0.05 },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** デフォルト: 中央固定 */
+export const Default: Story = {
+  args: {},
+};
+
+/** 比率 0 (上端) */
+export const RatioTop: Story = {
+  args: {
+    ratio: 0,
+  },
+};
+
+/** 比率 0.5 (中央) */
+export const RatioCenter: Story = {
+  args: {
+    ratio: 0.5,
+  },
+};
+
+/** 比率 1 (下端) */
+export const RatioBottom: Story = {
+  args: {
+    ratio: 1,
+  },
+};

--- a/frontend/src/components/timeline/NowIndicator.tsx
+++ b/frontend/src/components/timeline/NowIndicator.tsx
@@ -1,0 +1,48 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * 矢印形の「NOW」バッジ。ラインと組み合わせて使う `NowIndicator` からも、
+ * ブロックコーナー用の `BlockNowBadge` からも共有される。
+ */
+export const NowBadge = ({ className }: { className?: string }) => (
+  <div
+    className={cn(
+      'select-none rounded-l-sm bg-red-500 py-0.5 pr-2 pl-1.5 font-bold text-10px text-white [clip-path:polygon(0_0,calc(100%_-_6px)_0,100%_50%,calc(100%_-_6px)_100%,0_100%)]',
+      className
+    )}
+  >
+    NOW
+  </div>
+);
+
+const clampRatio = (r: number): number => Math.min(1, Math.max(0, r));
+
+interface NowIndicatorProps {
+  /** 縦方向の位置比率 (0=上端 / 1=下端)。undefined なら中央固定。 */
+  ratio?: number;
+  /** ルートに追加するクラス。`col-span-2` (行モード) や `absolute inset-0` (オーバーレイモード) を指定する。 */
+  className?: string;
+}
+
+/**
+ * 現在時刻を示す赤いインジケータ。
+ * 左端に矢印形の「NOW」バッジ、右側に赤ラインが伸びる。
+ * `ratio` に応じて縦方向の高さ内で位置が変わる。
+ */
+export const NowIndicator = ({ ratio, className }: NowIndicatorProps) => {
+  const clamped = clampRatio(ratio ?? 0.5);
+
+  return (
+    <div className={cn('flex h-8 flex-col', className)} data-testid='now-indicator'>
+      <div style={{ flexGrow: clamped }} aria-hidden />
+      <div className='flex items-center gap-1'>
+        <NowBadge />
+        <div className='h-0.5 flex-1 bg-red-500' />
+      </div>
+      <div style={{ flexGrow: 1 - clamped }} aria-hidden />
+    </div>
+  );
+};
+
+/** ブロックの左上角に貼り付けて「今このブロック中」を示す NOW バッジ。 */
+export const BlockNowBadge = () => <NowBadge className='-top-2.5 -left-1 absolute z-10' />;

--- a/frontend/src/components/timeline/Timeline.stories.tsx
+++ b/frontend/src/components/timeline/Timeline.stories.tsx
@@ -208,3 +208,144 @@ export const OverlappingWithGap: Story = {
     type: 'view',
   },
 };
+
+// --- 現在時刻インジケータ ---
+
+const nowSampleBlocks: Block[] = [
+  {
+    id: 1,
+    type: 'schedule',
+    title: '朝食',
+    startTime: new Date(2024, 0, 1, 8, 0),
+    endTime: new Date(2024, 0, 1, 9, 0),
+    pageId: 1,
+    location: null,
+  },
+  {
+    id: 2,
+    type: 'transportation',
+    transportationType: 'car',
+    title: '観光地へ移動',
+    startTime: new Date(2024, 0, 1, 9, 0),
+    endTime: new Date(2024, 0, 1, 10, 0),
+    pageId: 1,
+    location: null,
+    destinationLocation: null,
+  },
+  {
+    id: 3,
+    type: 'schedule',
+    title: '観光',
+    startTime: new Date(2024, 0, 1, 10, 0),
+    endTime: new Date(2024, 0, 1, 12, 0),
+    pageId: 1,
+    location: null,
+  },
+  {
+    id: 4,
+    type: 'schedule',
+    title: 'ランチ',
+    startTime: new Date(2024, 0, 1, 13, 0),
+    endTime: new Date(2024, 0, 1, 14, 0),
+    pageId: 1,
+    location: null,
+  },
+];
+
+/** NOW: ブロック時間内 (10:00-12:00 の観光中、now=11:00) → 該当ブロックに赤 ring + NOW バッジ */
+export const NowInsideBlock: Story = {
+  args: {
+    blocks: nowSampleBlocks,
+    type: 'view',
+    pageDate: new Date(2024, 0, 1),
+    now: new Date(2024, 0, 1, 11, 0),
+  },
+};
+
+/** NOW: gap 内 (12:00-13:00 の間、now=12:30) → gap 中央にライン */
+export const NowInGap: Story = {
+  args: {
+    blocks: nowSampleBlocks,
+    type: 'view',
+    pageDate: new Date(2024, 0, 1),
+    now: new Date(2024, 0, 1, 12, 30),
+  },
+};
+
+/** NOW: 旅程開始前 (now=6:00, 最初のブロック=8:00) → 先頭に張り付き */
+export const NowBeforeStart: Story = {
+  args: {
+    blocks: nowSampleBlocks,
+    type: 'view',
+    pageDate: new Date(2024, 0, 1),
+    now: new Date(2024, 0, 1, 6, 0),
+  },
+};
+
+/** NOW: 旅程終了後 (now=18:00, 最後のブロック終了=14:00) → 末尾に張り付き */
+export const NowAfterEnd: Story = {
+  args: {
+    blocks: nowSampleBlocks,
+    type: 'view',
+    pageDate: new Date(2024, 0, 1),
+    now: new Date(2024, 0, 1, 18, 0),
+  },
+};
+
+/** NOW: 末尾ブロックが endTime=null + bottom-stuck (末尾ブロックからの inline 点線が出ないことを確認) */
+export const NowAfterEndOfNullBlock: Story = {
+  args: {
+    blocks: [
+      {
+        id: 1,
+        type: 'schedule',
+        title: '朝食',
+        startTime: new Date(2024, 0, 1, 8, 0),
+        endTime: new Date(2024, 0, 1, 9, 0),
+        pageId: 1,
+        location: null,
+      },
+      {
+        id: 2,
+        type: 'schedule',
+        title: '点の予定 (最後)',
+        startTime: new Date(2024, 0, 1, 15, 0),
+        endTime: null,
+        pageId: 1,
+        location: null,
+      },
+    ] satisfies Block[],
+    type: 'view',
+    pageDate: new Date(2024, 0, 1),
+    now: new Date(2024, 0, 1, 18, 0),
+  },
+};
+
+/** NOW: endTime=null ブロック後の暗黙 gap */
+export const NowInImplicitGap: Story = {
+  args: {
+    blocks: [
+      {
+        id: 1,
+        type: 'schedule',
+        title: 'お土産購入',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: null,
+        pageId: 1,
+        location: null,
+      },
+      {
+        id: 2,
+        type: 'schedule',
+        title: '夕食',
+        startTime: new Date(2024, 0, 1, 18, 0),
+        endTime: new Date(2024, 0, 1, 19, 0),
+        pageId: 1,
+        location: null,
+      },
+    ] satisfies Block[],
+    type: 'view',
+    pageDate: new Date(2024, 0, 1),
+    now: new Date(2024, 0, 1, 14, 0),
+  },
+};

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -4,13 +4,15 @@ import { ViewTimeline } from './ViewTimeline';
 interface TimelineProps {
   blocks: Block[];
   type: 'view' | 'edit';
+  pageDate?: Date | null;
+  now?: Date | null;
   className?: string;
 }
 
-export function Timeline({ blocks, type, className }: TimelineProps) {
+export function Timeline({ blocks, type, pageDate, now, className }: TimelineProps) {
   switch (type) {
     case 'view':
-      return <ViewTimeline blocks={blocks} className={className} />;
+      return <ViewTimeline blocks={blocks} pageDate={pageDate} now={now} className={className} />;
     default:
       return null;
   }

--- a/frontend/src/components/timeline/TimelineAxis.tsx
+++ b/frontend/src/components/timeline/TimelineAxis.tsx
@@ -6,11 +6,18 @@ interface TimelineAxisProps {
   startTime: Date;
   endTime: Date | null;
   isConnectedWithNext: boolean;
-  isLastItem: boolean;
+  /** この group より後ろに別の group が存在するか。endTime=null の inline DottedLine 判定に使う。 */
+  hasFollowingGroup: boolean;
   themeColor: string;
 }
 
-export function TimelineAxis({ startTime, endTime, isConnectedWithNext, isLastItem, themeColor }: TimelineAxisProps) {
+export function TimelineAxis({
+  startTime,
+  endTime,
+  isConnectedWithNext,
+  hasFollowingGroup,
+  themeColor,
+}: TimelineAxisProps) {
   return (
     <div className='flex flex-row gap-2'>
       <div className='flex flex-col justify-between'>
@@ -28,7 +35,7 @@ export function TimelineAxis({ startTime, endTime, isConnectedWithNext, isLastIt
         {endTime ? (
           <div className={cn('-my-4 h-full w-2', themeColor)}></div>
         ) : (
-          !isLastItem && <DottedLine className='h-full self-end' />
+          hasFollowingGroup && <DottedLine className='h-full self-end' />
         )}
         {!isConnectedWithNext && endTime && (
           <div className={cn('h-6 w-6 shrink-0 rounded-full sm:h-8 sm:w-8', themeColor)} />

--- a/frontend/src/components/timeline/ViewTimeline.test.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.test.tsx
@@ -490,4 +490,31 @@ describe('buildTimelineItems - NOW 挿入位置', () => {
     expect(items.some(item => item.type === 'now')).toBe(false);
     expect(items.find(item => item.type === 'gap')?.ratio).toBeUndefined();
   });
+
+  it('ブロックと now の年月日が異なっても、時刻がブロック時間内なら in-block と判定される (anchor rebase)', () => {
+    // ブロックは 2020-01-01 の anchor 日、実時刻 (now) は 2026-07-09
+    // block.ts のスキーマコメント通り、date 部分は無視して時刻のみで判定されるはず
+    const oldAnchor = (h: number, m = 0) => new Date(2020, 0, 1, h, m);
+    const a = { ...makeSchedule(1, at(10), at(11)), startTime: oldAnchor(10), endTime: oldAnchor(11) };
+    const nowInBlock = new Date(2026, 6, 9, 10, 30);
+    const items = buildFromBlocks([a as unknown as ScheduleBlock], nowInBlock);
+
+    // in-block なので独立 NOW 行は追加されない
+    expect(items.some(item => item.type === 'now')).toBe(false);
+    // group item に in-block 検出結果が乗っている
+    const groupItem = items.find(item => item.type === 'group');
+    expect(groupItem?.nowBlockIds?.has(1)).toBe(true);
+  });
+
+  it('ブロックと now の年月日が異なっても、gap 内の時刻なら gap ratio が計算される (anchor rebase)', () => {
+    const oldAnchor = (h: number, m = 0) => new Date(2020, 0, 1, h, m);
+    const a = { ...makeSchedule(1, at(10), at(11)), startTime: oldAnchor(10), endTime: oldAnchor(11) };
+    const b = { ...makeSchedule(2, at(13), at(14)), startTime: oldAnchor(13), endTime: oldAnchor(14) };
+    // 実時刻は 6 年後の 2026-07-09、時刻は 12:00 (gap 11:00〜13:00 の中央)
+    const nowInGap = new Date(2026, 6, 9, 12, 0);
+    const items = buildFromBlocks([a, b] as unknown as ScheduleBlock[], nowInGap);
+
+    const gapItem = items.find(item => item.type === 'gap');
+    expect(gapItem?.ratio).toBeCloseTo(0.5, 5);
+  });
 });

--- a/frontend/src/components/timeline/ViewTimeline.test.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.test.tsx
@@ -1,18 +1,23 @@
 import { render, screen, within } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import type { ScheduleBlock, TransportationBlock } from '@/types/block';
-import { groupByStartTime, ViewTimeline } from './ViewTimeline';
+import { sortBlocks } from '@/lib/sortBlocks';
+import type { Block, ScheduleBlock, TransportationBlock } from '@/types/block';
+import { buildTimelineItems, groupByStartTime, ViewTimeline } from './ViewTimeline';
 
 vi.mock('../blocks/view/BlockScheduleView', () => ({
-  BlockScheduleView: ({ block }: { block: ScheduleBlock }) => (
-    <div data-testid={`schedule-${block.id}`}>{block.title}</div>
+  BlockScheduleView: ({ block, isNow }: { block: ScheduleBlock; isNow?: boolean }) => (
+    <div data-testid={`schedule-${block.id}`} data-is-now={isNow ? 'true' : 'false'}>
+      {block.title}
+    </div>
   ),
 }));
 
 vi.mock('../blocks/view/BlockTransportationView', () => ({
-  BlockTransportationView: ({ block }: { block: TransportationBlock }) => (
-    <div data-testid={`transportation-${block.id}`}>{block.title}</div>
+  BlockTransportationView: ({ block, isNow }: { block: TransportationBlock; isNow?: boolean }) => (
+    <div data-testid={`transportation-${block.id}`} data-is-now={isNow ? 'true' : 'false'}>
+      {block.title}
+    </div>
   ),
 }));
 
@@ -316,5 +321,173 @@ describe('ViewTimeline', () => {
       expect(screen.getByText('09:05')).toBeInTheDocument();
       expect(screen.getByText('09:30')).toBeInTheDocument();
     });
+  });
+
+  describe('現在時刻インジケータ', () => {
+    const pageDate = new Date(2026, 0, 1);
+
+    it('pageDate と now の日付が異なる場合、NOW インジケータは表示されない', () => {
+      const block = makeSchedule(1, at(9), at(10));
+      render(<ViewTimeline blocks={[block]} pageDate={pageDate} now={new Date(2026, 0, 2, 10, 0)} />);
+
+      expect(screen.queryByTestId('now-indicator')).not.toBeInTheDocument();
+    });
+
+    it('pageDate が null の場合、NOW インジケータは表示されない', () => {
+      const block = makeSchedule(1, at(9), at(10));
+      render(<ViewTimeline blocks={[block]} pageDate={null} now={at(9, 30)} />);
+
+      expect(screen.queryByTestId('now-indicator')).not.toBeInTheDocument();
+    });
+
+    it('now がブロック時間内のとき、そのブロックに isNow=true が渡される', () => {
+      const a = makeSchedule(1, at(9), at(10));
+      const b = makeSchedule(2, at(11), at(12));
+      render(<ViewTimeline blocks={[a, b]} pageDate={pageDate} now={at(9, 30)} />);
+
+      expect(screen.getByTestId('schedule-1')).toHaveAttribute('data-is-now', 'true');
+      expect(screen.getByTestId('schedule-2')).toHaveAttribute('data-is-now', 'false');
+      // ブロック内 NOW ではラインは表示されない
+      expect(screen.queryByTestId('now-indicator')).not.toBeInTheDocument();
+    });
+
+    it('now が明示的 gap 内のとき、点線を保ちつつ NOW オーバーレイが重なる', () => {
+      const a = makeSchedule(1, at(9), at(10));
+      const b = makeSchedule(2, at(12), at(13));
+      const { container } = render(<ViewTimeline blocks={[a, b]} pageDate={pageDate} now={at(11, 0)} />);
+
+      // NOW オーバーレイ
+      expect(screen.getByTestId('now-indicator')).toBeInTheDocument();
+      // 点線は残る (border-dashed は DottedLine の 2 本)
+      expect(countBorderDashed(container)).toBe(2);
+      // ブロックは isNow=false
+      expect(screen.getByTestId('schedule-1')).toHaveAttribute('data-is-now', 'false');
+      expect(screen.getByTestId('schedule-2')).toHaveAttribute('data-is-now', 'false');
+    });
+
+    it('now が最初のブロックより前のとき、NOW が先頭に挿入される', () => {
+      const block = makeSchedule(1, at(10), at(11));
+      const { container } = render(<ViewTimeline blocks={[block]} pageDate={pageDate} now={at(8, 0)} />);
+
+      const root = container.firstChild as HTMLElement;
+      expect(root.firstElementChild).toHaveAttribute('data-testid', 'now-indicator');
+    });
+
+    it('now が最後のブロックより後のとき、NOW が末尾に挿入される', () => {
+      const block = makeSchedule(1, at(10), at(11));
+      const { container } = render(<ViewTimeline blocks={[block]} pageDate={pageDate} now={at(22, 0)} />);
+
+      const root = container.firstChild as HTMLElement;
+      expect(root.lastElementChild).toHaveAttribute('data-testid', 'now-indicator');
+    });
+
+    it('endTime=null ブロック後の暗黙 gap に now が入るとき、点線を残しつつ NOW オーバーレイが重なる', () => {
+      const a = makeSchedule(1, at(9), null);
+      const b = makeSchedule(2, at(12), at(13));
+      const { container } = render(<ViewTimeline blocks={[a, b]} pageDate={pageDate} now={at(10, 30)} />);
+
+      // NOW オーバーレイ
+      expect(screen.getByTestId('now-indicator')).toBeInTheDocument();
+      // 直前グループの inline DottedLine (2 dashed) + gap item の DottedLine (2 dashed) = 4 個
+      expect(countBorderDashed(container)).toBe(4);
+    });
+
+    it('重複した複数ブロックが同時刻を含むとき、全ブロックに isNow=true が付く', () => {
+      const a = makeSchedule(1, at(10), at(14));
+      const b = makeSchedule(2, at(11), at(13));
+      render(<ViewTimeline blocks={[a, b]} pageDate={pageDate} now={at(12, 0)} />);
+
+      expect(screen.getByTestId('schedule-1')).toHaveAttribute('data-is-now', 'true');
+      expect(screen.getByTestId('schedule-2')).toHaveAttribute('data-is-now', 'true');
+    });
+
+    it('ブロックが空でも pageDate=today の場合 NOW インジケータが1つ表示される', () => {
+      render(<ViewTimeline blocks={[]} pageDate={pageDate} now={at(10, 0)} />);
+
+      expect(screen.getByTestId('now-indicator')).toBeInTheDocument();
+    });
+
+    it('末尾ブロックが endTime=null で NOW が bottom-stuck のとき、末尾ブロックに inline 点線を描画しない', () => {
+      // 末尾は endTime=null の点イベント。now はそれより後（bottom-stuck）。
+      // 末尾ブロック直後は now-bottom 行しかないので、末尾ブロックから伸びる inline DottedLine は不要。
+      const a = makeSchedule(1, at(10), at(11));
+      const b = makeSchedule(2, at(15), null);
+      const { container } = render(<ViewTimeline blocks={[a, b]} pageDate={pageDate} now={at(18, 0)} />);
+
+      // NOW インジケータ (bottom-stuck)
+      expect(screen.getByTestId('now-indicator')).toBeInTheDocument();
+      // gap 1 個 (a と b の間) = border-dashed 2 個。末尾 b からの inline DottedLine は 0 個。
+      expect(countBorderDashed(container)).toBe(2);
+    });
+  });
+});
+
+describe('buildTimelineItems - NOW 挿入位置', () => {
+  const at = (h: number, m = 0) => new Date(2026, 0, 1, h, m);
+  const makeSchedule = (id: number, start: Date, end: Date | null): ScheduleBlock => ({
+    id,
+    type: 'schedule',
+    title: `S${id}`,
+    startTime: start,
+    endTime: end,
+    detail: null,
+    pageId: 1,
+    location: null,
+  });
+  const buildFromBlocks = (blocks: Block[], now: Date | null) =>
+    buildTimelineItems(groupByStartTime(sortBlocks(blocks)), now);
+
+  it('明示的 gap 内で ratio が gap アイテムに乗って計算される', () => {
+    const a = makeSchedule(1, at(10), at(11));
+    const b = makeSchedule(2, at(13), at(14));
+    // gap: 11:00 〜 13:00 (2h), now = 12:00 → ratio 0.5
+    const items = buildFromBlocks([a, b], at(12, 0));
+
+    const gapItem = items.find(item => item.type === 'gap');
+    expect(gapItem).toBeDefined();
+    expect(gapItem?.ratio).toBeCloseTo(0.5, 5);
+    // 独立した 'now' 行は追加されない（overlay として同じ gap 上に描画）
+    expect(items.some(item => item.type === 'now')).toBe(false);
+  });
+
+  it('明示的 gap の 25% 時点で ratio が 0.25 になる', () => {
+    const a = makeSchedule(1, at(10), at(11));
+    const b = makeSchedule(2, at(15), at(16));
+    // gap: 11:00 〜 15:00 (4h), now = 12:00 → ratio 0.25
+    const items = buildFromBlocks([a, b], at(12, 0));
+
+    const gapItem = items.find(item => item.type === 'gap');
+    expect(gapItem?.ratio).toBeCloseTo(0.25, 5);
+  });
+
+  it('gap 内に NOW がない場合、gap.ratio は undefined', () => {
+    const a = makeSchedule(1, at(10), at(11));
+    const b = makeSchedule(2, at(13), at(14));
+    // now は範囲外
+    const items = buildFromBlocks([a, b], at(20, 0));
+
+    const gapItem = items.find(item => item.type === 'gap');
+    expect(gapItem?.ratio).toBeUndefined();
+  });
+
+  it('暗黙 gap (endTime=null 後) でも gap item + ratio で処理される', () => {
+    const a = makeSchedule(1, at(9), null);
+    const b = makeSchedule(2, at(12), at(13));
+    // gap: 9:00 〜 12:00 (3h), now = 10:30 → ratio 0.5
+    const items = buildFromBlocks([a, b], at(10, 30));
+
+    const gapItem = items.find(item => item.type === 'gap');
+    expect(gapItem).toBeDefined();
+    expect(gapItem?.ratio).toBeCloseTo(0.5, 5);
+    // 独立した 'now' 行は追加されない
+    expect(items.some(item => item.type === 'now')).toBe(false);
+  });
+
+  it('now=null のとき NOW 系アイテムは一切追加されない', () => {
+    const block = makeSchedule(1, at(9), at(10));
+    const items = buildFromBlocks([block], null);
+
+    expect(items.some(item => item.type === 'now')).toBe(false);
+    expect(items.find(item => item.type === 'gap')?.ratio).toBeUndefined();
   });
 });

--- a/frontend/src/components/timeline/ViewTimeline.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.tsx
@@ -91,6 +91,22 @@ export const groupByStartTime = (sortedBlocks: Block[]): OverlapGroup[] => {
 
 // --- NOW 判定ヘルパー ---
 
+/**
+ * `source` の時刻 (H:M:S.ms) を `dateSource` の年月日にリベースした Date を返す。
+ * ブロック時刻は年月日部分が任意 anchor 日なので (block.ts コメント参照)、`now` を
+ * 同じ anchor 日にそろえてから `.getTime()` 比較を行うために使う。
+ */
+const rebaseTimeOntoDate = (source: Date, dateSource: Date): Date =>
+  new Date(
+    dateSource.getFullYear(),
+    dateSource.getMonth(),
+    dateSource.getDate(),
+    source.getHours(),
+    source.getMinutes(),
+    source.getSeconds(),
+    source.getMilliseconds()
+  );
+
 /** 現在時刻を含むブロック（endTime あり、startTime ≤ now ≤ endTime）の id 集合を全ブロックから求める。 */
 const collectNowBlockIds = (groups: OverlapGroup[], nowTime: number): ReadonlySet<number> => {
   const ids = new Set<number>();
@@ -112,7 +128,12 @@ const collectNowBlockIds = (groups: OverlapGroup[], nowTime: number): ReadonlySe
  */
 export const buildTimelineItems = (groups: OverlapGroup[], now: Date | null = null): TimelineItem[] => {
   const items: TimelineItem[] = [];
-  const nowTime = now?.getTime() ?? null;
+  // ブロック側は「時刻データ + 任意 anchor 日」で持っているため、実時刻の now をそのまま
+  // .getTime() 比較すると年月日ズレの影響で常に bottom-stuck 側に落ちてしまう。
+  // 先頭ブロックの anchor 日にリベースしてから比較する。
+  const anchor = groups[0]?.blocks[0]?.startTime;
+  const rebasedNow = now != null && anchor != null ? rebaseTimeOntoDate(now, anchor) : now;
+  const nowTime = rebasedNow?.getTime() ?? null;
 
   const nowBlockIds = nowTime != null ? collectNowBlockIds(groups, nowTime) : null;
   const isInBlock = (nowBlockIds?.size ?? 0) > 0;

--- a/frontend/src/components/timeline/ViewTimeline.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { isSameLocalDate } from '@/lib/date';
 import { sortBlocks } from '@/lib/sortBlocks';
 import { cn } from '@/lib/utils';
 import type { Block } from '@/types/block';
@@ -14,15 +15,37 @@ export interface OverlapGroup {
   groupEnd: Date | null; // 全ブロックの max endTime（全 null なら null）
 }
 
-export interface TimelineItem {
+interface GroupItem {
+  type: 'group';
   id: string;
-  type: 'group' | 'gap';
-  group?: OverlapGroup;
-  isConnectedWithNextGroup?: boolean;
+  group: OverlapGroup;
+  isConnectedWithNextGroup: boolean;
+  /** この group より後ろに別の group が存在するか。endTime=null の trailing DottedLine 判定に使う。 */
+  hasFollowingGroup: boolean;
+  /** 現在時刻を含むブロック id 集合（全 group で共通の Set を共有）。 */
+  nowBlockIds?: ReadonlySet<number>;
 }
+
+interface GapItem {
+  type: 'gap';
+  id: string;
+  /** gap 上に絶対配置する NOW オーバーレイの縦位置比率 (0〜1)。未設定なら NOW を重ねない。 */
+  ratio?: number;
+}
+
+interface NowItem {
+  type: 'now';
+  id: string;
+}
+
+export type TimelineItem = GroupItem | GapItem | NowItem;
 
 interface ViewTimelineProps {
   blocks: Block[];
+  /** そのページの日付。今日と一致する場合のみ NOW インジケータを表示する。 */
+  pageDate?: Date | null;
+  /** 現在時刻。省略時は NOW インジケータを表示しない。 */
+  now?: Date | null;
   className?: string;
 }
 
@@ -66,12 +89,41 @@ export const groupByStartTime = (sortedBlocks: Block[]): OverlapGroup[] => {
   return groups;
 };
 
+// --- NOW 判定ヘルパー ---
+
+/** 現在時刻を含むブロック（endTime あり、startTime ≤ now ≤ endTime）の id 集合を全ブロックから求める。 */
+const collectNowBlockIds = (groups: OverlapGroup[], nowTime: number): ReadonlySet<number> => {
+  const ids = new Set<number>();
+  for (const g of groups) {
+    for (const b of g.blocks) {
+      if (b.endTime != null && b.startTime.getTime() <= nowTime && nowTime <= b.endTime.getTime()) {
+        ids.add(b.id);
+      }
+    }
+  }
+  return ids;
+};
+
 // --- タイムラインアイテム構築 ---
 
-const buildTimelineItems = (blocks: Block[]): TimelineItem[] => {
-  const sorted = sortBlocks(blocks);
-  const groups = groupByStartTime(sorted);
+/**
+ * ソート済み groups と現在時刻から TimelineItem 列を構築する。
+ * `groups` の再生成 (sort/group) を抑えるため、呼び出し側で memoize しておくのを想定。
+ */
+export const buildTimelineItems = (groups: OverlapGroup[], now: Date | null = null): TimelineItem[] => {
   const items: TimelineItem[] = [];
+  const nowTime = now?.getTime() ?? null;
+
+  const nowBlockIds = nowTime != null ? collectNowBlockIds(groups, nowTime) : null;
+  const isInBlock = (nowBlockIds?.size ?? 0) > 0;
+
+  // in-block のときはブロックに赤 ring/バッジで表現するため、追加の NOW 行を挿入しない
+  let nowInserted = nowTime == null || isInBlock;
+
+  if (!nowInserted && groups.length > 0 && nowTime != null && nowTime < groups[0].groupStart.getTime()) {
+    items.push({ type: 'now', id: 'now-top' });
+    nowInserted = true;
+  }
 
   let maxEndTime = -Infinity;
 
@@ -79,32 +131,50 @@ const buildTimelineItems = (blocks: Block[]): TimelineItem[] => {
     const currentGroup = groups[i];
     const nextGroup = i < groups.length - 1 ? groups[i + 1] : null;
 
-    // gap 判定: 前のグループの maxEndTime と現在グループの startTime を比較
-    // 直前のグループが groupEnd=null の場合、そのコンポーネント自身が DottedLine を描画するため gap は不要
-    if (i > 0 && maxEndTime !== -Infinity && groups[i - 1].groupEnd !== null) {
-      if (currentGroup.groupStart.getTime() > maxEndTime) {
-        items.push({
-          type: 'gap',
-          id: `gap-${i}`,
-        });
-      }
+    // 直前グループが groupEnd=null の場合、そのグループの inline DottedLine が gap を埋めるので独立 gap 不要
+    const hasExplicitGap =
+      i > 0 &&
+      maxEndTime !== -Infinity &&
+      groups[i - 1].groupEnd !== null &&
+      currentGroup.groupStart.getTime() > maxEndTime;
+
+    const nowInPreBoundary =
+      !nowInserted &&
+      nowTime != null &&
+      i > 0 &&
+      maxEndTime !== -Infinity &&
+      nowTime >= maxEndTime &&
+      nowTime < currentGroup.groupStart.getTime();
+
+    if (nowInPreBoundary && nowTime != null) {
+      // 明示的/暗黙どちらの gap でも、gap 上に absolute overlay で NOW を重ねる (点線を途切れさせない)
+      const gapDuration = currentGroup.groupStart.getTime() - maxEndTime;
+      const ratio = gapDuration > 0 ? (nowTime - maxEndTime) / gapDuration : 0.5;
+      items.push({ type: 'gap', id: `gap-${i}`, ratio });
+      nowInserted = true;
+    } else if (hasExplicitGap) {
+      items.push({ type: 'gap', id: `gap-${i}` });
     }
 
-    // maxEndTime を更新
     const currentEnd = currentGroup.groupEnd?.getTime() ?? currentGroup.groupStart.getTime();
     maxEndTime = Math.max(maxEndTime, currentEnd);
 
-    // isConnected 判定
-    const isConnectedWithNextGroup = nextGroup
-      ? nextGroup.groupStart.getTime() === currentGroup.groupEnd?.getTime()
-      : false;
+    const isConnectedWithNextGroup =
+      nextGroup != null && nextGroup.groupStart.getTime() === currentGroup.groupEnd?.getTime();
 
     items.push({
       type: 'group',
       id: `group-${currentGroup.blocks.map(b => b.id).join('-')}`,
       group: currentGroup,
       isConnectedWithNextGroup,
+      hasFollowingGroup: nextGroup != null,
+      nowBlockIds: nowBlockIds ?? undefined,
     });
+  }
+
+  // 末尾より後（旅程終了後）。空タイムラインでは maxEndTime=-Infinity のままこの分岐で処理される。
+  if (!nowInserted && nowTime != null && nowTime > maxEndTime) {
+    items.push({ type: 'now', id: 'now-bottom' });
   }
 
   return items;
@@ -112,13 +182,20 @@ const buildTimelineItems = (blocks: Block[]): TimelineItem[] => {
 
 // --- コンポーネント ---
 
-export function ViewTimeline({ blocks, className }: ViewTimelineProps) {
-  const timelineItems = useMemo(() => buildTimelineItems(blocks), [blocks]);
+export function ViewTimeline({ blocks, pageDate, now, className }: ViewTimelineProps) {
+  const effectiveNow = useMemo(() => {
+    if (!(pageDate && now)) return null;
+    return isSameLocalDate(pageDate, now) ? now : null;
+  }, [pageDate, now]);
+
+  // blocks の並び替え・グループ化は now に依存しないので、tick 毎に破棄されないよう分けて memo する
+  const groups = useMemo(() => groupByStartTime(sortBlocks(blocks)), [blocks]);
+  const timelineItems = useMemo(() => buildTimelineItems(groups, effectiveNow), [groups, effectiveNow]);
 
   return (
     <div className={cn('grid w-full grid-cols-[auto_1fr] gap-x-4', className)}>
-      {timelineItems.map((item, index) => (
-        <ViewTimelineItem key={item.id} item={item} isLastItem={index === timelineItems.length - 1} />
+      {timelineItems.map(item => (
+        <ViewTimelineItem key={item.id} item={item} />
       ))}
     </div>
   );

--- a/frontend/src/components/timeline/ViewTimelineItem.tsx
+++ b/frontend/src/components/timeline/ViewTimelineItem.tsx
@@ -1,20 +1,25 @@
 import { DottedLine } from './DottedLine';
 import { GroupTimelineRow } from './GroupTimelineRow';
+import { NowIndicator } from './NowIndicator';
 import type { TimelineItem } from './ViewTimeline';
 
 interface ViewTimelineItemProps {
   item: TimelineItem;
-  isLastItem: boolean;
 }
 
-export function ViewTimelineItem({ item, isLastItem }: ViewTimelineItemProps) {
+export function ViewTimelineItem({ item }: ViewTimelineItemProps) {
   if (item.type === 'gap') {
     return (
-      <div className='contents'>
+      <div className='relative col-span-2 grid h-8 grid-cols-subgrid'>
         <DottedLine />
         <div />
+        {item.ratio != null && <NowIndicator ratio={item.ratio} className='pointer-events-none absolute inset-0' />}
       </div>
     );
+  }
+
+  if (item.type === 'now') {
+    return <NowIndicator className='col-span-2' />;
   }
 
   const group = item.group;
@@ -24,7 +29,8 @@ export function ViewTimelineItem({ item, isLastItem }: ViewTimelineItemProps) {
     <GroupTimelineRow
       group={group}
       isConnectedWithNext={item.isConnectedWithNextGroup ?? false}
-      isLastItem={isLastItem}
+      hasFollowingGroup={item.hasFollowingGroup ?? false}
+      nowBlockIds={item.nowBlockIds}
     />
   );
 }

--- a/frontend/src/hooks/useCurrentTime.test.ts
+++ b/frontend/src/hooks/useCurrentTime.test.ts
@@ -29,7 +29,8 @@ describe('useCurrentTime', () => {
   });
 
   it('visibilitychange で visible になった時に時刻が更新される', () => {
-    const { result } = renderHook(() => useCurrentTime());
+    // interval を非現実的な長さにして、時刻更新が visibilitychange 経由でしか起きないようにする
+    const { result } = renderHook(() => useCurrentTime({ intervalMs: 60 * 60 * 1000 }));
     const initial = result.current!.getTime();
 
     act(() => {
@@ -38,7 +39,7 @@ describe('useCurrentTime', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
 
-    expect(result.current!.getTime()).toBeGreaterThanOrEqual(initial + 5 * 60_000);
+    expect(result.current!.getTime()).toBe(initial + 5 * 60_000);
   });
 
   it('アンマウント時に interval と listener がクリーンアップされる', () => {

--- a/frontend/src/hooks/useCurrentTime.test.ts
+++ b/frontend/src/hooks/useCurrentTime.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCurrentTime } from './useCurrentTime';
+
+describe('useCurrentTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-09T10:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('マウント時に現在時刻を返す', () => {
+    const { result } = renderHook(() => useCurrentTime());
+    expect(result.current?.toISOString()).toBe(new Date('2026-07-09T10:00:00').toISOString());
+  });
+
+  it('interval 経過ごとに時刻が更新される', () => {
+    const { result } = renderHook(() => useCurrentTime({ intervalMs: 60_000 }));
+    const initial = result.current!.getTime();
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(result.current!.getTime()).toBe(initial + 60_000);
+  });
+
+  it('visibilitychange で visible になった時に時刻が更新される', () => {
+    const { result } = renderHook(() => useCurrentTime());
+    const initial = result.current!.getTime();
+
+    act(() => {
+      vi.advanceTimersByTime(5 * 60_000);
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(result.current!.getTime()).toBeGreaterThanOrEqual(initial + 5 * 60_000);
+  });
+
+  it('アンマウント時に interval と listener がクリーンアップされる', () => {
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    const removeListenerSpy = vi.spyOn(document, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useCurrentTime());
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(removeListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+  });
+
+  it('enabled=false のとき null を返し interval を設定しない', () => {
+    const setIntervalSpy = vi.spyOn(global, 'setInterval');
+
+    const { result } = renderHook(() => useCurrentTime({ enabled: false }));
+
+    expect(result.current).toBeNull();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useCurrentTime.ts
+++ b/frontend/src/hooks/useCurrentTime.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+interface UseCurrentTimeOptions {
+  /** false の場合は tick を停止し、常に null を返す（非 today ページ等での無駄な再レンダー抑止用）。 */
+  enabled?: boolean;
+  /** tick 間隔 (ms)。デフォルト 60_000。 */
+  intervalMs?: number;
+}
+
+/**
+ * 現在時刻を返すフック。
+ * - マウント時に取得
+ * - `visibilitychange` でタブ復帰時に再取得（PWA でロック→復帰などを想定）
+ * - `intervalMs` 間隔で再取得（デフォルト 60 秒）
+ * - `enabled: false` の場合は購読も setState も行わず null を返す
+ */
+export const useCurrentTime = ({ enabled = true, intervalMs = 60_000 }: UseCurrentTimeOptions = {}): Date | null => {
+  const [now, setNow] = useState<Date | null>(() => (enabled ? new Date() : null));
+
+  useEffect(() => {
+    if (!enabled) {
+      setNow(null);
+      return;
+    }
+    setNow(new Date());
+    const update = () => setNow(new Date());
+    const interval = setInterval(update, intervalMs);
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') update();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [enabled, intervalMs]);
+
+  return now;
+};

--- a/frontend/src/lib/date.test.ts
+++ b/frontend/src/lib/date.test.ts
@@ -7,6 +7,7 @@ import {
   formatTripRangeMD,
   formatTripRangeYMD,
   isDateOutsideRange,
+  isSameLocalDate,
   parseDateOnly,
 } from './date';
 
@@ -123,5 +124,15 @@ describe('isDateOutsideRange', () => {
   it('end のみ指定で後は true / 前は false', () => {
     expect(isDateOutsideRange(new Date(2026, 4, 27), null, end)).toBe(true);
     expect(isDateOutsideRange(new Date(2026, 4, 1), null, end)).toBe(false);
+  });
+});
+
+describe('isSameLocalDate', () => {
+  it('同じ年月日なら時刻が違ってもtrue', () => {
+    expect(isSameLocalDate(new Date(2026, 0, 1, 9, 0), new Date(2026, 0, 1, 23, 30))).toBe(true);
+  });
+
+  it('日付が違うとfalse', () => {
+    expect(isSameLocalDate(new Date(2026, 0, 1), new Date(2026, 0, 2))).toBe(false);
   });
 });

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -61,3 +61,8 @@ export const isDateOutsideRange = (date: Date | null, start?: Date | null, end?:
   if (end && date > end) return true;
   return false;
 };
+
+/**
+ * 2 つの `Date` がローカル時刻で同じ年月日か判定する。
+ */
+export const isSameLocalDate = (a: Date, b: Date): boolean => dayjs(a).isSame(b, 'day');

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -170,6 +170,7 @@ const TripPage = () => {
                 <div className='flex h-full flex-col items-center pt-4'>
                   <ViewTripLayout
                     selectedPageId={page.id}
+                    pageDate={page.date ?? null}
                     tripDetail={trip.detail ?? null}
                     isFirstPage={page.id === pages[0].id}
                   />

--- a/frontend/src/pages/TripPage/ViewTripLayout.tsx
+++ b/frontend/src/pages/TripPage/ViewTripLayout.tsx
@@ -5,17 +5,23 @@ import { Timeline } from '@/components/timeline/Timeline';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { MarkdownViewer } from '@/components/ui/markdown';
 import { useBlocks } from '@/hooks/useBlocks';
+import { useCurrentTime } from '@/hooks/useCurrentTime';
+import { isSameLocalDate } from '@/lib/date';
 import type { Page } from '@/types';
 
 type ViewTripLayoutProps = {
   selectedPageId: Page['id'];
+  pageDate: Page['date'];
   tripDetail: string | null;
   isFirstPage: boolean;
 };
 
-const ViewTripLayout = ({ selectedPageId, tripDetail, isFirstPage }: ViewTripLayoutProps) => {
+const ViewTripLayout = ({ selectedPageId, pageDate, tripDetail, isFirstPage }: ViewTripLayoutProps) => {
   const { blocks, error: blocksError, isLoading: isBlocksLoading } = useBlocks(selectedPageId ?? null);
   const [accordionValue, setAccordionValue] = useState(isFirstPage ? 'trip-detail' : '');
+  // pageDate が今日と一致するページだけ tick を回して、非該当ページの毎分再レンダーを避ける
+  const isToday = pageDate != null && isSameLocalDate(pageDate, new Date());
+  const now = useCurrentTime({ enabled: isToday });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedPageId変更時にAccordionの開閉状態を切り替えるための意図的な依存
   useEffect(() => {
@@ -54,7 +60,7 @@ const ViewTripLayout = ({ selectedPageId, tripDetail, isFirstPage }: ViewTripLay
               </AccordionItem>
             </Accordion>
           )}
-          <Timeline blocks={blocks} type='view' className='pb-4' />
+          <Timeline blocks={blocks} type='view' pageDate={pageDate} now={now} className='pb-4' />
         </div>
       )}
     </>

--- a/frontend/src/types/block.ts
+++ b/frontend/src/types/block.ts
@@ -44,6 +44,11 @@ export const TRANSPORTATION_OPTIONS = [
  *
  * location は `LocationUpdate`（id optional）を持つ。新規選択直後は id 未確定、
  * サーバから返った後は id 付き。PUT 時はそのまま埋め込んで後勝ちで送る。
+ *
+ * NOTE: `startTime` / `endTime` の年月日部分は意味を持たない (時刻データのみを使用する)。
+ * ブロックが「どの日か」は親 `Page.date` が持つ。FullCalendar は
+ * `calendarApi.gotoDate(blocks[0].startTime)` で block 側の anchor 日にビューを合わせている。
+ * したがって現実の日時と比較する際は必ず時刻部分に正規化 (rebase) する必要がある。
  */
 const AppBaseBlockSchema = z.object({
   id: z.number(),


### PR DESCRIPTION
Closes #167

## Summary
- 閲覧タイムラインで `page.date === today` のとき、現在時刻を示す NOW インジケータを表示
- 5 ケース: 開始前 (先頭張り付き) / ブロック時間内 (赤 ring + NOW バッジ) / 明示 gap / 暗黙 gap / 終了後 (末尾張り付き)
- gap 内は経過時間の比率で NOW ラインの縦位置を算出

<img width="1080" height="1159" alt="Screenshot_20260710-053635" src="https://github.com/user-attachments/assets/3568d4da-bece-4700-92b6-93c85b2f0128" />

## 主な設計判断
- **NOW = 赤で統一 (`red-500`)**: Google Calendar 等の業界標準に合わせ、既存の teal/sky と衝突しない
- **ブロック時間内のハイライトは ring + バッジ**: 当初は shadow glow を試したが、境界が曖昧で「今どのブロック中か」が伝わりにくかったため、くっきりした 2px ring + 左上コーナーの NOW バッジに切り替え
- **明示/暗黙 gap を統合**: 当初は暗黙 gap を独立した NOW 行として挿入していたが、点線が途切れる見栄えの悪さがあったため、両者とも「gap item に ratio を持たせ absolute overlay で NOW を重ねる」形に統一
- **末尾 endTime=null 対応**: `TimelineAxis` の trailing DottedLine 描画条件を `!isLastItem` から `hasFollowingGroup` に変更。NOW 行だけが後続の場合は点線を伸ばさない
- **`useCurrentTime` に `enabled` オプション**: embla carousel が全ページを同時マウントするため、非 today ページで tick を止めないと毎分の再レンダーが N ページ分走ってしまう問題を回避
- **memo の分割**: `sortBlocks` / `groupByStartTime` は now に依存しないので、tick 毎に破棄されないよう別 `useMemo` に切り出し
- **編集タイムラインは対象外**: 現状 `type: 'view'` のみ実装済みのため今回スコープ外

## Test plan
- [x] `pnpm run type-check` / `lint:check` / `format:check` 通過
- [x] `pnpm run test` 通過 (169 tests, +11 追加)
- [x] Storybook で 5 ケース + 末尾 endTime=null デグレケースを目視確認
- [ ] モバイル実機で NOW バッジのはみ出し確認 (レビュアーで対応可)
- [ ] 実際の trip で pageDate=today に対して NOW ラインが分単位で更新されることを確認