### PR TITLE
refactor(#148): FastAPI の依存/パラメータを Annotated 形式に統一

### DIFF
--- a/server/app/auth.py
+++ b/server/app/auth.py
@@ -8,7 +8,7 @@
 
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import Literal
+from typing import Annotated, Literal
 from urllib.parse import urlparse
 
 import jwt
@@ -26,7 +26,7 @@ from app.models import Block, Page
 
 
 def require_basic_auth(
-    credentials: HTTPBasicCredentials = Depends(HTTPBasic()),
+    credentials: Annotated[HTTPBasicCredentials, Depends(HTTPBasic())],
 ) -> None:
     """Basic 認証で保護する。APIドキュメントや管理系エンドポイントで使用。"""
     settings = get_settings()
@@ -131,9 +131,9 @@ def require_trip_access(trip_id: int, request: Request) -> int:
 
 
 async def require_page_access(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     page_id: int,
     request: Request,
-    db: AsyncSession = Depends(get_db_session),
 ) -> int:
     """page_id から trip_id を解決し、アクセス権を検証する。"""
     result = await db.execute(select(Page.trip_id).where(Page.id == page_id))
@@ -148,9 +148,9 @@ async def require_page_access(
 
 
 async def require_block_access(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     block_id: int,
     request: Request,
-    db: AsyncSession = Depends(get_db_session),
 ) -> int:
     """block_id から trip_id を解決し、アクセス権を検証する。"""
     result = await db.execute(

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Annotated
 
 from fastapi import Depends, FastAPI, Query
 from fastapi.exceptions import RequestValidationError
@@ -49,7 +50,7 @@ app = FastAPI(
 
 @app.get("/docs", include_in_schema=False)
 async def swagger_ui(
-    _: None = Depends(require_basic_auth),
+    _: Annotated[None, Depends(require_basic_auth)],
 ) -> HTMLResponse:
     """
     説明:
@@ -61,7 +62,7 @@ async def swagger_ui(
 
 @app.get("/redoc", include_in_schema=False)
 async def redoc(
-    _: None = Depends(require_basic_auth),
+    _: Annotated[None, Depends(require_basic_auth)],
 ) -> HTMLResponse:
     """
     説明:
@@ -73,7 +74,7 @@ async def redoc(
 
 @app.get("/openapi.json", include_in_schema=False)
 async def openapi_schema(
-    _: None = Depends(require_basic_auth),
+    _: Annotated[None, Depends(require_basic_auth)],
 ) -> JSONResponse:
     """
     説明:
@@ -109,7 +110,9 @@ app.add_exception_handler(RequestValidationError, validation_exception_handler)
 
 @app.get("/health", tags=["Health"])
 async def health_check(
-    delay: float = Query(0, ge=0, le=30, description="デバッグ用: レスポンス遅延(秒)"),
+    delay: Annotated[
+        float, Query(ge=0, le=30, description="デバッグ用: レスポンス遅延(秒)")
+    ] = 0,
 ):
     """Renderのヘルスチェック用エンドポイント"""
     if delay > 0:

--- a/server/app/routers/blocks.py
+++ b/server/app/routers/blocks.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,10 +19,10 @@ router = APIRouter(tags=["Blocks"])
     response_model=Block,
 )
 async def create_block(
+    _: Annotated[int, Depends(require_page_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     page_id: int,
     block: BlockCreate,
-    _: int = Depends(require_page_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> Block:
     """
     説明:
@@ -38,9 +40,9 @@ async def create_block(
     response_model=list[Block],
 )
 async def get_blocks(
+    _: Annotated[int, Depends(require_page_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     page_id: int,
-    _: int = Depends(require_page_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> list[Block]:
     """
     説明:
@@ -57,9 +59,9 @@ async def get_blocks(
     response_model=Block,
 )
 async def get_block(
+    _: Annotated[int, Depends(require_block_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     block_id: int,
-    _: int = Depends(require_block_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> Block:
     """
     説明:
@@ -80,10 +82,10 @@ async def get_block(
     response_model=Block,
 )
 async def update_block(
+    _: Annotated[int, Depends(require_block_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     block_id: int,
     block: BlockUpdate,
-    _: int = Depends(require_block_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> Block:
     """
     説明:
@@ -106,9 +108,9 @@ async def update_block(
     status_code=204,
 )
 async def delete_block(
+    _: Annotated[int, Depends(require_block_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     block_id: int,
-    _: int = Depends(require_block_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> None:
     """
     説明:

--- a/server/app/routers/notification.py
+++ b/server/app/routers/notification.py
@@ -10,6 +10,7 @@
 
 import logging
 import time
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,12 +36,15 @@ _test_send_last_sent: dict[str, float] = {}
 
 
 def get_fcm_token_from_header(
-    x_fcm_token: str = Header(
-        min_length=1,
-        max_length=500,
-        alias="X-FCM-Token",
-        description="FCM registration token. URL クエリではなく header で受け取ることでアクセスログへの露出を避ける",
-    ),
+    x_fcm_token: Annotated[
+        str,
+        Header(
+            min_length=1,
+            max_length=500,
+            alias="X-FCM-Token",
+            description="FCM registration token. URL クエリではなく header で受け取ることでアクセスログへの露出を避ける",
+        ),
+    ],
 ) -> str:
     return x_fcm_token
 
@@ -53,9 +57,9 @@ def get_fcm_token_from_header(
     status_code=status.HTTP_201_CREATED,
 )
 async def subscribe(
+    trip_id: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     payload: DeviceSubscriptionCreate,
-    trip_id: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> DeviceSubscription:
     """指定 Trip に対して端末を購読させる。既存があれば timezone/minutes_before/user_agent を更新。"""
     sub = await notif_cruds.upsert_subscription(db, trip_id=trip_id, payload=payload)
@@ -69,9 +73,9 @@ async def subscribe(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def unsubscribe(
-    fcm_token: str = Depends(get_fcm_token_from_header),
-    trip_id: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
+    fcm_token: Annotated[str, Depends(get_fcm_token_from_header)],
+    trip_id: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> None:
     """指定 (fcm_token, trip_id) の購読を解除する。存在しなくても 204。"""
     await notif_cruds.delete_subscription(db, trip_id=trip_id, fcm_token=fcm_token)
@@ -84,9 +88,9 @@ async def unsubscribe(
     response_model=DeviceSubscription | None,
 )
 async def get_subscription(
-    fcm_token: str = Depends(get_fcm_token_from_header),
-    trip_id: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
+    fcm_token: Annotated[str, Depends(get_fcm_token_from_header)],
+    trip_id: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> DeviceSubscription | None:
     """指定 (fcm_token, trip_id) の購読レコードを返す。無ければ null。"""
     sub = await notif_cruds.get_subscription(db, trip_id=trip_id, fcm_token=fcm_token)
@@ -102,9 +106,9 @@ async def get_subscription(
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def send_test_notification(
-    fcm_token: str = Depends(get_fcm_token_from_header),
-    trip_id: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
+    fcm_token: Annotated[str, Depends(get_fcm_token_from_header)],
+    trip_id: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> dict[str, str]:
     """自端末にテスト通知を即座に送信する (二重クリック防止で 1 秒に 1 回まで)。"""
     sub = await notif_cruds.get_subscription(db, trip_id=trip_id, fcm_token=fcm_token)
@@ -126,7 +130,11 @@ async def send_test_notification(
         raise NotFound(message="Trip not found")
 
     settings = get_settings()
-    frontend_base = "https://tabishare.net" if settings.environment == "production" else "https://st.tabishare.net"
+    frontend_base = (
+        "https://tabishare.net"
+        if settings.environment == "production"
+        else "https://st.tabishare.net"
+    )
     try:
         send_fcm(
             token=fcm_token,

--- a/server/app/routers/notification_internal.py
+++ b/server/app/routers/notification_internal.py
@@ -8,6 +8,7 @@
 
 import logging
 import time
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from firebase_admin import exceptions as firebase_exceptions
@@ -103,7 +104,9 @@ def _build_badge_url() -> str:
     operation_id="notification-tick",
     dependencies=[Depends(verify_cloud_scheduler_oidc)],
 )
-async def tick(db: AsyncSession = Depends(get_db_session)) -> dict[str, int]:
+async def tick(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> dict[str, int]:
     """通知候補をスキャンし、送信ロックを取ったものだけ FCM に送信する。
 
     Cloud Scheduler から 1 分ごとに叩かれる想定。

--- a/server/app/routers/pages.py
+++ b/server/app/routers/pages.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,10 +21,10 @@ router = APIRouter(tags=["Pages"])
     response_model=PageCreateResponse,
 )
 async def create_page(
+    _: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     trip_id: int,
     page: PageCreate,
-    _: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> PageCreateResponse:
     """
     説明:
@@ -39,9 +41,9 @@ async def create_page(
     response_model=list[Page],
 )
 async def get_pages(
+    _: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     trip_id: int,
-    _: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> list[Page]:
     """
     説明:
@@ -58,9 +60,9 @@ async def get_pages(
     response_model=Page,
 )
 async def get_page(
+    _: Annotated[int, Depends(require_page_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     page_id: int,
-    _: int = Depends(require_page_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> Page:
     """
     説明:
@@ -81,10 +83,10 @@ async def get_page(
     response_model=Page,
 )
 async def update_page(
+    _: Annotated[int, Depends(require_page_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     page_id: int,
     page: PageUpdate,
-    _: int = Depends(require_page_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> Page:
     """
     説明:
@@ -105,9 +107,9 @@ async def update_page(
     status_code=204,
 )
 async def delete_page(
+    _: Annotated[int, Depends(require_page_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     page_id: int,
-    _: int = Depends(require_page_access),
-    db: AsyncSession = Depends(get_db_session),
 ):
     """
     説明:

--- a/server/app/routers/trips.py
+++ b/server/app/routers/trips.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Request, Response
 from nanoid import generate
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,10 +22,10 @@ URL_ID_SIZE = 16
     response_model=TripCreateOut,
 )
 async def create_trip(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     trip_in: TripCreateIn,
     request: Request,
     response: Response,
-    db: AsyncSession = Depends(get_db_session),
 ) -> TripCreateOut:
     """
     説明:
@@ -46,8 +48,8 @@ async def create_trip(
     response_model=list[Trip],
 )
 async def list_trips(
-    _: None = Depends(require_basic_auth),
-    db: AsyncSession = Depends(get_db_session),
+    _: Annotated[None, Depends(require_basic_auth)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> list[Trip]:
     """
     説明:
@@ -64,9 +66,9 @@ async def list_trips(
     response_model=Trip,
 )
 async def get_trip(
+    _: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     trip_id: int,
-    _: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> Trip:
     """
     説明:
@@ -87,10 +89,10 @@ async def get_trip(
     response_model=Trip,
 )
 async def get_trip_by_url_id(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     url_id: str,
     request: Request,
     response: Response,
-    db: AsyncSession = Depends(get_db_session),
 ) -> Trip:
     """
     説明:
@@ -113,10 +115,10 @@ async def get_trip_by_url_id(
     response_model=Trip,
 )
 async def update_trip(
+    _: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     trip_id: int,
     trip_in: TripUpdate,
-    _: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> Trip:
     """
     説明:
@@ -137,9 +139,9 @@ async def update_trip(
     status_code=204,
 )
 async def delete_trip(
+    _: Annotated[int, Depends(require_trip_access)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
     trip_id: int,
-    _: int = Depends(require_trip_access),
-    db: AsyncSession = Depends(get_db_session),
 ) -> None:
     """
     説明:


### PR DESCRIPTION
## 概要
FastAPI の依存/パラメータをすべて `Annotated` 形式に統一する。

## 詳細
- `Depends`/`Query`/`Header` をデフォルト値へ直接代入する旧形式（`x: T = Depends(...)`）を廃止し、`x: Annotated[T, Depends(...)]` 形式に統一（`main.py` / `auth.py` / `routers/*.py`）
- DI (`Depends`) 系の引数は関数シグネチャの先頭に配置し、依存関係が一目で分かるように並び替え
- 挙動・OpenAPIスキーマへの影響なし（純粋なシグネチャの書き方変更）
- ruff/mypyの体制強化（FAST002ルール追加・検証スクリプト・CI変更）は別PR #214 に分離

## 動作確認
- `uv run ruff check app/` — pass
- アプリ import + `app.openapi()` によるスモークテスト（DIグラフ・引数順の破綻を検出）— 11 paths, 25 routes で成功

## 確認項目
- [x] 動作確認を実施している
- [ ] issueはPRページ右下のDevelopmentからissueが紐づいている

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>