### PR TITLE
fix(#195): PWA の theme_color をヘッダー背景色に合わせる

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0d9488" />
+    <meta name="theme-color" content="#f0fdfa" />
 
     <title>たびしぇあ | 旅程を簡単に作成・共有</title>
     <meta name="description" content="旅程を仲間と一緒に作って共有できる、旅行旅程の管理アプリ" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
         name: 'たびしぇあ',
         short_name: 'たびしぇあ',
         description: '旅程を簡単に作成・共有',
-        theme_color: '#0d9488',
+        theme_color: '#f0fdfa',
         background_color: '#f0fdfa',
         display: 'standalone',
         scope: '/',


### PR DESCRIPTION
## Summary

- Android PWA スタンドアロン起動時の status bar 色 (`theme_color`) をヘッダー背景と揃え、全画面感の途切れを解消
- `#0d9488` (teal-600) → `#f0fdfa` (teal-50) に変更。`background_color` (元から `#f0fdfa`) とも一致

Closes #195

## 設計判断: なぜ「theme_color をヘッダーに合わせる」なのか

案の比較:

| 案 | 判断 |
|---|---|
| **A. theme_color を薄い teal に合わせる (採用)** | ヘッダー `bg-teal-50/80 + backdrop-blur` の明るいエアリーなデザインを維持しつつ、status bar と連続化 |
| B. ヘッダーを濃い teal にする | 意図的に薄く設計されたヘッダーを壊す。Issue の要求(濃い色の違和感解消)と逆行 |
| C. `black-translucent` で iOS 側 status bar を透過 | Android には効かず、safe-area 対応が別途必要でコスト大 |

補足:
- iOS は `theme_color` を参照せず、既に `apple-mobile-web-app-status-bar-style: default` で調和済み → 影響なし
- Android の status bar テキスト色は theme_color の明度で自動判定されるため、`#f0fdfa` (ほぼ白)でも視認性 OK
- タスクスイッチャーでのアプリ識別性はやや低下するが、Issue の要求(全画面感)を優先

## Test plan

- [x] Android 実機 (Chrome) で PWA インストール → スタンドアロン起動し、status bar とヘッダーが同色に見えることを確認
- [x] iOS 実機で PWA スタンドアロン起動し、既存の見た目に regression がないことを確認
- [x] DevTools > Application > Manifest で `theme_color: #f0fdfa` が反映されていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ブラウザのアドレスバーなどに表示されるテーマカラーを、より明るい色調に変更しました。
  * インストール可能なWebアプリのテーマカラーも同じ色に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->