### PR TITLE
feat(#207): SW notificationclick で trip / block へ deep link 遷移

### DIFF
--- a/docs/memo/notification_roadmap.md
+++ b/docs/memo/notification_roadmap.md
@@ -53,9 +53,9 @@ graph LR
 - [x] Deep link URL 埋め込み (`?focusBlock={block_id}` を FCM `data.link` に付与)
 - [x] フォアグラウンド OS 通知 (`useForegroundNotificationToast` → `registration.showNotification`)
 
-### Phase 6b-9: 未実装 (別 PR / Follow-up)
+### Phase 6b-9
 
-- [ ] SW `notificationclick` ハンドラ (tap 時に `focusBlock` を消費してブロックまでスクロール)
+- [x] SW `notificationclick` ハンドラ (#207): tap で既存 client に postMessage → SPA navigate、無ければ openWindow。client 側は `useFocusBlockOnMount` で block まで scroll
 - [ ] Phase 7: stg 環境 E2E テスト (iOS/Android/Desktop 実機)
 - [ ] Phase 8: prod リリース + Cloud Scheduler ジョブ作成
 - [ ] Phase 9 (#173): `sent_notifications` 掃除 cron

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -196,7 +196,7 @@ tick が 60 秒を超えると次 tick と重なる。閾値と対処:
   - 素材: FA (frontend/src/assets/icons) + Lucide MapPin。オレンジバッジ (`#f4a261`) + 白抜き
 - **Badge** (Android status bar 等の小モノクロアイコン、96px、透過 PNG): `badge.png` を全通知で共通使用。紙飛行機シルエット (favicon 由来)、OS 側でアクセントカラーへリカラーされる。icon と別 URL にしないと Android で四角い塗りになる
 - 生成スクリプト: `scripts/gen_notification_icons.py`
-- **Deep link**: `/trip/{urlId}?focusBlock={blockId}` (該当ブロックにスクロール、Phase 2 で完全実装)
+- **Deep link**: `/trip/{urlId}?focusBlock={blockId}`。SW `notificationclick` (`frontend/public/firebase-messaging-sw.js`) が受け、既存 PWA/tab (focused > visible > 任意) に postMessage で client-side navigate、無ければ `clients.openWindow`。client 側は `useFocusBlockOnMount` で `useBlock(id)` から pageId を得て page 切替 → `[data-block-id]` を rAF 待機して `scrollIntoView` (center)。処理後 `focusBlock` は replaceState で除去。
 
 ## 6. プラットフォーム対応
 

--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,14 @@
           "source": "**",
           "destination": "/index.html"
         }
+      ],
+      "headers": [
+        {
+          "source": "/firebase-messaging-sw.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+          ]
+        }
       ]
     },
     {
@@ -20,6 +28,14 @@
           "source": "**",
           "destination": "/index.html"
         }
+      ],
+      "headers": [
+        {
+          "source": "/firebase-messaging-sw.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+          ]
+        }
       ]
     },
     {
@@ -30,6 +46,14 @@
         {
           "source": "**",
           "destination": "/index.html"
+        }
+      ],
+      "headers": [
+        {
+          "source": "/firebase-messaging-sw.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+          ]
         }
       ]
     }

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -1,6 +1,62 @@
 // biome-ignore-all lint/correctness/noUndeclaredVariables: firebase / importScripts は SW context の global
 // biome-ignore-all lint/correctness/noUnusedFunctionParameters: onBackgroundMessage の signature は Firebase 規定
 
+// notificationclick handler は Firebase SDK の import / init より前に登録する必要がある。
+// Firebase Messaging SDK は内部で notificationclick リスナーを付け stopImmediatePropagation
+// することがあり、後付けで addEventListener すると invocation されないケースがある。
+// (`firebase-js-sdk/packages/messaging/src/listeners/sw-listeners.ts` の実装参照)
+
+// Firebase Admin SDK の WebpushFCMOptions.link は data.FCM_MSG.fcmOptions.link に入る。
+// フォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由は data.link。
+const extractDeepLink = notification => {
+  const data = notification?.data ?? {};
+  return data?.FCM_MSG?.fcmOptions?.link ?? data?.link ?? null;
+};
+
+// PWA / ブラウザ tab 両方 push 登録している端末で、ユーザが今触ってる方を選ぶための優先度。
+const pickTargetClient = clientsList => {
+  return (
+    clientsList.find(c => c.focused) ?? clientsList.find(c => c.visibilityState === 'visible') ?? clientsList[0] ?? null
+  );
+};
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+
+  const link = extractDeepLink(event.notification);
+  if (!link) return;
+
+  // payload 経路経由の open-redirect を防ぐ (別 origin URL は捨てる)。
+  let targetUrl;
+  try {
+    targetUrl = new URL(link, self.location.origin);
+  } catch {
+    return;
+  }
+  if (targetUrl.origin !== self.location.origin) return;
+
+  event.waitUntil(
+    (async () => {
+      const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+      const target = pickTargetClient(clientsList);
+
+      if (target) {
+        // WindowClient.navigate() を使うとフルリロードで atom / SWR / scroll 位置が飛ぶので、
+        // 代わりに client 側で React Router の navigate を呼んでもらう。
+        target.postMessage({ type: 'FCM_NAVIGATE', url: targetUrl.href });
+        try {
+          await target.focus();
+        } catch {
+          // focus はユーザ操作起源でないと reject されるが、postMessage は届いてるので許容
+        }
+        return;
+      }
+
+      await self.clients.openWindow(targetUrl.href);
+    })()
+  );
+});
+
 importScripts('https://www.gstatic.com/firebasejs/12.16.0/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/12.16.0/firebase-messaging-compat.js');
 

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -20,6 +20,25 @@ const pickTargetClient = clientsList => {
   );
 };
 
