### PR TITLE
feat(#148): 通知機能の DB スキーマ追加

### DIFF
--- a/server/app/models.py
+++ b/server/app/models.py
@@ -232,6 +232,12 @@ class DeviceSubscription(Base):
             "trip_id",
             name="uq_device_subscriptions_fcm_token_trip_id",
         ),
+        # Pydantic 側の範囲検証をバイパスする経路 (raw SQL / 将来のバッチ) から
+        # 不正値が混入するのを防ぐため、DB 側でも保険をかける
+        CheckConstraint(
+            "minutes_before >= 1 AND minutes_before <= 120",
+            name="ck_device_subscriptions_minutes_before_range",
+        ),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -5,14 +5,18 @@ Add Trip, Page, Block, and Location models with relationships.
 from datetime import date, datetime
 
 from sqlalchemy import (
+    BigInteger,
     CheckConstraint,
     Connection,
     Date,
     DateTime,
     Float,
     ForeignKey,
+    Index,
+    SmallInteger,
     String,
     Text,
+    UniqueConstraint,
     event,
     func,
     text,
@@ -154,6 +158,9 @@ class Block(Base):
             "transportation_type IS NULL OR block_type = 'move'",
             name="ck_blocks_transportation_type_only_for_move",
         ),
+        # 通知 tick スキャンで WHERE start_time > now() AND start_time <= now() + interval
+        # を毎分実行するため
+        Index("idx_blocks_start_time", "start_time"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
@@ -207,6 +214,93 @@ class Block(Base):
         "Location",
         foreign_keys=[destination_location_id],
         lazy="raise",
+    )
+
+
+class DeviceSubscription(Base):
+    """FCM プッシュ通知の端末 × Trip 単位の購読レコード。
+
+    Firebase Auth 未導入のため user_id ではなく fcm_token を主キー相当として扱う。
+    """
+
+    __tablename__ = "device_subscriptions"
+    __table_args__ = (
+        # (fcm_token, trip_id) の順序は fcm_token 単体クエリ (token リフレッシュ /
+        # 失効時に全 trip 分削除) でも B-tree の左端 prefix match が効くよう意図的
+        UniqueConstraint(
+            "fcm_token",
+            "trip_id",
+            name="uq_device_subscriptions_fcm_token_trip_id",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    fcm_token: Mapped[str] = mapped_column(
+        String(500), nullable=False, comment="FCM registration token"
+    )
+    trip_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("trips.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="購読対象 Trip",
+    )
+    minutes_before: Mapped[int] = mapped_column(
+        SmallInteger,
+        nullable=False,
+        server_default=text("5"),
+        comment="通知先行分",
+    )
+    timezone: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="IANA TZ (例: 'Asia/Tokyo')。通知本文の時刻整形に使用",
+    )
+    user_agent: Mapped[str | None] = mapped_column(
+        String(500), nullable=True, comment="デバッグ用の User-Agent"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="購読作成日時",
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="最終アクセス日時 (token リフレッシュ判定用)",
+    )
+
+
+class SentNotification(Base):
+    """送信済み通知記録。
+
+    (block_id, fcm_token, kind) の複合 PK を「送信ロック」として使い、
+    INSERT-first で二重送信を絶対に防ぐ (送信失敗はロスト受容 / MVP 方針)。
+    """
+
+    __tablename__ = "sent_notifications"
+
+    block_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("blocks.id", ondelete="CASCADE"),
+        primary_key=True,
+        comment="送信対象 Block",
+    )
+    fcm_token: Mapped[str] = mapped_column(
+        String(500), primary_key=True, comment="送信先 FCM token"
+    )
+    kind: Mapped[str] = mapped_column(
+        String(30),
+        primary_key=True,
+        comment="通知種別 (現状 'before_5min' 固定、将来拡張余地)",
+    )
+    sent_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="送信ロックを取得した時刻",
     )
 
 

