### PR TITLE
feat(#194): 認可のセッションキー方式化に向けた DB スキーマ追加

### DIFF
--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -1,30 +1,96 @@
 # DBの論理設計図
+
 ```mermaid
 erDiagram
-  Pages {
-    type name PK "Comment"
-    int id PK
-    int trip_id FK
-    str title "not null"
+  Users {
+    bigint id PK
+    varchar firebase_uid UK "nullable、Firebase Auth UID（匿名 user は NULL）"
+    timestamp created_at
+  }
+  Sessions {
+    varchar id PK "Cookie に載る session_id（不透明トークン）"
+    bigint user_id FK
+    timestamp created_at
+    timestamp last_seen_at
+  }
+  UserTripAccess {
+    bigint id PK
+    bigint user_id FK "(user_id, trip_id) の UNIQUE 制約に含まれる"
+    bigint trip_id FK "(user_id, trip_id) の UNIQUE 制約に含まれる"
+    bool archived "一覧からアーカイブされたか"
+    timestamp granted_at
   }
   Trips {
-    type name PK "Comment"
-    int id PK
-    str url_id UK "urlに含めるハッシュ値"
-    str title "not null"
-    str detail "not null"
+    bigint id PK
+    varchar url_id UK "URLに含めるハッシュ値"
+    varchar title
+    text detail "nullable"
+    date start_date "nullable"
+    date end_date "nullable"
+    timestamp created_at
+    timestamp updated_at
+    timestamp last_edited_at "配下 Page/Block の変更も含む"
+  }
+  Pages {
+    bigint id PK
+    bigint trip_id FK
+    varchar title
+    date date "nullable、ページの単日程"
   }
   Blocks {
-    type name PK "Comment"
-    int id PK
-    str title  "not null"
-    time start_time  "not null"
-    time end_time "nullable"
-    int page_id FK
-    str detail "not null"
-    enum block_type      "not null <br>schedule | transportation"
-    str transportation_type  "nullable"
+    bigint id PK
+    varchar title
+    timestamp start_time "UTC"
+    timestamp end_time "nullable、UTC"
+    bigint page_id FK
+    text detail "nullable"
+    varchar block_type "schedule / move"
+    varchar transportation_type "nullable、move のみ"
+    bigint location_id FK "nullable、schedule=この場所 / move=出発地"
+    bigint destination_location_id FK "nullable、move の目的地"
   }
-  Trips ||--o{ Pages :""
+  Locations {
+    bigint id PK
+    varchar google_place_id "nullable、Google Places の place_id"
+    varchar name
+    text address "nullable"
+    float latitude "nullable"
+    float longitude "nullable"
+    varchar website_uri "nullable"
+    timestamp created_at
+    timestamp updated_at
+  }
+  DeviceSubscriptions {
+    bigint id PK
+    varchar fcm_token "FCM registration token"
+    bigint trip_id FK "購読対象 Trip"
+    smallint minutes_before "通知先行分（1-120）"
+    varchar timezone "IANA TZ"
+    varchar user_agent "nullable、デバッグ用"
+    timestamp created_at
+    timestamp last_seen_at
+  }
+  SentNotifications {
+    bigint block_id PK,FK
+    varchar fcm_token PK
+    varchar kind PK "現状 before_5min 固定"
+    timestamp sent_at "送信ロック取得時刻"
+  }
+
+  Users ||--o{ Sessions : "1 user に複数デバイス"
+  Users ||--o{ UserTripAccess : ""
+  Trips ||--o{ UserTripAccess : ""
+  Trips ||--o{ Pages : ""
   Pages ||--o{ Blocks : ""
+  Locations ||--o{ Blocks : "location_id"
+  Locations ||--o{ Blocks : "destination_location_id"
+  Trips ||--o{ DeviceSubscriptions : ""
+  Blocks ||--o{ SentNotifications : ""
 ```
+
+## 認可モデルの補足
+
+- 認可判定は常に `UserTripAccess` を参照する（認証・未認証で分岐しない）
+- Cookie 発行時に匿名 `User` レコード (`firebase_uid IS NULL`) を自動作成
+- Firebase Auth 認証時、匿名 user の `firebase_uid` を埋めて昇格、または既存 user へマージ
+- `UserTripAccess.(user_id, trip_id)` の UNIQUE 制約と `INSERT ... ON CONFLICT DO NOTHING` により、並列付与の race を idempotent 化

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     CheckConstraint,
     Connection,
     Date,
@@ -311,6 +312,114 @@ class SentNotification(Base):
         server_default=func.now(),
         nullable=False,
         comment="送信ロックを取得した時刻",
+    )
+
+
+class User(Base):
+    """認可のための user 概念。
+
+    Cookie 発行時に匿名 user として自動作成される。Firebase Auth 認証時に
+    firebase_uid が埋められて認証済み user に昇格する。認可判定は常に
+    user_trip_access を参照するため、認証・未認証の分岐は user レコードの
+    firebase_uid が NULL かどうかだけに集約される。
+    """
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    firebase_uid: Mapped[str | None] = mapped_column(
+        String(128),
+        nullable=True,
+        unique=True,
+        comment="Firebase Authentication UID（匿名 user は NULL）",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="作成日時",
+    )
+
+
+class UserSession(Base):
+    """Cookie に載る不透明トークンで識別されるデバイスセッション。
+
+    テーブル名は業界慣習に沿って sessions。Python クラス名は
+    sqlalchemy.orm.Session との衝突回避のため UserSession とする。
+    """
+
+    __tablename__ = "sessions"
+
+    id: Mapped[str] = mapped_column(
+        String(32),
+        primary_key=True,
+        comment="Cookie に載る session_id（不透明トークン）",
+    )
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="紐付く user",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="作成日時",
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="最終アクセス日時",
+    )
+
+
+class UserTripAccess(Base):
+    """user × trip のアクセス権と一覧上のアーカイブ状態。
+
+    サロゲートキー id を PK とし、(user_id, trip_id) を UNIQUE 制約に置く。
+    並列付与の race は INSERT ... ON CONFLICT DO NOTHING (unique 制約経由) で
+    idempotent 化する (旧来の trip_ids 配列 JWT が read-modify-write で抱えていた
+    問題を根本解決)。将来カラム追加や個別参照が生じた際に扱いやすい構成。
+    """
+
+    __tablename__ = "user_trip_access"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "trip_id",
+            name="uq_user_trip_access_user_id_trip_id",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="アクセス権を持つ user",
+    )
+    trip_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("trips.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="アクセス可能な trip",
+    )
+    archived: Mapped[bool] = mapped_column(
+        Boolean,
+        server_default=text("false"),
+        nullable=False,
+        comment="一覧からアーカイブされたか",
+    )
+    granted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        comment="アクセス権を得た日時",
     )
 
 