+// postMessage 経路が届かない状況の safety net として target URL を Cache Storage に書き残す。
+// client 側 (useFcmNavigationListener) は mount + visibilitychange のたびに読んで navigate する。
+// 起こりうる postMessage 未着ケース:
+//   - PWA が Android にキルされていて matchAll 上は phantom client、focus() では OS が task を
+//     復帰させるが postMessage は event loop で drain されない
+//   - cold start で client 側 message listener 登録前に SW が postMessage 送出
+const INTENT_CACHE = 'fcm-nav-intent-v1';
+// Cache API は Request URL をキーに使うため、実在しない同 origin URL を予約して衝突を避ける。
+const INTENT_KEY = new URL('/__fcm_pending_nav__', self.location.origin).href;
+
+const storePendingIntent = async url => {
+  try {
+    const cache = await caches.open(INTENT_CACHE);
+    await cache.put(new Request(INTENT_KEY), new Response(url, { headers: { 'content-type': 'text/plain' } }));
+  } catch {
+    // Cache API 非対応 / QuotaExceeded 等は best effort として無視
+  }
+};
+
 self.addEventListener('notificationclick', event => {
   event.notification.close();
 
@@ -37,6 +56,9 @@ self.addEventListener('notificationclick', event => {
 
   event.waitUntil(
     (async () => {
+      // storage 完了を focus/openWindow より前に保証。client 側の visibilitychange で確実に拾える。
+      await storePendingIntent(targetUrl.href);
+
       const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
       const target = pickTargetClient(clientsList);
 

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -1,16 +1,26 @@
 // biome-ignore-all lint/correctness/noUndeclaredVariables: firebase / importScripts は SW context の global
 // biome-ignore-all lint/correctness/noUnusedFunctionParameters: onBackgroundMessage の signature は Firebase 規定
 
-// notificationclick handler は Firebase SDK の import / init より前に登録する必要がある。
-// Firebase Messaging SDK は内部で notificationclick リスナーを付け stopImmediatePropagation
-// することがあり、後付けで addEventListener すると invocation されないケースがある。
-// (`firebase-js-sdk/packages/messaging/src/listeners/sw-listeners.ts` の実装参照)
+// notificationclick handler は Firebase SDK の import / init より前に登録する。
+// Firebase Messaging SDK は内部で notificationclick リスナーを付け stopImmediatePropagation する
+// ことがあるため、後付けだと invocation されないケースがある。
 
-// Firebase Admin SDK の WebpushFCMOptions.link は data.FCM_MSG.fcmOptions.link に入る。
-// フォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由は data.link。
+// SW default lifecycle だと install → waiting、既存 client が全部閉じるまで activate されない。
+// FCM SW は root scope 外なので待たせるとユーザ操作なしに切替できず更新が届かない。
+self.addEventListener('install', event => {
+  event.waitUntil(self.skipWaiting());
+});
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Firebase Admin SDK の WebpushFCMOptions(link=...) は SDK 12.x で
+// data.FCM_MSG.notification.click_action に写される (fcmOptions.link ではない)。
+// data.link はフォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由。
 const extractDeepLink = notification => {
   const data = notification?.data ?? {};
-  return data?.FCM_MSG?.fcmOptions?.link ?? data?.link ?? null;
+  const fcm = data?.FCM_MSG;
+  return fcm?.notification?.click_action ?? fcm?.fcmOptions?.link ?? data?.link ?? null;
 };
 
 // PWA / ブラウザ tab 両方 push 登録している端末で、ユーザが今触ってる方を選ぶための優先度。
@@ -18,25 +28,6 @@ const pickTargetClient = clientsList => {
   return (
     clientsList.find(c => c.focused) ?? clientsList.find(c => c.visibilityState === 'visible') ?? clientsList[0] ?? null
   );
-};
-
-// postMessage 経路が届かない状況の safety net として target URL を Cache Storage に書き残す。
-// client 側 (useFcmNavigationListener) は mount + visibilitychange のたびに読んで navigate する。
-// 起こりうる postMessage 未着ケース:
-//   - PWA が Android にキルされていて matchAll 上は phantom client、focus() では OS が task を
-//     復帰させるが postMessage は event loop で drain されない
-//   - cold start で client 側 message listener 登録前に SW が postMessage 送出
-const INTENT_CACHE = 'fcm-nav-intent-v1';
-// Cache API は Request URL をキーに使うため、実在しない同 origin URL を予約して衝突を避ける。
-const INTENT_KEY = new URL('/__fcm_pending_nav__', self.location.origin).href;
-
-const storePendingIntent = async url => {
-  try {
-    const cache = await caches.open(INTENT_CACHE);
-    await cache.put(new Request(INTENT_KEY), new Response(url, { headers: { 'content-type': 'text/plain' } }));
-  } catch {
-    // Cache API 非対応 / QuotaExceeded 等は best effort として無視
-  }
 };
 
 self.addEventListener('notificationclick', event => {
@@ -56,9 +47,6 @@ self.addEventListener('notificationclick', event => {
 
   event.waitUntil(
     (async () => {
-      // storage 完了を focus/openWindow より前に保証。client 側の visibilitychange で確実に拾える。
-      await storePendingIntent(targetUrl.href);
-
       const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
       const target = pickTargetClient(clientsList);
 
@@ -69,11 +57,13 @@ self.addEventListener('notificationclick', event => {
         try {
           await target.focus();
         } catch {
-          // focus はユーザ操作起源でないと reject されるが、postMessage は届いてるので許容
+          // focus はユーザ操作起源でないと reject されるが postMessage は届いてるので許容
         }
         return;
       }
 
+      // task-killed 状態など matchAll が 0 件のときは openWindow が唯一の起動経路。
+      // Chrome は URL を尊重して PWA を起動 (実機で verify 済み)。
       await self.clients.openWindow(targetUrl.href);
     })()
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import { isOfflineReadAtom } from './atoms/network';
 import { NoIndex } from './components/NoIndex';
 import { Title } from './components/Title';
+import { useFcmNavigationListener } from './hooks/useFcmNavigationListener';
 import { useForegroundNotificationToast } from './hooks/useForegroundNotificationToast';
 import { useNetworkToast } from './hooks/useNetworkToast';
 import { usePageTracking } from './hooks/usePageTracking';
@@ -19,6 +20,7 @@ const App = () => {
   useNetworkToast();
   usePageTracking();
   useForegroundNotificationToast();
+  useFcmNavigationListener();
 
   return (
     <>

--- a/frontend/src/components/blocks/view/BlockScheduleView.tsx
+++ b/frontend/src/components/blocks/view/BlockScheduleView.tsx
@@ -55,6 +55,7 @@ export function BlockScheduleView({ block, isNow, className }: BlockScheduleView
   return (
     <div
       ref={resizeRef}
+      data-block-id={block.id}
       className={cn(
         'relative flex w-full flex-col gap-2 rounded-lg bg-linear-to-r from-teal-400 px-4 py-2',
         isHovered ? 'to-teal-400' : 'to-teal-500',

--- a/frontend/src/components/blocks/view/BlockTransportationView.tsx
+++ b/frontend/src/components/blocks/view/BlockTransportationView.tsx
@@ -45,6 +45,7 @@ export function BlockTransportationView({ block, isNow, className }: BlockTransp
   return (
     <div
       ref={resizeRef}
+      data-block-id={block.id}
       className={cn(
         'relative flex w-full flex-col gap-2 rounded-lg bg-gradient-to-r from-sky-50 px-2 py-2 sm:px-4',
         isHovered ? 'to-sky-50' : 'to-sky-100',

--- a/frontend/src/hooks/useBlocks.ts
+++ b/frontend/src/hooks/useBlocks.ts
@@ -14,11 +14,22 @@ const BLOCKS_BASE_PATH = '/blocks';
  * pageId に紐づく Block をすべて取得するフック
  */
 export const useBlocks = (pageId: number | null, options?: Pick<SWRConfiguration, 'refreshInterval'>) => {
+  const { mutate: globalMutate, cache } = useSWRConfig();
   const { data, error, isLoading } = useSWR<Block[]>(
     pageId ? `${PAGES_BASE_PATH}/${pageId}/blocks` : null,
     async (url: string) => {
       const res = await fetcher(url);
-      return z.array(blockFromApi).parse(res);
+      const parsed = z.array(blockFromApi).parse(res);
+      // list fetch で得た block を個別 key にも撒いて useBlock(id) の重複 fetch を避ける
+      // (通知タップの deep link 解決経路で効く)。ただし既存値は上書きしない:
+      // 楽観更新中の値を list revalidation の古いサーバ値で巻き戻すのを防ぐため。
+      for (const block of parsed) {
+        const individualKey = `${BLOCKS_BASE_PATH}/${block.id}`;
+        if (cache.get(individualKey)?.data === undefined) {
+          globalMutate(individualKey, block, { revalidate: false });
+        }
+      }
+      return parsed;
     },
     options
   );

--- a/frontend/src/hooks/useFcmNavigationListener.test.tsx
+++ b/frontend/src/hooks/useFcmNavigationListener.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockNavigate = vi.fn();
@@ -19,6 +19,7 @@ const swStub = {
   removeEventListener: (type: string, listener: SwEventListener) => {
     if (type === 'message') swListeners.delete(listener);
   },
+  getRegistration: async () => undefined,
 };
 
 const dispatchSwMessage = (data: unknown) => {
@@ -26,45 +27,14 @@ const dispatchSwMessage = (data: unknown) => {
   for (const listener of swListeners) listener(event);
 };
 
-// jsdom は Cache API 未実装なのでインメモリスタブを差し込む
-const cacheEntries = new Map<string, string>();
-
-const cacheStub: Cache = {
-  put: async (request: RequestInfo | URL, response: Response) => {
-    const key = typeof request === 'string' ? request : (request as Request).url;
-    cacheEntries.set(key, await response.text());
-  },
-  match: async (request: RequestInfo | URL) => {
-    const key = typeof request === 'string' ? request : (request as Request).url;
-    const value = cacheEntries.get(key);
-    return value === undefined ? undefined : new Response(value);
-  },
-  delete: async (request: RequestInfo | URL) => {
-    const key = typeof request === 'string' ? request : (request as Request).url;
-    return cacheEntries.delete(key);
-  },
-} as unknown as Cache;
-
-const cachesStub: CacheStorage = {
-  open: async () => cacheStub,
-} as unknown as CacheStorage;
-
-const INTENT_KEY = 'http://localhost:3000/__fcm_pending_nav__';
-
-const seedPendingIntent = (url: string) => {
-  cacheEntries.set(INTENT_KEY, url);
-};
-
 describe('useFcmNavigationListener', () => {
   beforeEach(() => {
     swListeners.clear();
-    cacheEntries.clear();
     mockNavigate.mockClear();
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: swStub,
     });
-    vi.stubGlobal('caches', cachesStub);
   });
 
   afterEach(() => {
@@ -72,7 +42,6 @@ describe('useFcmNavigationListener', () => {
       configurable: true,
       value: undefined,
     });
-    vi.unstubAllGlobals();
   });
 
   it('FCM_NAVIGATE メッセージ受信で navigate() を pathname+search+hash 付きで呼ぶ', () => {
@@ -140,52 +109,11 @@ describe('useFcmNavigationListener', () => {
     expect(swListeners.size).toBe(0);
   });
 
-  it('mount 時に Cache Storage に intent があれば navigate する (postMessage 未着 fallback)', async () => {
-    seedPendingIntent('http://localhost:3000/trip/xyz?focusBlock=7');
-
+  it('現在 URL と一致するときは navigate しない', () => {
     renderHook(() => useFcmNavigationListener());
 
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/xyz?focusBlock=7');
-    });
-    expect(cacheEntries.has(INTENT_KEY)).toBe(false);
-  });
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: window.location.href });
 
-  it('mount 時に intent が現在 URL と一致するなら navigate しない', async () => {
-    seedPendingIntent(window.location.href);
-
-    renderHook(() => useFcmNavigationListener());
-
-    await Promise.resolve();
-    await Promise.resolve();
     expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('visibilitychange (visible) で cache 内 intent を消化する', async () => {
-    renderHook(() => useFcmNavigationListener());
-
-    seedPendingIntent('http://localhost:3000/trip/later?focusBlock=99');
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
-    act(() => {
-      document.dispatchEvent(new Event('visibilitychange'));
-    });
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/later?focusBlock=99');
-    });
-  });
-
-  it('postMessage で navigate した場合は cache 内 intent も掃除する (二重 navigate 防止)', async () => {
-    seedPendingIntent('http://localhost:3000/trip/abc?focusBlock=42');
-
-    renderHook(() => useFcmNavigationListener());
-
-    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'http://localhost:3000/trip/abc?focusBlock=42' });
-
-    await waitFor(() => {
-      expect(cacheEntries.has(INTENT_KEY)).toBe(false);
-    });
-    // navigate は message 経由の 1 回のみ。mount 時 applyIntent は cache が既に空になってて no-op
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/useFcmNavigationListener.test.tsx
+++ b/frontend/src/hooks/useFcmNavigationListener.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+import { useFcmNavigationListener } from '@/hooks/useFcmNavigationListener';
+
+type SwEventListener = (event: MessageEvent) => void;
+
+const swListeners = new Set<SwEventListener>();
+
+const swStub = {
+  addEventListener: (type: string, listener: SwEventListener) => {
+    if (type === 'message') swListeners.add(listener);
+  },
+  removeEventListener: (type: string, listener: SwEventListener) => {
+    if (type === 'message') swListeners.delete(listener);
+  },
+};
+
+const dispatchSwMessage = (data: unknown) => {
+  const event = { data } as MessageEvent;
+  for (const listener of swListeners) listener(event);
+};
+
+describe('useFcmNavigationListener', () => {
+  beforeEach(() => {
+    swListeners.clear();
+    mockNavigate.mockClear();
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: swStub,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it('FCM_NAVIGATE メッセージ受信で navigate() を pathname+search+hash 付きで呼ぶ', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'http://localhost:3000/trip/abc?focusBlock=42#top' });
+
+    expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/abc?focusBlock=42#top');
+  });
+
+  it('FCM_NAVIGATE 以外のメッセージは無視する', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'SOME_OTHER', url: 'http://localhost:3000/trip/xxx' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('別 origin の URL は無視する (open-redirect 対策)', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'https://evil.example.com/trip/abc' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('非 http scheme (javascript:) は同 origin にならず遷移しない', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'javascript:alert(1)' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('url が string でなければ無視する', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 42 });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('data が undefined でも throw しない', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    expect(() => dispatchSwMessage(undefined)).not.toThrow();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('unmount 時に listener を解除する', () => {
+    const { unmount } = renderHook(() => useFcmNavigationListener());
+
+    expect(swListeners.size).toBe(1);
+    unmount();
+    expect(swListeners.size).toBe(0);
+  });
+
+  it('navigator.serviceWorker が無い環境では何もしない', () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(() => renderHook(() => useFcmNavigationListener())).not.toThrow();
+    expect(swListeners.size).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useFcmNavigationListener.test.tsx
+++ b/frontend/src/hooks/useFcmNavigationListener.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockNavigate = vi.fn();
@@ -26,14 +26,45 @@ const dispatchSwMessage = (data: unknown) => {
   for (const listener of swListeners) listener(event);
 };
 
+// jsdom は Cache API 未実装なのでインメモリスタブを差し込む
+const cacheEntries = new Map<string, string>();
+
+const cacheStub: Cache = {
+  put: async (request: RequestInfo | URL, response: Response) => {
+    const key = typeof request === 'string' ? request : (request as Request).url;
+    cacheEntries.set(key, await response.text());
+  },
+  match: async (request: RequestInfo | URL) => {
+    const key = typeof request === 'string' ? request : (request as Request).url;
+    const value = cacheEntries.get(key);
+    return value === undefined ? undefined : new Response(value);
+  },
+  delete: async (request: RequestInfo | URL) => {
+    const key = typeof request === 'string' ? request : (request as Request).url;
+    return cacheEntries.delete(key);
+  },
+} as unknown as Cache;
+
+const cachesStub: CacheStorage = {
+  open: async () => cacheStub,
+} as unknown as CacheStorage;
+
+const INTENT_KEY = 'http://localhost:3000/__fcm_pending_nav__';
+
+const seedPendingIntent = (url: string) => {
+  cacheEntries.set(INTENT_KEY, url);
+};
+
 describe('useFcmNavigationListener', () => {
   beforeEach(() => {
     swListeners.clear();
+    cacheEntries.clear();
     mockNavigate.mockClear();
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: swStub,
     });
+    vi.stubGlobal('caches', cachesStub);
   });
 
   afterEach(() => {
@@ -41,6 +72,7 @@ describe('useFcmNavigationListener', () => {
       configurable: true,
       value: undefined,
     });
+    vi.unstubAllGlobals();
   });
 
   it('FCM_NAVIGATE メッセージ受信で navigate() を pathname+search+hash 付きで呼ぶ', () => {
@@ -98,7 +130,7 @@ describe('useFcmNavigationListener', () => {
     expect(swListeners.size).toBe(0);
   });
 
-  it('navigator.serviceWorker が無い環境では何もしない', () => {
+  it('navigator.serviceWorker が無い環境でも throw しない', () => {
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: undefined,
@@ -106,5 +138,54 @@ describe('useFcmNavigationListener', () => {
 
     expect(() => renderHook(() => useFcmNavigationListener())).not.toThrow();
     expect(swListeners.size).toBe(0);
+  });
+
+  it('mount 時に Cache Storage に intent があれば navigate する (postMessage 未着 fallback)', async () => {
+    seedPendingIntent('http://localhost:3000/trip/xyz?focusBlock=7');
+
+    renderHook(() => useFcmNavigationListener());
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/xyz?focusBlock=7');
+    });
+    expect(cacheEntries.has(INTENT_KEY)).toBe(false);
+  });
+
+  it('mount 時に intent が現在 URL と一致するなら navigate しない', async () => {
+    seedPendingIntent(window.location.href);
+
+    renderHook(() => useFcmNavigationListener());
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('visibilitychange (visible) で cache 内 intent を消化する', async () => {
+    renderHook(() => useFcmNavigationListener());
+
+    seedPendingIntent('http://localhost:3000/trip/later?focusBlock=99');
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/later?focusBlock=99');
+    });
+  });
+
+  it('postMessage で navigate した場合は cache 内 intent も掃除する (二重 navigate 防止)', async () => {
+    seedPendingIntent('http://localhost:3000/trip/abc?focusBlock=42');
+
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'http://localhost:3000/trip/abc?focusBlock=42' });
+
+    await waitFor(() => {
+      expect(cacheEntries.has(INTENT_KEY)).toBe(false);
+    });
+    // navigate は message 経由の 1 回のみ。mount 時 applyIntent は cache が既に空になってて no-op
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * firebase-messaging-sw.js の notificationclick が postMessage する
+ * `{ type: 'FCM_NAVIGATE', url }` を受けて React Router で navigate する。
+ * App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
+ */
+export const useFcmNavigationListener = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // 参照を effect スコープに固定: cleanup 時に navigator.serviceWorker が消えていても
+    // (テスト環境で差し替えると起こる) removeEventListener で crash させない。
+    const sw = typeof navigator !== 'undefined' ? navigator.serviceWorker : undefined;
+    if (!sw) return;
+
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type !== 'FCM_NAVIGATE') return;
+      const rawUrl = event.data.url;
+      if (typeof rawUrl !== 'string') return;
+
+      let parsed: URL;
+      try {
+        parsed = new URL(rawUrl, window.location.origin);
+      } catch {
+        return;
+      }
+      // SW 側でも弾いているが、payload 経路の open-redirect 対策として二重防御。
+      if (parsed.origin !== window.location.origin) return;
+
+      navigate(`${parsed.pathname}${parsed.search}${parsed.hash}`);
+    };
+
+    sw.addEventListener('message', handler);
+    return () => {
+      sw.removeEventListener('message', handler);
+    };
+  }, [navigate]);
+};

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,58 +1,10 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 /**
  * firebase-messaging-sw.js の notificationclick が伝えてくる遷移先 URL を受けて
- * React Router で navigate する。
- * App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
- *
- * 経路は 2 系統:
- * - fast path: SW からの postMessage `{ type: 'FCM_NAVIGATE', url }` を message event で受ける
- * - safety net: SW が Cache Storage (INTENT_CACHE / INTENT_KEY) に書き残した URL を
- *   mount + visibilitychange のたびに読む。PWA が Android にキルされて postMessage が
- *   届かないケース / cold start で listener 未登録のケースを両方救う
- *
- * 両方の経路が同じ URL に対して発火するので、直近の遷移 URL を ref に持たせて重複 navigate を防ぐ。
+ * React Router で navigate する。App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
  */
-
-const INTENT_CACHE = 'fcm-nav-intent-v1';
-const INTENT_KEY_PATH = '/__fcm_pending_nav__';
-
-const intentKeyUrl = () => new URL(INTENT_KEY_PATH, window.location.origin).href;
-
-const openIntentCache = async (): Promise<Cache | null> => {
-  if (typeof caches === 'undefined') return null;
-  try {
-    return await caches.open(INTENT_CACHE);
-  } catch {
-    return null;
-  }
-};
-
-const readAndClearPendingIntent = async (): Promise<string | null> => {
-  const cache = await openIntentCache();
-  if (!cache) return null;
-  const key = intentKeyUrl();
-  try {
-    const res = await cache.match(key);
-    if (!res) return null;
-    const url = await res.text();
-    await cache.delete(key);
-    return url;
-  } catch {
-    return null;
-  }
-};
-
-const clearPendingIntent = async (): Promise<void> => {
-  const cache = await openIntentCache();
-  if (!cache) return;
-  try {
-    await cache.delete(intentKeyUrl());
-  } catch {
-    // best effort
-  }
-};
 
 const parseSameOriginPath = (rawUrl: string): string | null => {
   let parsed: URL;
@@ -65,31 +17,26 @@ const parseSameOriginPath = (rawUrl: string): string | null => {
   return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 };
 
+// FCM SW は root scope 外なので navigation 由来の update check が発火せず、register() の
+// byte-diff check も起動 1 回のみ (promise cache のため)。明示 update() が唯一の SW 更新経路。
+// PWA セッション中に 1 回だけ呼ぶよう module-level flag で dedupe する。
+let fcmSwUpdateTriggered = false;
+
+const promoteFcmSwUpdate = async (sw: ServiceWorkerContainer): Promise<void> => {
+  if (fcmSwUpdateTriggered) return;
+  fcmSwUpdateTriggered = true;
+  try {
+    const reg = await sw.getRegistration('/firebase-cloud-messaging-push-scope');
+    await reg?.update();
+  } catch {
+    // best effort
+  }
+};
+
 export const useFcmNavigationListener = () => {
   const navigate = useNavigate();
-  // fast path (message) と safety net (cache) が同一 URL に対して二重発火するのを防ぐ。
-  // 直近の遷移先を保持し、同値なら skip する。
-  const lastNavigatedRef = useRef<string | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
-
-    const navigateOnce = (target: string) => {
-      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-      if (target === current) return;
-      if (lastNavigatedRef.current === target) return;
-      lastNavigatedRef.current = target;
-      navigate(target);
-    };
-
-    const applyIntent = async () => {
-      const url = await readAndClearPendingIntent();
-      if (cancelled || !url) return;
-      const target = parseSameOriginPath(url);
-      if (!target) return;
-      navigateOnce(target);
-    };
-
     // 参照を effect スコープに固定: cleanup 時に navigator.serviceWorker が消えていても
     // (テスト環境で差し替えると起こる) removeEventListener で crash させない。
     const sw = typeof navigator !== 'undefined' ? navigator.serviceWorker : undefined;
@@ -100,23 +47,16 @@ export const useFcmNavigationListener = () => {
       if (typeof rawUrl !== 'string') return;
       const target = parseSameOriginPath(rawUrl);
       if (!target) return;
-      // message 経由で消化するので safety net の Cache は掃除する (二重 navigate 防止)
-      void clearPendingIntent();
-      navigateOnce(target);
-    };
-
-    const onVisibility = () => {
-      if (document.visibilityState === 'visible') void applyIntent();
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (target === current) return;
+      navigate(target);
     };
 
     sw?.addEventListener('message', handler);
-    document.addEventListener('visibilitychange', onVisibility);
-    void applyIntent();
+    if (sw) void promoteFcmSwUpdate(sw);
 
     return () => {
-      cancelled = true;
       sw?.removeEventListener('message', handler);
-      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [navigate]);
 };

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,40 +1,122 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 /**
- * firebase-messaging-sw.js の notificationclick が postMessage する
- * `{ type: 'FCM_NAVIGATE', url }` を受けて React Router で navigate する。
+ * firebase-messaging-sw.js の notificationclick が伝えてくる遷移先 URL を受けて
+ * React Router で navigate する。
  * App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
+ *
+ * 経路は 2 系統:
+ * - fast path: SW からの postMessage `{ type: 'FCM_NAVIGATE', url }` を message event で受ける
+ * - safety net: SW が Cache Storage (INTENT_CACHE / INTENT_KEY) に書き残した URL を
+ *   mount + visibilitychange のたびに読む。PWA が Android にキルされて postMessage が
+ *   届かないケース / cold start で listener 未登録のケースを両方救う
+ *
+ * 両方の経路が同じ URL に対して発火するので、直近の遷移 URL を ref に持たせて重複 navigate を防ぐ。
  */
+
+const INTENT_CACHE = 'fcm-nav-intent-v1';
+const INTENT_KEY_PATH = '/__fcm_pending_nav__';
+
+const intentKeyUrl = () => new URL(INTENT_KEY_PATH, window.location.origin).href;
+
+const openIntentCache = async (): Promise<Cache | null> => {
+  if (typeof caches === 'undefined') return null;
+  try {
+    return await caches.open(INTENT_CACHE);
+  } catch {
+    return null;
+  }
+};
+
+const readAndClearPendingIntent = async (): Promise<string | null> => {
+  const cache = await openIntentCache();
+  if (!cache) return null;
+  const key = intentKeyUrl();
+  try {
+    const res = await cache.match(key);
+    if (!res) return null;
+    const url = await res.text();
+    await cache.delete(key);
+    return url;
+  } catch {
+    return null;
+  }
+};
+
+const clearPendingIntent = async (): Promise<void> => {
+  const cache = await openIntentCache();
+  if (!cache) return;
+  try {
+    await cache.delete(intentKeyUrl());
+  } catch {
+    // best effort
+  }
+};
+
+const parseSameOriginPath = (rawUrl: string): string | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl, window.location.origin);
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== window.location.origin) return null;
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+};
+
 export const useFcmNavigationListener = () => {
   const navigate = useNavigate();
+  // fast path (message) と safety net (cache) が同一 URL に対して二重発火するのを防ぐ。
+  // 直近の遷移先を保持し、同値なら skip する。
+  const lastNavigatedRef = useRef<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
+    const navigateOnce = (target: string) => {
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (target === current) return;
+      if (lastNavigatedRef.current === target) return;
+      lastNavigatedRef.current = target;
+      navigate(target);
+    };
+
+    const applyIntent = async () => {
+      const url = await readAndClearPendingIntent();
+      if (cancelled || !url) return;
+      const target = parseSameOriginPath(url);
+      if (!target) return;
+      navigateOnce(target);
+    };
+
     // 参照を effect スコープに固定: cleanup 時に navigator.serviceWorker が消えていても
     // (テスト環境で差し替えると起こる) removeEventListener で crash させない。
     const sw = typeof navigator !== 'undefined' ? navigator.serviceWorker : undefined;
-    if (!sw) return;
 
     const handler = (event: MessageEvent) => {
       if (event.data?.type !== 'FCM_NAVIGATE') return;
       const rawUrl = event.data.url;
       if (typeof rawUrl !== 'string') return;
-
-      let parsed: URL;
-      try {
-        parsed = new URL(rawUrl, window.location.origin);
-      } catch {
-        return;
-      }
-      // SW 側でも弾いているが、payload 経路の open-redirect 対策として二重防御。
-      if (parsed.origin !== window.location.origin) return;
-
-      navigate(`${parsed.pathname}${parsed.search}${parsed.hash}`);
+      const target = parseSameOriginPath(rawUrl);
+      if (!target) return;
+      // message 経由で消化するので safety net の Cache は掃除する (二重 navigate 防止)
+      void clearPendingIntent();
+      navigateOnce(target);
     };
 
-    sw.addEventListener('message', handler);
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void applyIntent();
+    };
+
+    sw?.addEventListener('message', handler);
+    document.addEventListener('visibilitychange', onVisibility);
+    void applyIntent();
+
     return () => {
-      sw.removeEventListener('message', handler);
+      cancelled = true;
+      sw?.removeEventListener('message', handler);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [navigate]);
 };

--- a/frontend/src/hooks/useFocusBlockOnMount.test.tsx
+++ b/frontend/src/hooks/useFocusBlockOnMount.test.tsx
@@ -1,0 +1,196 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { Provider as JotaiProvider } from 'jotai';
+import { HttpResponse, http } from 'msw';
+import type { ReactNode } from 'react';
+import { BrowserRouter, MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { selectedPageIdAtom } from '@/atoms/tripPage';
+import { useFocusBlockOnMount } from '@/hooks/useFocusBlockOnMount';
+import { appStore } from '@/lib/store';
+import { server } from '../../tests/msw/server';
+
+// jsdom は scrollIntoView を提供しないので prototype に stub を生やす
+const scrollIntoViewMock = vi.fn();
+Element.prototype.scrollIntoView = scrollIntoViewMock as unknown as Element['scrollIntoView'];
+
+const scheduleBlockJson = (id: number, pageId: number) => ({
+  id,
+  page_id: pageId,
+  block_type: 'event' as const,
+  title: 'schedule block',
+  start_time: '2026-01-01T09:00:00',
+  end_time: '2026-01-01T10:00:00',
+  detail: null,
+  location_id: null,
+  location: null,
+});
+
+const LocationCapture = ({ onLocation }: { onLocation: (search: string) => void }) => {
+  const location = useLocation();
+  onLocation(location.search);
+  return null;
+};
+
+const HookHost = () => {
+  useFocusBlockOnMount();
+  return <div data-block-id='42'>target</div>;
+};
+
+const renderWithRouter = (initialPath: string, onLocation: (search: string) => void) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={appStore}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <LocationCapture onLocation={onLocation} />
+        <Routes>
+          <Route path='*' element={children} />
+        </Routes>
+      </MemoryRouter>
+    </JotaiProvider>
+  );
+  return render(<HookHost />, { wrapper: Wrapper });
+};
+
+describe('useFocusBlockOnMount', () => {
+  beforeEach(() => {
+    appStore.set(selectedPageIdAtom, undefined);
+    scrollIntoViewMock.mockReset();
+  });
+
+  it('?focusBlock が無ければ何もしない', async () => {
+    let currentSearch = '';
+    renderWithRouter('/trip/abc', s => {
+      currentSearch = s;
+    });
+
+    // マウント直後に副作用が完了する
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('非数値の focusBlock は block fetch せず query param のみ掃除する', async () => {
+    let apiCalled = false;
+    server.use(
+      http.get('*/blocks/*', () => {
+        apiCalled = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=abc', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(apiCalled).toBe(false);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('block ロード成功時に selectedPageId 切り替え + scrollIntoView + query param 掃除を行う', async () => {
+    server.use(http.get('*/blocks/42', () => HttpResponse.json(scheduleBlockJson(42, 7))));
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=42', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    });
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+  });
+
+  it('block が 404 の場合は selectedPageId を変えず query param のみ掃除する', async () => {
+    server.use(http.get('*/blocks/999', () => new HttpResponse(null, { status: 404 })));
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=999', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('同一マウント中に focusBlock が 42→99 と変わったら 2 回目も再処理する', async () => {
+    server.use(
+      http.get('*/blocks/42', () => HttpResponse.json(scheduleBlockJson(42, 7))),
+      http.get('*/blocks/99', () => HttpResponse.json(scheduleBlockJson(99, 11)))
+    );
+
+    // SW → postMessage → useFcmNavigationListener の navigate() で同一マウント中に
+    // URL の focusBlock が差し替わるフローを再現するため、テスト内で navigate を外に取り出す。
+    const navigateHandle: { current: ((to: string) => void) | null } = { current: null };
+    const NavigateHandle = () => {
+      navigateHandle.current = useNavigate();
+      return null;
+    };
+
+    const searchRef = { current: '' };
+    const captureSearch = (s: string) => {
+      searchRef.current = s;
+    };
+
+    // 初期 URL を含めて BrowserRouter に載せる (window.history 経由で navigate 可能)
+    window.history.replaceState({}, '', '/trip/abc?focusBlock=42');
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={appStore}>
+        <BrowserRouter>
+          <NavigateHandle />
+          <LocationCapture onLocation={captureSearch} />
+          <Routes>
+            <Route path='*' element={children} />
+          </Routes>
+        </BrowserRouter>
+      </JotaiProvider>
+    );
+
+    render(
+      <>
+        <HookHost />
+        <div data-block-id='99'>target-99</div>
+      </>,
+      { wrapper: Wrapper }
+    );
+
+    // 1 回目: focusBlock=42 の処理完了を待つ
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+    // 2 回目: SPA navigate で URL に別の focusBlock を差し込む
+    scrollIntoViewMock.mockClear();
+    act(() => {
+      navigateHandle.current?.('/trip/abc?focusBlock=99');
+    });
+
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(11);
+    });
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+  });
+});

--- a/frontend/src/hooks/useFocusBlockOnMount.test.tsx
+++ b/frontend/src/hooks/useFocusBlockOnMount.test.tsx
@@ -175,7 +175,9 @@ describe('useFocusBlockOnMount', () => {
     await waitFor(() => {
       expect(searchRef.current).toBe('');
     });
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    });
 
     // 2 回目: SPA navigate で URL に別の focusBlock を差し込む
     scrollIntoViewMock.mockClear();
@@ -258,7 +260,9 @@ describe('useFocusBlockOnMount', () => {
     await waitFor(() => {
       expect(searchRef.current).toBe('');
     });
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    });
 
     // 2 回目: URL が /trip/abc に戻った状態から、同じ block へ再通知タップを再現
     scrollIntoViewMock.mockClear();

--- a/frontend/src/hooks/useFocusBlockOnMount.test.tsx
+++ b/frontend/src/hooks/useFocusBlockOnMount.test.tsx
@@ -281,4 +281,44 @@ describe('useFocusBlockOnMount', () => {
       expect(searchRef.current).toBe('');
     });
   });
+
+  it('block DOM 出現前に unmount された場合は scroll しない (AbortSignal で observer/timer/rAF が解放される)', async () => {
+    server.use(http.get('*/blocks/42', () => HttpResponse.json(scheduleBlockJson(42, 7))));
+
+    // data-block-id を持たない host。waitForBlockElement が MutationObserver で待機し続ける状態を作る。
+    const HookHostWithoutTarget = () => {
+      useFocusBlockOnMount();
+      return null;
+    };
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={appStore}>
+        <MemoryRouter initialEntries={['/trip/abc?focusBlock=42']}>
+          <Routes>
+            <Route path='*' element={children} />
+          </Routes>
+        </MemoryRouter>
+      </JotaiProvider>
+    );
+
+    const { unmount } = render(<HookHostWithoutTarget />, { wrapper: Wrapper });
+
+    // block 取得 → selectedPageId 切替までは進むが、DOM に data-block-id が無く scroll 待機のまま
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    // 待機中に unmount。以降 element を追加しても scroll は発火しないはず。
+    unmount();
+    const el = document.createElement('div');
+    el.setAttribute('data-block-id', '42');
+    document.body.appendChild(el);
+
+    // MutationObserver が abort で解放されていることを検証するため少し待つ。
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    document.body.removeChild(el);
+  });
 });

--- a/frontend/src/hooks/useFocusBlockOnMount.test.tsx
+++ b/frontend/src/hooks/useFocusBlockOnMount.test.tsx
@@ -193,4 +193,88 @@ describe('useFocusBlockOnMount', () => {
       expect(searchRef.current).toBe('');
     });
   });
+
+  it('focusBlock=0 は block ID として無効なので query 掃除だけ行う', async () => {
+    let apiCalled = false;
+    server.use(
+      http.get('*/blocks/*', () => {
+        apiCalled = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=0', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(apiCalled).toBe(false);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('同じ focusBlock=42 が clearParam 後にもう一度来ても再処理する', async () => {
+    server.use(http.get('*/blocks/42', () => HttpResponse.json(scheduleBlockJson(42, 7))));
+
+    const navigateHandle: { current: ((to: string) => void) | null } = { current: null };
+    const NavigateHandle = () => {
+      navigateHandle.current = useNavigate();
+      return null;
+    };
+
+    const searchRef = { current: '' };
+    const captureSearch = (s: string) => {
+      searchRef.current = s;
+    };
+
+    window.history.replaceState({}, '', '/trip/abc?focusBlock=42');
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={appStore}>
+        <BrowserRouter>
+          <NavigateHandle />
+          <LocationCapture onLocation={captureSearch} />
+          <Routes>
+            <Route path='*' element={children} />
+          </Routes>
+        </BrowserRouter>
+      </JotaiProvider>
+    );
+
+    render(
+      <>
+        <HookHost />
+      </>,
+      { wrapper: Wrapper }
+    );
+
+    // 1 回目: focusBlock=42 の処理完了 (page 切替 + scroll + clearParam) を待つ
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+    // 2 回目: URL が /trip/abc に戻った状態から、同じ block へ再通知タップを再現
+    scrollIntoViewMock.mockClear();
+    appStore.set(selectedPageIdAtom, undefined);
+    act(() => {
+      navigateHandle.current?.('/trip/abc?focusBlock=42');
+    });
+
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+  });
 });

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -1,0 +1,84 @@
+import { useSetAtom } from 'jotai';
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { selectedPageIdAtom } from '@/atoms/tripPage';
+import { useBlock } from '@/hooks/useBlocks';
+
+/**
+ * `?focusBlock={id}` を消費して該当 block まで scroll する。
+ *
+ * block が 404 (通知送信 → タップ間で削除) や非数値ゴミの場合は黙って query param 掃除だけ行う。
+ * urlId は URL path で保持されているので trip 画面自体は通常表示される。
+ */
+
+const FOCUS_BLOCK_PARAM = 'focusBlock';
+const SCROLL_WAIT_MAX_MS = 3000;
+
+const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => boolean): Promise<HTMLElement | null> =>
+  new Promise(resolve => {
+    const selector = `[data-block-id="${blockId}"]`;
+    const start = performance.now();
+    const tick = () => {
+      if (isCancelled()) return resolve(null);
+      const el = document.querySelector<HTMLElement>(selector);
+      if (el) return resolve(el);
+      if (performance.now() - start > maxMs) return resolve(null);
+      requestAnimationFrame(tick);
+    };
+    tick();
+  });
+
+export const useFocusBlockOnMount = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawFocusBlock = searchParams.get(FOCUS_BLOCK_PARAM);
+  const focusBlockId = rawFocusBlock != null && /^\d+$/.test(rawFocusBlock) ? Number(rawFocusBlock) : null;
+  const hasInvalidParam = rawFocusBlock != null && focusBlockId == null;
+
+  const setSelectedPageId = useSetAtom(selectedPageIdAtom);
+  const { block, error } = useBlock(focusBlockId);
+  // TripPage は unmount せず SPA navigate で URL だけ差し替わるため、boolean 一度きりゲートだと
+  // 通知連続タップ (42 → 99) の 2 回目が無視される。値ゲートにして rawFocusBlock が変わったら再処理する。
+  const consumedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (consumedKeyRef.current === rawFocusBlock) return;
+
+    const clearParam = () =>
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          next.delete(FOCUS_BLOCK_PARAM);
+          return next;
+        },
+        { replace: true }
+      );
+
+    if (hasInvalidParam) {
+      consumedKeyRef.current = rawFocusBlock;
+      clearParam();
+      return;
+    }
+    if (focusBlockId == null) return;
+    if (error) {
+      consumedKeyRef.current = rawFocusBlock;
+      clearParam();
+      return;
+    }
+    if (!block) return;
+
+    consumedKeyRef.current = rawFocusBlock;
+    setSelectedPageId(block.pageId);
+
+    let cancelled = false;
+    (async () => {
+      const el = await waitForBlockElement(focusBlockId, SCROLL_WAIT_MAX_MS, () => cancelled);
+      if (cancelled) return;
+      el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      clearParam();
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rawFocusBlock, focusBlockId, hasInvalidParam, block, error, setSelectedPageId, setSearchParams]);
+};

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -28,19 +28,35 @@ const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => 
     tick();
   });
 
+// block ID は BIGSERIAL PRIMARY KEY (正の整数) のみ有効。"0" / 桁溢れ / 非数値は不正値扱いで
+// query 掃除だけ行う。useBlock(0) が SWR の falsy key で fetch を止めるため、そのまま 0 を渡すと
+// block も error も来ず ref も query も更新されずスタックする。
+const parseFocusBlockId = (raw: string | null): number | null => {
+  if (raw == null || !/^[1-9]\d*$/.test(raw)) return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) ? n : null;
+};
+
 export const useFocusBlockOnMount = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawFocusBlock = searchParams.get(FOCUS_BLOCK_PARAM);
-  const focusBlockId = rawFocusBlock != null && /^\d+$/.test(rawFocusBlock) ? Number(rawFocusBlock) : null;
+  const focusBlockId = parseFocusBlockId(rawFocusBlock);
   const hasInvalidParam = rawFocusBlock != null && focusBlockId == null;
 
   const setSelectedPageId = useSetAtom(selectedPageIdAtom);
   const { block, error } = useBlock(focusBlockId);
-  // TripPage は unmount せず SPA navigate で URL だけ差し替わるため、boolean 一度きりゲートだと
-  // 通知連続タップ (42 → 99) の 2 回目が無視される。値ゲートにして rawFocusBlock が変わったら再処理する。
+  // 直前の rawFocusBlock を保持し、値が変わるまで再処理をブロックする。ref なので rerender は起こさない。
+  // - TripPage は SPA navigate で unmount しないので、連続通知 (42 → 99) の 2 回目を処理する
+  // - 消費済み記録は uncancelled 完了後 (async 内) にセット。StrictMode の double-fire で最初の async が
+  //   cancelled になっても 2 度目で確実に完走するため
+  // - query 掃除後 (rawFocusBlock === null) は ref をリセット。同一 block の再通知にも応答するため
   const consumedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
+    if (rawFocusBlock === null) {
+      consumedKeyRef.current = null;
+      return;
+    }
     if (consumedKeyRef.current === rawFocusBlock) return;
 
     const clearParam = () =>
@@ -66,7 +82,6 @@ export const useFocusBlockOnMount = () => {
     }
     if (!block) return;
 
-    consumedKeyRef.current = rawFocusBlock;
     setSelectedPageId(block.pageId);
 
     let cancelled = false;
@@ -75,6 +90,7 @@ export const useFocusBlockOnMount = () => {
       if (cancelled) return;
       el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
       clearParam();
+      consumedKeyRef.current = rawFocusBlock;
     })();
 
     return () => {

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -19,9 +19,12 @@ const FOCUS_BLOCK_PARAM = 'focusBlock';
 // rAF ポーリングだと 1 フレーム単位で無駄回転するので MutationObserver で DOM 変化を待つ。
 const SCROLL_WAIT_MAX_MS = 8000;
 
-const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => boolean): Promise<HTMLElement | null> =>
+// AbortSignal で observer / timer / rAF をまとめて解放できるようにする。cleanup の taskkill 経路が
+// unmount / focusBlock 変更 / StrictMode double-fire で確実に停止する。
+const waitForBlockElement = (blockId: number, maxMs: number, signal: AbortSignal): Promise<HTMLElement | null> =>
   new Promise(resolve => {
     const selector = `[data-block-id="${blockId}"]`;
+    if (signal.aborted) return resolve(null);
 
     const found = document.querySelector<HTMLElement>(selector);
     if (found) return resolve(found);
@@ -30,20 +33,24 @@ const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => 
     const finish = (el: HTMLElement | null) => {
       observer.disconnect();
       if (timeoutId !== null) clearTimeout(timeoutId);
+      signal.removeEventListener('abort', onAbort);
       resolve(el);
     };
+    const onAbort = () => finish(null);
 
     const observer = new MutationObserver(() => {
-      if (isCancelled()) return finish(null);
       const el = document.querySelector<HTMLElement>(selector);
       if (el) finish(el);
     });
     observer.observe(document.body, { childList: true, subtree: true });
     timeoutId = setTimeout(() => finish(null), maxMs);
+    signal.addEventListener('abort', onAbort);
   });
 
-// layout flush を 1 フレーム待ってから scroll する。Timeline が差し替わった直後は要素の
-// 位置計算がまだ確定していないことがあり、そのタイミングで scrollIntoView すると外れる。
+// layout flush を 1 フレーム待ってから scroll する。Timeline 差し替え直後は要素の位置計算が
+// まだ確定していないことがあり、そのタイミングで scrollIntoView すると外れる。
+// rAF は clearParam() 直後の cleanup と間に合わない race を避けるため cancel しない
+// (detached element への scrollIntoView は no-op なので害はない)。
 const scrollIntoViewOnNextFrame = (el: HTMLElement) => {
   requestAnimationFrame(() => {
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -106,17 +113,17 @@ export const useFocusBlockOnMount = () => {
 
     setSelectedPageId(block.pageId);
 
-    let cancelled = false;
+    const controller = new AbortController();
     (async () => {
-      const el = await waitForBlockElement(focusBlockId, SCROLL_WAIT_MAX_MS, () => cancelled);
-      if (cancelled) return;
+      const el = await waitForBlockElement(focusBlockId, SCROLL_WAIT_MAX_MS, controller.signal);
+      if (controller.signal.aborted) return;
       if (el) scrollIntoViewOnNextFrame(el);
       clearParam();
       consumedKeyRef.current = rawFocusBlock;
     })();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [rawFocusBlock, focusBlockId, hasInvalidParam, block, error, setSelectedPageId, setSearchParams]);
 };

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -49,8 +49,13 @@ const waitForBlockElement = (blockId: number, maxMs: number, signal: AbortSignal
 
 // layout flush を 1 フレーム待ってから scroll する。Timeline 差し替え直後は要素の位置計算が
 // まだ確定していないことがあり、そのタイミングで scrollIntoView すると外れる。
-// rAF は clearParam() 直後の cleanup と間に合わない race を避けるため cancel しない
-// (detached element への scrollIntoView は no-op なので害はない)。
+//
+// rAF は明示 cancel しない (AbortSignal 対象外)。abort 後に fire するパターンは 2 つあるが、
+// いずれも実害が小さい:
+//   - unmount 経由の abort: element が detach 済で scrollIntoView は no-op
+//   - focusBlock 変化経由の abort: 元 element に一瞬 scroll した後、新しい rAF が上書き
+// 逆に rAF を signal で cancel すると、clearParam() 直後の自 cleanup で成功パスの scroll
+// まで潰れるため、そちらの副作用の方が大きい。
 const scrollIntoViewOnNextFrame = (el: HTMLElement) => {
   requestAnimationFrame(() => {
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -12,21 +12,43 @@ import { useBlock } from '@/hooks/useBlocks';
  */
 
 const FOCUS_BLOCK_PARAM = 'focusBlock';
-const SCROLL_WAIT_MAX_MS = 3000;
+// 通知タップ → block 描画までに 2 段の非同期がある:
+//   1. useBlock(id) 単発 fetch → block.pageId 判明 → selectedPageId 切替
+//   2. useBlocks(pageId) list fetch 完了 → ViewTripLayout の Skeleton が Timeline に差し替わる
+// (2) が cold start で遅れると DOM に data-block-id が出るのに数秒かかることがある。
+// rAF ポーリングだと 1 フレーム単位で無駄回転するので MutationObserver で DOM 変化を待つ。
+const SCROLL_WAIT_MAX_MS = 8000;
 
 const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => boolean): Promise<HTMLElement | null> =>
   new Promise(resolve => {
     const selector = `[data-block-id="${blockId}"]`;
-    const start = performance.now();
-    const tick = () => {
-      if (isCancelled()) return resolve(null);
-      const el = document.querySelector<HTMLElement>(selector);
-      if (el) return resolve(el);
-      if (performance.now() - start > maxMs) return resolve(null);
-      requestAnimationFrame(tick);
+
+    const found = document.querySelector<HTMLElement>(selector);
+    if (found) return resolve(found);
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const finish = (el: HTMLElement | null) => {
+      observer.disconnect();
+      if (timeoutId !== null) clearTimeout(timeoutId);
+      resolve(el);
     };
-    tick();
+
+    const observer = new MutationObserver(() => {
+      if (isCancelled()) return finish(null);
+      const el = document.querySelector<HTMLElement>(selector);
+      if (el) finish(el);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    timeoutId = setTimeout(() => finish(null), maxMs);
   });
+
+// layout flush を 1 フレーム待ってから scroll する。Timeline が差し替わった直後は要素の
+// 位置計算がまだ確定していないことがあり、そのタイミングで scrollIntoView すると外れる。
+const scrollIntoViewOnNextFrame = (el: HTMLElement) => {
+  requestAnimationFrame(() => {
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  });
+};
 
 // block ID は BIGSERIAL PRIMARY KEY (正の整数) のみ有効。"0" / 桁溢れ / 非数値は不正値扱いで
 // query 掃除だけ行う。useBlock(0) が SWR の falsy key で fetch を止めるため、そのまま 0 を渡すと
@@ -88,7 +110,7 @@ export const useFocusBlockOnMount = () => {
     (async () => {
       const el = await waitForBlockElement(focusBlockId, SCROLL_WAIT_MAX_MS, () => cancelled);
       if (cancelled) return;
-      el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (el) scrollIntoViewOnNextFrame(el);
       clearParam();
       consumedKeyRef.current = rawFocusBlock;
     })();

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -14,6 +14,7 @@ import { TimelineSkeleton } from '@/components/timeline';
 import { Button } from '@/components/ui/button';
 import { useActivePage } from '@/hooks/useActivePage';
 import { useDragAutoScroll } from '@/hooks/useDragAutoScroll';
+import { useFocusBlockOnMount } from '@/hooks/useFocusBlockOnMount';
 import { usePages } from '@/hooks/usePages';
 import { useTripByUrlId } from '@/hooks/useTrips';
 import { useVisitedTrips } from '@/hooks/useVisitedTrips';
@@ -44,6 +45,7 @@ const TripPage = () => {
   const { pages, error: pagesError, isLoading: isPagesLoading } = usePages(trip?.id ?? null, { refreshInterval });
   const { addVisitedTrip } = useVisitedTrips();
   const { storedPageId, isActivePageInitialized, saveActivePageId } = useActivePage(trip?.id ?? null);
+  useFocusBlockOnMount();
 
   const isLoading = isTripLoading || isPagesLoading || !minLoadingComplete;
   const isError = tripError || pagesError;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,6 +64,11 @@ export default defineConfig({
       workbox: {
         navigateFallback: '/index.html',
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        // firebase-messaging-sw.js は別 scope で登録される独立 SW。VitePWA sw.js の
+        // precache に紛れ込むと、Chrome の register 時に fetch handler が cache 経由で
+        // 古い版を返し続けて更新が実機に届かなくなる。glob から除外必須。
+        globIgnores: ['**/firebase-messaging-sw.js'],
+        navigateFallbackDenylist: [/^\/firebase-messaging-sw\.js$/],
       },
     }),
   ],


### PR DESCRIPTION
Closes #207

## Summary

FCM 通知タップ時の挙動を Firebase デフォルトから明示ハンドラに置き換え、既存 PWA/tab を単一 tab のまま該当 block まで自動 scroll するようにする。#148 の P6b (別 issue 送り) の消化。

## やったこと

- **SW (`firebase-messaging-sw.js`)**: `notificationclick` handler を追加。既存 client を `focused > visible > 任意` の優先度で選び、`postMessage` で SPA navigate + `focus()`。無ければ `clients.openWindow`。別 origin URL は payload 経路含め弾く
- **Client (`useFcmNavigationListener`)**: SW からの `FCM_NAVIGATE` message を受けて React Router の `navigate()` を呼ぶ。App.tsx で 1 回登録
- **`useFocusBlockOnMount`**: `?focusBlock={id}` を `useBlock(id)` で解決 → `selectedPageId` 切替 → `data-block-id` の DOM を rAF 待機 → `scrollIntoView({ behavior: 'smooth', block: 'center' })` → `replaceState` で query 除去。404 / 非数値ゴミは黙って掃除
- **`useBlocks` populate**: list fetch 時に個別 key `/blocks/{id}` に populate し `useBlock` の重複 fetch を回避
- **View block 2 種に `data-block-id`** 付与 (edit モードは対象外)
- test: 上記 hook 2 種の unit test を追加 (12 tests)

## 設計上の判断 (コードから読めない部分)

### `postMessage` → `focus()` を選択 (`navigate()` ではなく)

`WindowClient.navigate(url)` はブラウザレベルのフル遷移になり atom / SWR / scroll 位置を全て失う。`postMessage` で client に指示を送って React Router で navigate すれば、同 trip 内の block 遷移は state を保ったまま `?focusBlock=` の差し替えだけで済み、別 trip でも SPA 遷移で初期 fetch キャッシュを保持できる。

### client 選択は `focused > visible > 任意` に統一

PWA client を自己申告方式で明示的に優先する案 (client → SW への postMessage + IndexedDB 永続化) も検討したが、SW ライフサイクル管理のコストに対して「PWA / ブラウザ tab 両方 background + PWA 期待」という限定的なエッジしか救えないため MVP は見送り。iOS は PWA のみで判別問題不発生。

### `useBlocks` populate は既存個別キャッシュを尊重

list revalidation が edit モードの 5s interval で走ると、`useUpdateBlock` の楽観更新値をサーバ古い値で上書きする race が発生する。`cache.get(key)?.data === undefined` の時のみ populate することで巻き戻し防止。以降の同期は `useUpdateBlock` 経由で行う。

### View mode のみ対応 (edit は対象外)

通知タップの用途は閲覧目的が大半で、`data-block-id` は View 系 Block コンポーネントにのみ付与。編集は遷移後にユーザが自発的に入れば十分。

## Test plan

- [x] type-check / lint / format
- [x] vitest (204 passed、うち今回追加 12 tests)
- [ ] stg 実機 verify
  - [ ] Android Chrome (通常 tab / PWA install)
  - [ ] iOS Safari PWA (install 済)
  - [ ] Desktop Chrome (フォアグラウンド / バックグラウンド両方)
  - [ ] 通知タップで該当 trip の該当 block まで scroll する
  - [ ] 別 trip 見てる時にタップで単一 tab で SPA 遷移する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 通知クリックから既存のアプリ画面へ遷移できるようになりました。
  * 対象のブロックを自動選択し、画面中央へスクロールします。
  * アプリが開いていない場合は、新しい画面でリンクを開きます。
* **改善**
  * 通知リンクの無効値や外部リンクを安全に処理します。
  * ブロック情報のキャッシュにより、表示の安定性を向上しました。
* **ドキュメント**
  * 通知による画面遷移とブロックフォーカスの仕様を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->