--- a/server/app/schemas/notification.py
+++ b/server/app/schemas/notification.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+FCM_TOKEN_MAX_LENGTH = 500
+TIMEZONE_MAX_LENGTH = 64
+USER_AGENT_MAX_LENGTH = 500
+NOTIFICATION_KIND_MAX_LENGTH = 30
+
+MINUTES_BEFORE_MIN = 1
+MINUTES_BEFORE_MAX = 120
+MINUTES_BEFORE_DEFAULT = 5
+
+
+class DeviceSubscriptionBase(BaseModel):
+    fcm_token: str = Field(min_length=1, max_length=FCM_TOKEN_MAX_LENGTH)
+    timezone: str = Field(min_length=1, max_length=TIMEZONE_MAX_LENGTH)
+    minutes_before: int = Field(
+        default=MINUTES_BEFORE_DEFAULT,
+        ge=MINUTES_BEFORE_MIN,
+        le=MINUTES_BEFORE_MAX,
+    )
+    user_agent: str | None = Field(default=None, max_length=USER_AGENT_MAX_LENGTH)
+
+
+class DeviceSubscriptionCreate(DeviceSubscriptionBase):
+    """クライアントからの購読リクエスト。
+
+    trip_id は URL パスから取り、リクエストボディには含めない前提。
+    """
+
+    pass
+
+
+class DeviceSubscription(DeviceSubscriptionBase):
+    id: int
+    trip_id: int
+    created_at: datetime
+    last_seen_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SentNotificationBase(BaseModel):
+    block_id: int
+    fcm_token: str = Field(min_length=1, max_length=FCM_TOKEN_MAX_LENGTH)
+    kind: str = Field(min_length=1, max_length=NOTIFICATION_KIND_MAX_LENGTH)
+
+
+class SentNotificationCreate(SentNotificationBase):
+    pass
+
+
+class SentNotification(SentNotificationBase):
+    sent_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/server/migrations/versions/20260711_1700_add_notification_tables.py
+++ b/server/migrations/versions/20260711_1700_add_notification_tables.py
@@ -83,6 +83,10 @@ def upgrade() -> None:
             "trip_id",
             name="uq_device_subscriptions_fcm_token_trip_id",
         ),