--- a/server/migrations/versions/20260726_0000_add_users_sessions_and_user_trip_access_tables.py
+++ b/server/migrations/versions/20260726_0000_add_users_sessions_and_user_trip_access_tables.py
@@ -1,0 +1,170 @@
+"""add_users_sessions_and_user_trip_access_tables
+
+Revision ID: a7e8f1d9c342
+Revises: e6a2f9b18c34
+Create Date: 2026-07-26 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a7e8f1d9c342"
+down_revision: Union[str, Sequence[str], None] = "e6a2f9b18c34"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # users: 認可の主体。匿名 user は Cookie 発行時に自動作成される。
+    # Firebase Auth 認証時に firebase_uid が埋まって認証済み user に昇格。
+    op.create_table(
+        "users",
+        sa.Column(
+            "id",
+            sa.BigInteger(),
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "firebase_uid",
+            sa.String(length=128),
+            nullable=True,
+            comment="Firebase Authentication UID（匿名 user は NULL）",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="作成日時",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("firebase_uid", name="uq_users_firebase_uid"),
+    )
+
+    # sessions: Cookie に載る session_id → user_id の紐付け。
+    # user_id は CASCADE で、匿名 user 統合時に session を振り替えた後、
+    # 匿名 user を削除しても他 session が残らないようにする。
+    op.create_table(
+        "sessions",
+        sa.Column(
+            "id",
+            sa.String(length=32),
+            nullable=False,
+            comment="Cookie に載る session_id（不透明トークン）",
+        ),
+        sa.Column(
+            "user_id",
+            sa.BigInteger(),
+            nullable=False,
+            comment="紐付く user",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="作成日時",
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="最終アクセス日時",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_sessions_user_id",
+        "sessions",
+        ["user_id"],
+    )
+
+    # user_trip_access: user × trip のアクセス権と一覧アーカイブ状態。
+    # サロゲートキー id を PK とし、(user_id, trip_id) を UNIQUE 制約に置く。
+    # 並列付与の race は INSERT ... ON CONFLICT DO NOTHING (unique 制約経由) で
+    # idempotent 化する。将来カラム追加や個別参照が生じた際に扱いやすい。
+    op.create_table(
+        "user_trip_access",
+        sa.Column(
+            "id",
+            sa.BigInteger(),
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.BigInteger(),
+            nullable=False,
+            comment="アクセス権を持つ user",
+        ),
+        sa.Column(
+            "trip_id",
+            sa.BigInteger(),
+            nullable=False,
+            comment="アクセス可能な trip",
+        ),
+        sa.Column(
+            "archived",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+            comment="一覧からアーカイブされたか",
+        ),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="アクセス権を得た日時",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["trip_id"],
+            ["trips.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "trip_id",
+            name="uq_user_trip_access_user_id_trip_id",
+        ),
+    )
+    # user_id: 「この user が持つ access 一覧」を引くケース向け
+    op.create_index(
+        "idx_user_trip_access_user_id",
+        "user_trip_access",
+        ["user_id"],
+    )
+    # trip_id: 「その trip にアクセスできる user 一覧」を引くケース向け
+    op.create_index(
+        "idx_user_trip_access_trip_id",
+        "user_trip_access",
+        ["trip_id"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("idx_user_trip_access_trip_id", table_name="user_trip_access")
+    op.drop_index("idx_user_trip_access_user_id", table_name="user_trip_access")
+    op.drop_table("user_trip_access")
+    op.drop_index("idx_sessions_user_id", table_name="sessions")
+    op.drop_table("sessions")
+    op.drop_table("users")

--- a/server/migrations/versions/20260801_0000_add_users_sessions_and_user_trip_access_tables.py
+++ b/server/migrations/versions/20260801_0000_add_users_sessions_and_user_trip_access_tables.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 
 revision: str = "a7e8f1d9c342"
-down_revision: Union[str, Sequence[str], None] = "e6a2f9b18c34"
+down_revision: Union[str, Sequence[str], None] = "f7a1c2d3b4e5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/server/migrations/versions/20260801_0000_add_users_sessions_and_user_trip_access_tables.py
+++ b/server/migrations/versions/20260801_0000_add_users_sessions_and_user_trip_access_tables.py
@@ -1,6 +1,6 @@
 """add_users_sessions_and_user_trip_access_tables
 
