### PR TITLE
fix: Safari で same-site cookie が送られない問題を修正 (#179)

### DIFF
--- a/server/app/auth.py
+++ b/server/app/auth.py
@@ -8,6 +8,8 @@
 
 import secrets
 from datetime import UTC, datetime, timedelta
+from typing import Literal
+from urllib.parse import urlparse
 
 import jwt
 from fastapi import Depends, HTTPException, Request, Response, status
@@ -21,6 +23,7 @@ from app.errors import Forbidden, NotFound
 from app.models import Block, Page
 
 # ---- Basic 認証 ----
+
 
 def require_basic_auth(
     credentials: HTTPBasicCredentials = Depends(HTTPBasic()),
@@ -39,6 +42,7 @@ def require_basic_auth(
             detail="認証に失敗しました",
             headers={"WWW-Authenticate": "Basic"},
         )
+
 
 SESSION_COOKIE_NAME = "tabishare_session"
 
@@ -63,7 +67,26 @@ def get_allowed_trip_ids(request: Request) -> set[int]:
     return {tid for tid in ids if isinstance(tid, int)}
 
 
-def _set_session_cookie(response: Response, trip_ids: set[int]) -> None:
+def _resolve_samesite(request: Request, is_production: bool) -> Literal["lax", "none"]:
+    """リクエスト元 Origin から適切な SameSite 値を選ぶ。
+
+    - `st.tabishare.net` 等 `tabishare.net` 配下からのアクセスは same-site なので `Lax`。
+      Safari の ITP でも first-party 扱いとなり cookie が送信される。
+    - Firebase Hosting プレビュー (`*.web.app`) 等の cross-site origin からは `None` に
+      フォールバックする (`Secure` 前提)。Safari は third-party として扱いブロックするが、
+      Chrome ではプレビュー動作確認が可能になる。
+    """
+    if not is_production:
+        return "lax"
+    origin_host = urlparse(request.headers.get("origin", "")).hostname or ""
+    if origin_host == "tabishare.net" or origin_host.endswith(".tabishare.net"):
+        return "lax"
+    return "none"
+
+
+def _set_session_cookie(
+    request: Request, response: Response, trip_ids: set[int]
+) -> None:
     """trip_ids 集合をまとめた署名付きセッション Cookie を発行する。"""
     settings = get_settings()
     payload = {
@@ -79,14 +102,12 @@ def _set_session_cookie(response: Response, trip_ids: set[int]) -> None:
         max_age=settings.cookie_max_age,
         httponly=True,
         secure=is_production,
-        samesite="none" if is_production else "lax",
+        samesite=_resolve_samesite(request, is_production),
         path="/",
     )
 
 
-def grant_trip_access(
-    request: Request, response: Response, trip_id: int
-) -> None:
+def grant_trip_access(request: Request, response: Response, trip_id: int) -> None:
     """指定 trip_id へのアクセス権を Cookie に追記する。
 
     既存 Cookie の trip_ids を読み、`trip_id` をマージしてから再発行する。
@@ -95,7 +116,7 @@ def grant_trip_access(
     """
     allowed = get_allowed_trip_ids(request)
     allowed.add(trip_id)
-    _set_session_cookie(response, allowed)
+    _set_session_cookie(request, response, allowed)
 
 
 # ---- FastAPI Depends 用の認可関数 ----


### PR DESCRIPTION
## Summary

Cookie の SameSite を Origin で分岐させ、`tabishare.net` 配下 (`st.tabishare.net` / `tabishare.net`) からは `Lax` を返すよう変更。Safari で発生していた `/pages` `/blocks` の 403 が解消される。

Closes #179

## 経緯 / 設計判断

`_set_session_cookie` は元々 production/staging で `SameSite=None; Secure` を一律付与していた。しかし front (`st.tabishare.net`) と API (`api.st.tabishare.net`) は eTLD+1 が同一 (`tabishare.net`) なので、本来 **same-site cross-origin** の関係。`SameSite=None` を宣言することは「これは cross-site cookie」というブラウザへの意思表示であり、Safari の ITP がその宣言を額面通り受け取ってサードパーティ cookie として送信を抑止していた。Chrome は `None; Secure` を素直に通すので Safari のみ症状化していた。

正しい設定は `Lax`。Lax は same-site の subresource fetch には送信されるので、`st.tabishare.net` → `api.st.tabishare.net` の fetch でも cookie が乗る。

一方で **Firebase Hosting プレビューチャンネル (`*.web.app`) からのアクセスは本物の cross-site** なので、そちらでは従来通り `None; Secure` にフォールバックする必要がある (`_resolve_samesite` で Origin ホストを見て判定)。

## 挙動サマリ (Before / After)

| Client Origin | Browser | Before | After |
|---|---|---|---|
| `st.tabishare.net` / `tabishare.net` | Safari | ❌ `None` (ITP block) | ✅ **`Lax`** |
| `st.tabishare.net` / `tabishare.net` | Chrome | ✅ `None` | ✅ `Lax` |
| `*.web.app` (preview) | Chrome | ✅ `None` | ✅ `None` |
| `*.web.app` (preview) | Safari | ❌ `None` (ITP block) | ❌ `None` (ITP block) |
| `localhost` (dev) | 任意 | ✅ `Lax` | ✅ `Lax` |

Safari × `tabishare.net` 配下 が Before ❌ → After ✅ になるのが本 PR の主眼。preview × Safari は Before / After ともに ❌ で、これはブラウザ側のポリシー起因で変えられない (下記「既知の制限」参照)。

## 既知の制限

**preview × Safari は非対応。** Safari ITP のサードパーティ cookie ブロックはブラウザ側のポリシーで、`SameSite=None; Secure` を返しても抜けられない。Safari 動作確認は stg (`st.tabishare.net`) で行う運用とする。将来的に preview 用カスタムドメイン (`*.preview.tabishare.net`) を切るか JWT ヘッダ運用への移行で解消可能。

## Test plan

- [x] stg デプロイ後、Safari で `/trip/{urlId}` を開き、`/pages` `/blocks` が 200 で返ることを確認
- [x] stg + Chrome で回帰していないことを確認
- [x] Safari の Web Inspector で `/trips/url/{urlId}` の Set-Cookie が `SameSite=Lax` になっていることを確認
- [x] 続く subresource fetch の Request Cookie に `tabishare_session` が乗っていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 環境やアクセス元に応じてCookieのSameSite設定を適切に切り替えるよう改善しました。
  * セッションCookieの発行・再発行時に、認証状態が維持されやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->