+        sa.CheckConstraint(
+            "minutes_before >= 1 AND minutes_before <= 120",
+            name="ck_device_subscriptions_minutes_before_range",
+        ),
     )
     op.create_index(
         "idx_device_subscriptions_trip",

--- a/server/migrations/versions/20260711_1700_add_notification_tables.py
+++ b/server/migrations/versions/20260711_1700_add_notification_tables.py
@@ -1,0 +1,142 @@
+"""add_notification_tables
+
+Revision ID: e6a2f9b18c34
+Revises: d5b3e9c1f27a
+Create Date: 2026-07-11 17:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e6a2f9b18c34"
+down_revision: Union[str, Sequence[str], None] = "d5b3e9c1f27a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # device_subscriptions: 端末 × Trip の購読関係
+    op.create_table(
+        "device_subscriptions",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "fcm_token",
+            sa.String(length=500),
+            nullable=False,
+            comment="FCM registration token",
+        ),
+        sa.Column(
+            "trip_id",
+            sa.BigInteger(),
+            nullable=False,
+            comment="購読対象 Trip",
+        ),
+        sa.Column(
+            "minutes_before",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("5"),
+            comment="通知先行分",
+        ),
+        sa.Column(
+            "timezone",
+            sa.String(length=64),
+            nullable=False,
+            comment="IANA TZ (例: 'Asia/Tokyo')。通知本文の時刻整形に使用",
+        ),
+        sa.Column(
+            "user_agent",
+            sa.String(length=500),
+            nullable=True,
+            comment="デバッグ用の User-Agent",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="購読作成日時",
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="最終アクセス日時 (token リフレッシュ判定用)",
+        ),
+        sa.ForeignKeyConstraint(
+            ["trip_id"],
+            ["trips.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        # (fcm_token, trip_id) の順序は fcm_token 単体クエリ (token リフレッシュ /
+        # 失効時全削除) にも B-tree の左端 prefix match で使えるよう意図的
+        sa.UniqueConstraint(
+            "fcm_token",
+            "trip_id",
+            name="uq_device_subscriptions_fcm_token_trip_id",
+        ),
+    )
+    op.create_index(
+        "idx_device_subscriptions_trip",
+        "device_subscriptions",
+        ["trip_id"],
+    )
+
+    # sent_notifications: 送信済み記録 (二重送信阻止のロック)
+    op.create_table(
+        "sent_notifications",
+        sa.Column(
+            "block_id",
+            sa.BigInteger(),
+            nullable=False,
+            comment="送信対象 Block",
+        ),
+        sa.Column(
+            "fcm_token",
+            sa.String(length=500),
+            nullable=False,
+            comment="送信先 FCM token",
+        ),
+        sa.Column(
+            "kind",
+            sa.String(length=30),
+            nullable=False,
+            comment="通知種別 (現状 'before_5min' 固定、将来拡張余地)",
+        ),
+        sa.Column(
+            "sent_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="送信ロックを取得した時刻",
+        ),
+        sa.ForeignKeyConstraint(
+            ["block_id"],
+            ["blocks.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("block_id", "fcm_token", "kind"),
+    )
+
+    # tick スキャン (WHERE b.start_time > now() AND b.start_time <= now() + interval) 用
+    op.create_index(
+        "idx_blocks_start_time",
+        "blocks",
+        ["start_time"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("idx_blocks_start_time", table_name="blocks")
+    op.drop_table("sent_notifications")
+    op.drop_index("idx_device_subscriptions_trip", table_name="device_subscriptions")
+    op.drop_table("device_subscriptions")

--- a/server/tests/test_notification_models.py
+++ b/server/tests/test_notification_models.py
@@ -1,0 +1,184 @@
+"""通知機能の DB スキーマに対する smoke test。
+
+まだ CRUD 層は無いので、モデルの INSERT / 制約 / Pydantic スキーマの往復のみを確認する。
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import DeviceSubscription, SentNotification
+from app.schemas.block import Block as BlockSchema
+from app.schemas.notification import (
+    DeviceSubscription as DeviceSubscriptionSchema,
+)
+from app.schemas.notification import (
+    DeviceSubscriptionCreate,
+    SentNotificationCreate,
+)
+from app.schemas.notification import (
+    SentNotification as SentNotificationSchema,
+)
+from app.schemas.trip import Trip
+
+
+@pytest.mark.asyncio
+async def test_device_subscription_insert_and_defaults(
+    db_session: AsyncSession, test_create_trip: Trip
+) -> None:
+    """DeviceSubscription を INSERT すると DB 側で minutes_before/created_at がデフォルト値になる"""
+    sub = DeviceSubscription(
+        fcm_token="token-abc",
+        trip_id=test_create_trip.id,
+        timezone="Asia/Tokyo",
+    )
+    db_session.add(sub)
+    await db_session.commit()
+    await db_session.refresh(sub)
+
+    assert sub.id is not None
+    assert sub.minutes_before == 5
+    assert sub.timezone == "Asia/Tokyo"
+    assert sub.user_agent is None
+    assert sub.created_at is not None
+    assert sub.last_seen_at is not None
+
+
+@pytest.mark.asyncio
+async def test_device_subscription_unique_token_trip(
+    db_session: AsyncSession, test_create_trip: Trip
+) -> None:
+    """同じ (fcm_token, trip_id) の二重購読は UNIQUE 制約で弾かれる"""
+    db_session.add(
+        DeviceSubscription(
+            fcm_token="token-dup",
+            trip_id=test_create_trip.id,
+            timezone="Asia/Tokyo",
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        DeviceSubscription(
+            fcm_token="token-dup",
+            trip_id=test_create_trip.id,
+            timezone="Asia/Tokyo",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_device_subscription_cascade_on_trip_delete(
+    db_session: AsyncSession, test_create_trip: Trip
+) -> None:
+    """Trip 削除で device_subscriptions は CASCADE 削除される"""
+    db_session.add(
+        DeviceSubscription(
+            fcm_token="token-cascade",
+            trip_id=test_create_trip.id,
+            timezone="Asia/Tokyo",
+        )
+    )
+    await db_session.commit()
+
+    from app.cruds import trips as trips_cruds
+
+    await trips_cruds.delete_trip(db=db_session, trip_id=test_create_trip.id)
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(DeviceSubscription).where(
+                    DeviceSubscription.trip_id == test_create_trip.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_sent_notification_insert_and_pk_duplicate(
+    db_session: AsyncSession, test_create_block: BlockSchema
+) -> None:
+    """SentNotification は複合 PK で二重送信をブロックする"""
+    db_session.add(
+        SentNotification(
+            block_id=test_create_block.id,
+            fcm_token="token-x",
+            kind="before_5min",
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        SentNotification(
+            block_id=test_create_block.id,
+            fcm_token="token-x",
+            kind="before_5min",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+def test_device_subscription_create_schema_defaults() -> None:
+    """DeviceSubscriptionCreate: minutes_before 未指定でデフォルト 5、user_agent は None"""
+    payload = DeviceSubscriptionCreate(fcm_token="token", timezone="Asia/Tokyo")
+    assert payload.minutes_before == 5
+    assert payload.user_agent is None
+
+
+def test_device_subscription_create_schema_rejects_out_of_range() -> None:
+    """minutes_before の範囲外は ValidationError"""
+    with pytest.raises(ValidationError):
+        DeviceSubscriptionCreate(
+            fcm_token="token", timezone="Asia/Tokyo", minutes_before=0
+        )
+    with pytest.raises(ValidationError):
+        DeviceSubscriptionCreate(
+            fcm_token="token", timezone="Asia/Tokyo", minutes_before=1000
+        )
+
+
+def test_device_subscription_schema_from_attributes() -> None:
+    """ORM モデル → Pydantic 変換の smoke"""
+    now = datetime.now(UTC)
+    sub = DeviceSubscription(
+        id=1,
+        fcm_token="token",
+        trip_id=42,
+        minutes_before=5,
+        timezone="Asia/Tokyo",
+        user_agent=None,
+        created_at=now,
+        last_seen_at=now,
+    )
+    schema = DeviceSubscriptionSchema.model_validate(sub)
+    assert schema.id == 1
+    assert schema.trip_id == 42
+    assert schema.minutes_before == 5
+
+
+def test_sent_notification_schema_from_attributes() -> None:
+    """SentNotification: ORM → Pydantic 変換"""
+    now = datetime.now(UTC)
+    row = SentNotification(block_id=1, fcm_token="t", kind="before_5min", sent_at=now)
+    schema = SentNotificationSchema.model_validate(row)
+    assert schema.block_id == 1
+    assert schema.kind == "before_5min"
+
+
+def test_sent_notification_create_schema_smoke() -> None:
+    """SentNotificationCreate: フィールド構築の smoke"""
+    payload = SentNotificationCreate(block_id=1, fcm_token="t", kind="before_5min")
+    assert payload.block_id == 1
+    assert payload.kind == "before_5min"

--- a/server/tests/test_notification_models.py
+++ b/server/tests/test_notification_models.py
@@ -74,6 +74,30 @@ async def test_device_subscription_unique_token_trip(
 
 
 @pytest.mark.asyncio
+async def test_device_subscription_minutes_before_check_constraint(
+    db_session: AsyncSession, test_create_trip: Trip
+) -> None:
+    """Pydantic 検証を通らない経路 (raw SQL 等) でも DB 側で範囲外を弾く"""
+    from sqlalchemy import text as sql_text
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            sql_text(
+                "INSERT INTO device_subscriptions "
+                "(fcm_token, trip_id, minutes_before, timezone) "
+                "VALUES (:token, :trip_id, :mb, :tz)"
+            ),
+            {
+                "token": "token-oor",
+                "trip_id": test_create_trip.id,
+                "mb": 0,
+                "tz": "Asia/Tokyo",
+            },
+        )
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
 async def test_device_subscription_cascade_on_trip_delete(
     db_session: AsyncSession, test_create_trip: Trip
 ) -> None:


### PR DESCRIPTION
## Summary

Issue #148 (PWA プッシュ通知) の DB スキーマ変更のみを先行してマージ。通知機能全体の実装は親ブランチ `feature/issue148_notification` で継続中。

- `device_subscriptions` テーブル: 端末 × Trip 単位の購読レコード
- `sent_notifications` テーブル: 送信ロック用 (INSERT-first で二重送信を絶対に阻止)
- `blocks.start_time` に INDEX 追加 (tick スキャンの `WHERE start_time BETWEEN now() AND ...` 用)

[一旦の仕様書](https://github.com/tabi-bit/tabi-share/blob/2a538a9095eb6d71aeddd7ebdee3c92c338604b6/docs/memo/notification_design.md)

## 設計判断

- **`fcm_token` を直接カラム化 (中間 device テーブルなし)**: MVP は token 単位で完結、Firebase Auth 導入時に `user_id` カラムで拡張可能
- **`UNIQUE (fcm_token, trip_id)` の列順は意図的**: fcm_token 単体クエリ (token リフレッシュ・失効時全削除) にも B-tree の左端 prefix match が効くため、追加 index 不要
- **`sent_notifications.kind` を持つ**: 現状 `'before_5min'` 固定だが、将来 "開始時通知" 等を追加しても複合 PK が壊れないよう保険で保持
- **送信失敗のリトライは未実装**: MVP は「送信ロスト受容 / 二重送信絶対禁止」の原則。将来必要になったら `sent_notifications.status` 列を追加して対応

## Test plan

- [x] `alembic -n devdb upgrade head` / `downgrade -1` が両方向で通ることを確認
- [x] 生成された各テーブル・INDEX・FK が `\d` で仕様通りであることを確認
- [x] `pytest tests/test_notification_models.py` (9 件) が pass
- [x] 既存テスト suite 全体 (121 件) が pass
- [x] `ruff check` / `ruff format --check` / `mypy` OK (触ったファイルのみ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 端末ごとに旅行の通知を購読できる仕組みを追加しました。
  * 通知の送信タイミング、タイムゾーン、端末情報を設定できるようになりました。
  * 同一キーによる重複した通知の送信を防止します。
* **改善**
  * 通知対象の検索性能を向上するインデックスを追加しました。
  * 通知設定値の範囲・重複・必須項目をより厳密に検証します。
* **テスト**
  * 通知設定の登録、削除、重複防止、入力検証、およびスキーマ変換を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->