### PR TITLE
fix(PlaceSearchDialog): 場所検索が発火しないバグを修正

### DIFF
--- a/frontend/src/dialogs/PlaceSearchDialog.tsx
+++ b/frontend/src/dialogs/PlaceSearchDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@vis.gl/react-google-maps';
 import { debounce } from 'lodash-es';
 import { Globe, MapPin, Search } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { PlaceDetailsCompact, type PlaceDetailsCompactElement } from '@/components/google-maps/PlaceDetailsCompact';
 import { Button } from '@/components/ui/button';
@@ -123,8 +123,13 @@ const PlaceSearchContent = ({
     }
   };
 
-  // 500msデバウンスされた検索（連続入力で無駄なAPI呼び出しを防ぐ、React Compiler が executeSearch 変化時のみ再生成）
-  const debouncedSearch = debounce(executeSearch, 500);
+  // 500msデバウンスされた検索（連続入力で無駄なAPI呼び出しを防ぐ）。
+  // executeSearch は sessionTokenRef を触るため React Compiler がコンポーネント全体をバイルアウトし、
+  // debounce インスタンスが毎レンダー再生成されて下の useEffect cleanup がタイマーを毎回キャンセルしてしまう。
+  // useMemo で参照を安定化する（escape hatch）。executeSearch の真の依存 = [placesLib, map] を使うため
+  // biome の useExhaustiveDependencies は意図的に抑制。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: executeSearch は毎レンダー新規のため deps に入れると無意味。真の依存 placesLib/map で安定化する。
+  const debouncedSearch = useMemo(() => debounce(executeSearch, 500), [placesLib, map]);
 
   // アンマウント・依存更新時にpending呼び出しをキャンセル
   useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);


### PR DESCRIPTION
## Summary

- 閉じる #190
- 場所検索ダイアログでテキスト入力しても Autocomplete サジェストが一切出ない問題を修正

## 原因

`PlaceSearchContent` 内の `debounce(executeSearch, 500)` を素で書いていたところ、**React Compiler が「refs during render」を理由にコンポーネント全体をバイルアウト**していた。

- `executeSearch` が `sessionTokenRef.current` を触るため、`babel-plugin-react-compiler` が `debounce(executeSearch, 500)` に対して \`CompileError: Passing a ref to a function may read its value during render\` を出して丸ごとメモ化を放棄する
- 結果、`debouncedSearch` は毎レンダー新規参照になり、`useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch])` の cleanup が毎キー入力ごとに発火して自分でセットしたタイマーを即キャンセル
- → `fetchAutocompleteSuggestions` が一度も呼ばれない

コミット e6ea204（React Compiler 有効化 + 手動メモ化全削除）で `useMemo` を撤去したときに、上記バイルアウトを想定できていなかった。

## 修正内容

`useMemo` を escape hatch として復活させ、`debouncedSearch` の参照を安定化。`executeSearch` の真の依存（\`placesLib\`, \`map\`）を deps に採用し、`useExhaustiveDependencies` は理由付きで biome-ignore。

コーディング規約（`.claude/rules/frontend.md`）の「参照安定性が仕様上必須な escape hatch」に該当する用法。

## 補足: 同種パターンの潜在リスク

`frontend/src/hooks/useResizeObserver.ts` にも同じ「素の debounce」パターンがあるが、致命的挙動は出にくいと判断し本 PR では対象外。将来同種再発を防ぐなら別 PR で `useMemo` を当てるのが望ましい。

## Test plan

- [ ] 場所検索ダイアログを開いて 2 文字以上入力し、サジェストが表示されること
- [ ] サジェストから場所を選択して確定できること
- [ ] 地図 POI クリック / 空地クリックが従来通り動くこと（回帰確認）