-Revision ID: a7e8f1d9c342
+Revision ID: f7a1c2d3b4e5
 Revises: e6a2f9b18c34
 Create Date: 2026-07-26 00:00:00.000000
 

--- a/server/migrations/versions/20260801_0000_add_users_sessions_and_user_trip_access_tables.py
+++ b/server/migrations/versions/20260801_0000_add_users_sessions_and_user_trip_access_tables.py
@@ -1,7 +1,7 @@
 """add_users_sessions_and_user_trip_access_tables
 
-Revision ID: f7a1c2d3b4e5
-Revises: e6a2f9b18c34
+Revision ID: a7e8f1d9c342
+Revises: f7a1c2d3b4e5
 Create Date: 2026-07-26 00:00:00.000000
 
 """


### PR DESCRIPTION
## 概要

issue #194 の認可方式移行 (PR #210) の前段として、認可用テーブルを追加する。

## やったこと

- **`users`** — 認可の主体。Cookie 発行時に匿名 user (`firebase_uid IS NULL`) を自動作成し、Firebase 認証時に `firebase_uid` を埋めて昇格させる
- **`sessions`** — Cookie に載る `session_id` と `user_id` の紐付け
- **`user_trip_access`** — `(user_id, trip_id)` 複合 PK の中間表。並列付与の race を `INSERT ... ON CONFLICT DO NOTHING` で idempotent 化する
- **Alembic migration** (`20260726_0000_add_users_sessions_and_user_trip_access_tables.py`)
- **`docs/db_schema.md` を全面最新化**（既存欠落テーブル `Location`, `DeviceSubscription`, `SentNotification` も含めて全体を追記）

## 設計上の意思決定

- **`users.email` は保持しない**: Firebase Auth 側に一元化してプライバシー面積を最小化。Firebase Admin SDK で必要時に `firebase_uid` から取得可能
- **クラス名は `UserSession`、テーブル名は `sessions`**: `sqlalchemy.orm.Session` との名前衝突を避けつつテーブル命名は業界慣習に沿う
- **`user_trip_access` を複合 PK テーブルに**: 単一 PK + UK ではなく `(user_id, trip_id)` の複合 PK にすることで、`ON CONFLICT DO NOTHING` の効きが自然になる

## Test plan

- [x] Alembic migration が実行できる（本 PR の CI で確認）
- [x] `pnpm dotenvx run -- sh -c 'cd server && uv run pytest'` (既存テストを壊していないこと)

## 関連

- Issue: #194
- 後段: PR #210 (認可ロジック実装、Firebase Auth 統合、旧 Cookie 移行ミドルウェア等)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ユーザー、セッション、旅行単位のアクセス権を管理できるようになりました。
  * アーカイブ状態や関連情報を含む、ユーザーごとの旅行アクセス管理に対応しました。
  * 重複アクセスを防止し、関連データを安全に管理できるようになりました。

* **ドキュメント**
  * 認証、アクセス権、旅行、ページ、ブロック、位置情報、通知に関するデータベース設計を全面的に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->