### PR TITLE
chore(#207): 通知タップ切り分け用 診断ロガー [DO NOT MERGE]

### DIFF
--- a/docs/memo/notification_deeplink_findings.md
+++ b/docs/memo/notification_deeplink_findings.md
@@ -1,0 +1,44 @@
+# 通知タップ deep link 実機検証で判明した仕様 (Issue #207)
+
+> 本メモは検証ブランチ `chore/issue207_debug-logger` (PR #216 / DO NOT MERGE)
+> で Android PWA 実機を使って一連の切り分けを行った結果、**検証で確定した仕様**
+> のみを記録する。実装の意思決定は #209 の commit / PR description に残す。
+
+## FCM SW の update lifecycle
+
+- **FCM SW は root scope 外 (`/firebase-cloud-messaging-push-scope`) に登録される**ため、navigation 由来の SW update check が発火しない
+- `navigator.serviceWorker.register()` の byte-diff check は PWA セッション中 1 回のみ (呼び出し側の promise cache により再呼び出しされない)
+- **明示 `registration.update()` が唯一の SW 更新経路**
+- SW default lifecycle だと new SW は install → waiting のまま、既存 client が全部閉じるまで activate されない
+- install イベントで `self.skipWaiting()` を呼ぶと即 waiting をスキップして activate に遷移する
+- activate イベントで `self.clients.claim()` を呼ぶと既存 client (root scope 含む) の controller にもなれる
+
+## VitePWA precache との干渉
+
+- `workbox.globPatterns: ['**/*.{js,...}']` は **firebase-messaging-sw.js を precache 対象に取り込む**
+- 結果、Chrome の `register('/firebase-messaging-sw.js')` 時に VitePWA sw.js の fetch handler が cache 経由で古い版を返す → 新 SW が実機で永遠に active にならない
+- **対策**: `workbox.globIgnores` + `navigateFallbackDenylist` で firebase-messaging-sw.js を除外
+
+## FCM payload に載る deep link の位置
+
+- Firebase Admin SDK v13 の `WebpushFCMOptions(link=...)` を指定して送ると、SDK v12.16 の client 側では **`data.FCM_MSG.notification.click_action`** に写された payload が届く
+- foreground 通知 (`useForegroundNotificationToast` の自前 `showNotification`) 経由の場合は **`data.link`** に相対 URL が入る (別経路)
+- extract 順は `click_action` を primary、`data.link` を fallback にする
+
+## Firebase Hosting のデフォルト cache header
+
+- 静的ファイルに `cache-control: max-age=3600` (1 時間) がデフォルトで付く
+- **SW file にこれが効くと deploy 直後でも update が実機に届くまで最悪 1 時間遅延する**
+- `firebase.json` の `headers` で `/firebase-messaging-sw.js` に `Cache-Control: no-cache, no-store, must-revalidate` を指定して抑制
+
+## task-killed 状態からの通知タップ
+
+- PWA を recents から swipe out した完全終了状態で通知タップすると、SW の `matchAll` は **0 件**を返す (phantom client を返さない)
+- `clients.openWindow(url)` で PWA が起動し、**渡した URL が尊重されて focusBlock まで適用**される (Android Chrome 実機で確認)
+- postMessage 未着ケース想定の Cache Storage safety net (SW → client の遅延伝達経路) は **不要**と確認された
+
+## block DOM の描画タイミング
+
+- `ViewTripLayout` は `useBlocks(pageId).isLoading` 中は `TimelineSkeleton` を返す構造 → 該当 page への `setSelectedPageId` 直後は `data-block-id` の DOM が未存在
+- rAF ポーリングだと Skeleton → Timeline 差し替え待ちで空回りする → **MutationObserver で DOM 変更 event 単位に補足**
+- staging Cold Start では Skeleton → Timeline 差し替えまで 3 秒を超えるケースがあり、**timeout は 8 秒**確保する

--- a/docs/memo/notification_roadmap.md
+++ b/docs/memo/notification_roadmap.md
@@ -53,9 +53,9 @@ graph LR
 - [x] Deep link URL 埋め込み (`?focusBlock={block_id}` を FCM `data.link` に付与)
 - [x] フォアグラウンド OS 通知 (`useForegroundNotificationToast` → `registration.showNotification`)
 
-### Phase 6b-9: 未実装 (別 PR / Follow-up)
+### Phase 6b-9
 
-- [ ] SW `notificationclick` ハンドラ (tap 時に `focusBlock` を消費してブロックまでスクロール)
+- [x] SW `notificationclick` ハンドラ (#207): tap で既存 client に postMessage → SPA navigate、無ければ openWindow。client 側は `useFocusBlockOnMount` で block まで scroll
 - [ ] Phase 7: stg 環境 E2E テスト (iOS/Android/Desktop 実機)
 - [ ] Phase 8: prod リリース + Cloud Scheduler ジョブ作成
 - [ ] Phase 9 (#173): `sent_notifications` 掃除 cron

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -196,7 +196,7 @@ tick が 60 秒を超えると次 tick と重なる。閾値と対処:
   - 素材: FA (frontend/src/assets/icons) + Lucide MapPin。オレンジバッジ (`#f4a261`) + 白抜き
 - **Badge** (Android status bar 等の小モノクロアイコン、96px、透過 PNG): `badge.png` を全通知で共通使用。紙飛行機シルエット (favicon 由来)、OS 側でアクセントカラーへリカラーされる。icon と別 URL にしないと Android で四角い塗りになる
 - 生成スクリプト: `scripts/gen_notification_icons.py`
-- **Deep link**: `/trip/{urlId}?focusBlock={blockId}` (該当ブロックにスクロール、Phase 2 で完全実装)
+- **Deep link**: `/trip/{urlId}?focusBlock={blockId}`。SW `notificationclick` (`frontend/public/firebase-messaging-sw.js`) が受け、既存 PWA/tab (focused > visible > 任意) に postMessage で client-side navigate、無ければ `clients.openWindow`。client 側は `useFocusBlockOnMount` で `useBlock(id)` から pageId を得て page 切替 → `[data-block-id]` を rAF 待機して `scrollIntoView` (center)。処理後 `focusBlock` は replaceState で除去。
 
 ## 6. プラットフォーム対応
 

--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,14 @@
           "source": "**",
           "destination": "/index.html"
         }
+      ],
+      "headers": [
+        {
+          "source": "/firebase-messaging-sw.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+          ]
+        }
       ]
     },
     {
@@ -20,6 +28,14 @@
           "source": "**",
           "destination": "/index.html"
         }
+      ],
+      "headers": [
+        {
+          "source": "/firebase-messaging-sw.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+          ]
+        }
       ]
     },
     {
@@ -30,6 +46,14 @@
         {
           "source": "**",
           "destination": "/index.html"
+        }
+      ],
+      "headers": [
+        {
+          "source": "/firebase-messaging-sw.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+          ]
         }
       ]
     }

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -12,7 +12,7 @@
 // DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
 // DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
 // 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
-const DEBUG_LOG_VERSION = 'v04-sw-2026-08-01';
+const DEBUG_LOG_VERSION = 'v05-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;
@@ -56,6 +56,18 @@ const debugLog = async (tag, message, data) => {
 
 // SW script が evaluate されたタイミングを残す。SW 更新のタイミング把握用。
 void debugLog('SW', 'sw script evaluated');
+
+// 新版 SW の active 待ち (デフォルト挙動) だと既存 tab が全部閉じるまで古い SW が動き続ける。
+// notificationclick handler / extractDeepLink の修正が実機に届かないケースが観測されたため
+// install → skipWaiting、activate → clients.claim で強制的に即切替させる。
+self.addEventListener('install', event => {
+  void debugLog('SW', 'install (skipWaiting)');
+  event.waitUntil(self.skipWaiting());
+});
+self.addEventListener('activate', event => {
+  void debugLog('SW', 'activate (clients.claim)');
+  event.waitUntil(self.clients.claim());
+});
 
 // FCM payload に載る deep link の位置は複数の可能性がある:
 // - `data.FCM_MSG.notification.click_action`: Firebase Admin SDK で WebpushFCMOptions(link=...) を

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -12,7 +12,7 @@
 // DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
 // DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
 // 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
-const DEBUG_LOG_VERSION = 'v08-sw-2026-08-01';
+const DEBUG_LOG_VERSION = 'v09-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -12,7 +12,7 @@
 // DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
 // DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
 // 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
-const DEBUG_LOG_VERSION = 'v05-sw-2026-08-01';
+const DEBUG_LOG_VERSION = 'v06-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;
@@ -67,6 +67,15 @@ self.addEventListener('install', event => {
 self.addEventListener('activate', event => {
   void debugLog('SW', 'activate (clients.claim)');
   event.waitUntil(self.clients.claim());
+});
+// client 側 (useFcmNavigationListener) が既に waiting 状態の SW を叩き起こすためのハンドラ。
+// 未来の SW が仮に install で skipWaiting を呼ばない実装になっても、client 側からこの経路で
+// 強制 activate に持ち込めるよう保険を挟む。
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    void debugLog('SW', 'SKIP_WAITING received');
+    void self.skipWaiting();
+  }
 });
 
 // FCM payload に載る deep link の位置は複数の可能性がある:

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -1,6 +1,62 @@
 // biome-ignore-all lint/correctness/noUndeclaredVariables: firebase / importScripts は SW context の global
 // biome-ignore-all lint/correctness/noUnusedFunctionParameters: onBackgroundMessage の signature は Firebase 規定
 
+// notificationclick handler は Firebase SDK の import / init より前に登録する必要がある。
+// Firebase Messaging SDK は内部で notificationclick リスナーを付け stopImmediatePropagation
+// することがあり、後付けで addEventListener すると invocation されないケースがある。
+// (`firebase-js-sdk/packages/messaging/src/listeners/sw-listeners.ts` の実装参照)
+
+// Firebase Admin SDK の WebpushFCMOptions.link は data.FCM_MSG.fcmOptions.link に入る。
+// フォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由は data.link。
+const extractDeepLink = notification => {
+  const data = notification?.data ?? {};
+  return data?.FCM_MSG?.fcmOptions?.link ?? data?.link ?? null;
+};
+
+// PWA / ブラウザ tab 両方 push 登録している端末で、ユーザが今触ってる方を選ぶための優先度。
+const pickTargetClient = clientsList => {
+  return (
+    clientsList.find(c => c.focused) ?? clientsList.find(c => c.visibilityState === 'visible') ?? clientsList[0] ?? null
+  );
+};
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+
+  const link = extractDeepLink(event.notification);
+  if (!link) return;
+
+  // payload 経路経由の open-redirect を防ぐ (別 origin URL は捨てる)。
+  let targetUrl;
+  try {
+    targetUrl = new URL(link, self.location.origin);
+  } catch {
+    return;
+  }
+  if (targetUrl.origin !== self.location.origin) return;
+
+  event.waitUntil(
+    (async () => {
+      const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+      const target = pickTargetClient(clientsList);
+
+      if (target) {
+        // WindowClient.navigate() を使うとフルリロードで atom / SWR / scroll 位置が飛ぶので、
+        // 代わりに client 側で React Router の navigate を呼んでもらう。
+        target.postMessage({ type: 'FCM_NAVIGATE', url: targetUrl.href });
+        try {
+          await target.focus();
+        } catch {
+          // focus はユーザ操作起源でないと reject されるが、postMessage は届いてるので許容
+        }
+        return;
+      }
+
+      await self.clients.openWindow(targetUrl.href);
+    })()
+  );
+});
+
 importScripts('https://www.gstatic.com/firebasejs/12.16.0/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/12.16.0/firebase-messaging-compat.js');
 

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -12,7 +12,7 @@
 // DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
 // DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
 // 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
-const DEBUG_LOG_VERSION = 'v06-sw-2026-08-01';
+const DEBUG_LOG_VERSION = 'v07-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -20,6 +20,25 @@ const pickTargetClient = clientsList => {
   );
 };
 
+// postMessage 経路が届かない状況の safety net として target URL を Cache Storage に書き残す。
+// client 側 (useFcmNavigationListener) は mount + visibilitychange のたびに読んで navigate する。
+// 起こりうる postMessage 未着ケース:
+//   - PWA が Android にキルされていて matchAll 上は phantom client、focus() では OS が task を
+//     復帰させるが postMessage は event loop で drain されない
+//   - cold start で client 側 message listener 登録前に SW が postMessage 送出
+const INTENT_CACHE = 'fcm-nav-intent-v1';
+// Cache API は Request URL をキーに使うため、実在しない同 origin URL を予約して衝突を避ける。
+const INTENT_KEY = new URL('/__fcm_pending_nav__', self.location.origin).href;
+
+const storePendingIntent = async url => {
+  try {
+    const cache = await caches.open(INTENT_CACHE);
+    await cache.put(new Request(INTENT_KEY), new Response(url, { headers: { 'content-type': 'text/plain' } }));
+  } catch {
+    // Cache API 非対応 / QuotaExceeded 等は best effort として無視
+  }
+};
+
 self.addEventListener('notificationclick', event => {
   event.notification.close();
 
@@ -37,6 +56,9 @@ self.addEventListener('notificationclick', event => {
 
   event.waitUntil(
     (async () => {
+      // storage 完了を focus/openWindow より前に保証。client 側の visibilitychange で確実に拾える。
+      await storePendingIntent(targetUrl.href);
+
       const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
       const target = pickTargetClient(clientsList);
 

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -12,7 +12,7 @@
 // DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
 // DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
 // 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
-const DEBUG_LOG_VERSION = 'v07-sw-2026-08-01';
+const DEBUG_LOG_VERSION = 'v08-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;
@@ -68,15 +68,9 @@ self.addEventListener('activate', event => {
   void debugLog('SW', 'activate (clients.claim)');
   event.waitUntil(self.clients.claim());
 });
-// client 側 (useFcmNavigationListener) が既に waiting 状態の SW を叩き起こすためのハンドラ。
-// 未来の SW が仮に install で skipWaiting を呼ばない実装になっても、client 側からこの経路で
-// 強制 activate に持ち込めるよう保険を挟む。
-self.addEventListener('message', event => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    void debugLog('SW', 'SKIP_WAITING received');
-    void self.skipWaiting();
-  }
-});
+// [Round 1 削減] SKIP_WAITING message handler は client 側の
+// registration.update() 経路と対で削除。install → skipWaiting のデフォルトルートのみで
+// 更新が成立するか検証する。
 
 // FCM payload に載る deep link の位置は複数の可能性がある:
 // - `data.FCM_MSG.notification.click_action`: Firebase Admin SDK で WebpushFCMOptions(link=...) を
@@ -97,24 +91,8 @@ const pickTargetClient = clientsList => {
   );
 };
 
-// postMessage 経路が届かない状況の safety net として target URL を Cache Storage に書き残す。
-// client 側 (useFcmNavigationListener) は mount + visibilitychange のたびに読んで navigate する。
-// 起こりうる postMessage 未着ケース:
-//   - PWA が Android にキルされていて matchAll 上は phantom client、focus() では OS が task を
-//     復帰させるが postMessage は event loop で drain されない
-//   - cold start で client 側 message listener 登録前に SW が postMessage 送出
-const INTENT_CACHE = 'fcm-nav-intent-v1';
-// Cache API は Request URL をキーに使うため、実在しない同 origin URL を予約して衝突を避ける。
-const INTENT_KEY = new URL('/__fcm_pending_nav__', self.location.origin).href;
-
-const storePendingIntent = async url => {
-  try {
-    const cache = await caches.open(INTENT_CACHE);
-    await cache.put(new Request(INTENT_KEY), new Response(url, { headers: { 'content-type': 'text/plain' } }));
-  } catch {
-    // Cache API 非対応 / QuotaExceeded 等は best effort として無視
-  }
-};
+// [Round 1 削減] Cache Storage safety net (storePendingIntent) と client 側 applyIntent 経路を削除。
+// SW 更新問題 (真の原因) が解決した今、postMessage + focus + openWindow fallback だけで十分か検証する。
 
 self.addEventListener('notificationclick', event => {
   event.notification.close();
@@ -139,10 +117,6 @@ self.addEventListener('notificationclick', event => {
 
   event.waitUntil(
     (async () => {
-      // storage 完了を focus/openWindow より前に保証。client 側の visibilitychange で確実に拾える。
-      await storePendingIntent(targetUrl.href);
-      void debugLog('SW', 'intent stored', { url: targetUrl.href });
-
       const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
       void debugLog('SW', 'matchAll', {
         n: clientsList.length,

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -6,6 +6,50 @@
 // することがあり、後付けで addEventListener すると invocation されないケースがある。
 // (`firebase-js-sdk/packages/messaging/src/listeners/sw-listeners.ts` の実装参照)
 
+// --- 診断ロガー (client 側 lib/debugLogger.ts と同じ DB / store) ---
+// Android PWA から console を取れない環境向け。SW から IndexedDB に書いて client 側で
+// 読み出す。運用機能ではないので消しても実装挙動には影響しない。
+const DEBUG_DB = 'fcm-debug-log';
+const DEBUG_STORE = 'entries';
+const DEBUG_MAX = 500;
+const openDebugDb = () =>
+  new Promise((resolve, reject) => {
+    const req = indexedDB.open(DEBUG_DB, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(DEBUG_STORE)) {
+        db.createObjectStore(DEBUG_STORE, { autoIncrement: true });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+const debugLog = async (tag, message, data) => {
+  try {
+    const db = await openDebugDb();
+    const tx = db.transaction(DEBUG_STORE, 'readwrite');
+    const store = tx.objectStore(DEBUG_STORE);
+    const safeData = data === undefined ? null : JSON.parse(JSON.stringify(data));
+    store.add({ ts: Date.now(), tag, message, data: safeData });
+    const countReq = store.count();
+    countReq.onsuccess = () => {
+      const excess = countReq.result - DEBUG_MAX;
+      if (excess <= 0) return;
+      const cursorReq = store.openCursor();
+      let remaining = excess;
+      cursorReq.onsuccess = e => {
+        const cursor = e.target.result;
+        if (!cursor || remaining <= 0) return;
+        cursor.delete();
+        remaining -= 1;
+        cursor.continue();
+      };
+    };
+  } catch (_) {
+    // logger must not throw
+  }
+};
+
 // Firebase Admin SDK の WebpushFCMOptions.link は data.FCM_MSG.fcmOptions.link に入る。
 // フォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由は data.link。
 const extractDeepLink = notification => {
@@ -41,39 +85,55 @@ const storePendingIntent = async url => {
 
 self.addEventListener('notificationclick', event => {
   event.notification.close();
+  void debugLog('SW', 'notificationclick', { data: event.notification.data });
 
   const link = extractDeepLink(event.notification);
+  void debugLog('SW', 'link extracted', { link });
   if (!link) return;
 
   // payload 経路経由の open-redirect を防ぐ (別 origin URL は捨てる)。
   let targetUrl;
   try {
     targetUrl = new URL(link, self.location.origin);
-  } catch {
+  } catch (err) {
+    void debugLog('SW', 'URL parse fail', { err: String(err) });
     return;
   }
-  if (targetUrl.origin !== self.location.origin) return;
+  if (targetUrl.origin !== self.location.origin) {
+    void debugLog('SW', 'origin mismatch', { target: targetUrl.origin, self: self.location.origin });
+    return;
+  }
 
   event.waitUntil(
     (async () => {
       // storage 完了を focus/openWindow より前に保証。client 側の visibilitychange で確実に拾える。
       await storePendingIntent(targetUrl.href);
+      void debugLog('SW', 'intent stored', { url: targetUrl.href });
 
       const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+      void debugLog('SW', 'matchAll', {
+        n: clientsList.length,
+        clients: clientsList.map(c => ({ url: c.url, focused: c.focused, vis: c.visibilityState })),
+      });
       const target = pickTargetClient(clientsList);
+      void debugLog('SW', 'target picked', { url: target ? target.url : null });
 
       if (target) {
         // WindowClient.navigate() を使うとフルリロードで atom / SWR / scroll 位置が飛ぶので、
         // 代わりに client 側で React Router の navigate を呼んでもらう。
         target.postMessage({ type: 'FCM_NAVIGATE', url: targetUrl.href });
+        void debugLog('SW', 'postMessage sent', { url: targetUrl.href });
         try {
           await target.focus();
-        } catch {
+          void debugLog('SW', 'focus ok');
+        } catch (err) {
           // focus はユーザ操作起源でないと reject されるが、postMessage は届いてるので許容
+          void debugLog('SW', 'focus fail', { err: String(err) });
         }
         return;
       }
 
+      void debugLog('SW', 'openWindow fallback', { url: targetUrl.href });
       await self.clients.openWindow(targetUrl.href);
     })()
   );

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -12,7 +12,7 @@
 // DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
 // DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
 // 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
-const DEBUG_LOG_VERSION = 'v03-sw-2026-08-01';
+const DEBUG_LOG_VERSION = 'v04-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;
@@ -57,11 +57,16 @@ const debugLog = async (tag, message, data) => {
 // SW script が evaluate されたタイミングを残す。SW 更新のタイミング把握用。
 void debugLog('SW', 'sw script evaluated');
 
-// Firebase Admin SDK の WebpushFCMOptions.link は data.FCM_MSG.fcmOptions.link に入る。
-// フォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由は data.link。
+// FCM payload に載る deep link の位置は複数の可能性がある:
+// - `data.FCM_MSG.notification.click_action`: Firebase Admin SDK で WebpushFCMOptions(link=...) を
+//   指定した場合、SDK 12.x が実 payload に写す形。実機ログで確認済で **これが primary**
+// - `data.FCM_MSG.fcmOptions.link`: SDK バージョンや Admin SDK 経路によってはこちらに入るとの
+//   資料あり (残しておく安全策)
+// - `data.link`: フォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由
 const extractDeepLink = notification => {
   const data = notification?.data ?? {};
-  return data?.FCM_MSG?.fcmOptions?.link ?? data?.link ?? null;
+  const fcm = data?.FCM_MSG;
+  return fcm?.notification?.click_action ?? fcm?.fcmOptions?.link ?? data?.link ?? null;
 };
 
 // PWA / ブラウザ tab 両方 push 登録している端末で、ユーザが今触ってる方を選ぶための優先度。

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -12,7 +12,7 @@
 // DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
 // DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
 // 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
-const DEBUG_LOG_VERSION = 'v02-sw-2026-08-01';
+const DEBUG_LOG_VERSION = 'v03-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -9,6 +9,10 @@
 // --- 診断ロガー (client 側 lib/debugLogger.ts と同じ DB / store) ---
 // Android PWA から console を取れない環境向け。SW から IndexedDB に書いて client 側で
 // 読み出す。運用機能ではないので消しても実装挙動には影響しない。
+// DEBUG_LOG_VERSION は診断コード修正のたびに手動で bump する。client 側 debugLogger.ts の
+// DEBUG_LOG_VERSION と対で更新。ログ各行に埋め込まれるので、実機で古い SW が動いているのか
+// 新しい SW が動いているのかを共有ログから判別できる (SW 更新は非同期でユーザ操作依存なため)。
+const DEBUG_LOG_VERSION = 'v02-sw-2026-08-01';
 const DEBUG_DB = 'fcm-debug-log';
 const DEBUG_STORE = 'entries';
 const DEBUG_MAX = 500;
@@ -30,7 +34,7 @@ const debugLog = async (tag, message, data) => {
     const tx = db.transaction(DEBUG_STORE, 'readwrite');
     const store = tx.objectStore(DEBUG_STORE);
     const safeData = data === undefined ? null : JSON.parse(JSON.stringify(data));
-    store.add({ ts: Date.now(), tag, message, data: safeData });
+    store.add({ ts: Date.now(), version: DEBUG_LOG_VERSION, tag, message, data: safeData });
     const countReq = store.count();
     countReq.onsuccess = () => {
       const excess = countReq.result - DEBUG_MAX;
@@ -49,6 +53,9 @@ const debugLog = async (tag, message, data) => {
     // logger must not throw
   }
 };
+
+// SW script が evaluate されたタイミングを残す。SW 更新のタイミング把握用。
+void debugLog('SW', 'sw script evaluated');
 
 // Firebase Admin SDK の WebpushFCMOptions.link は data.FCM_MSG.fcmOptions.link に入る。
 // フォアグラウンド通知 (useForegroundNotificationToast) の自前 showNotification 経由は data.link。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import { isOfflineReadAtom } from './atoms/network';
 import { NoIndex } from './components/NoIndex';
 import { Title } from './components/Title';
+import { useFcmNavigationListener } from './hooks/useFcmNavigationListener';
 import { useForegroundNotificationToast } from './hooks/useForegroundNotificationToast';
 import { useNetworkToast } from './hooks/useNetworkToast';
 import { usePageTracking } from './hooks/usePageTracking';
@@ -19,6 +20,7 @@ const App = () => {
   useNetworkToast();
   usePageTracking();
   useForegroundNotificationToast();
+  useFcmNavigationListener();
 
   return (
     <>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from 'jotai';
 import { Route, Routes } from 'react-router-dom';
 import { isOfflineReadAtom } from './atoms/network';
+import { DebugLogPanel } from './components/DebugLogPanel';
 import { NoIndex } from './components/NoIndex';
 import { Title } from './components/Title';
 import { useFcmNavigationListener } from './hooks/useFcmNavigationListener';
@@ -54,6 +55,7 @@ const App = () => {
           }
         />
       </Routes>
+      <DebugLogPanel />
     </>
   );
 };

--- a/frontend/src/components/DebugLogPanel.tsx
+++ b/frontend/src/components/DebugLogPanel.tsx
@@ -1,5 +1,5 @@
 import { toast } from 'sonner';
-import { clearAllLogs, readAllLogs } from '@/lib/debugLogger';
+import { clearAllLogs, DEBUG_LOG_VERSION, readAllLogs } from '@/lib/debugLogger';
 
 /**
  * 診断ブランチ (chore/issue207_debug-logger) 専用: 右下に Copy / Clear ボタンを常時表示する。
@@ -18,17 +18,24 @@ const copyText = async (text: string): Promise<boolean> => {
 const DebugLogPanel = () => {
   const onCopy = async () => {
     const logs = await readAllLogs();
-    if (!logs) {
-      toast.info('ログなし');
-      return;
-    }
-    const lines = logs.split('\n').length;
-    const ok = await copyText(logs);
+    const controllerUrl = navigator.serviceWorker?.controller?.scriptURL ?? '(no controller)';
+    const header = [
+      '=== fcm debug log ===',
+      `client version: ${DEBUG_LOG_VERSION}`,
+      `sw controller:  ${controllerUrl}`,
+      `current URL:    ${window.location.href}`,
+      `copied at:      ${new Date().toISOString()}`,
+      '=====================',
+    ].join('\n');
+    const body = logs || '(no entries)';
+    const payload = `${header}\n${body}`;
+    const lines = body.split('\n').length;
+    const ok = await copyText(payload);
     if (ok) {
-      toast.success(`${lines} 件コピー`);
+      toast.success(`${lines} 件コピー (+ header)`);
     } else {
       // クリップボード拒否時は prompt で見せて手動コピー
-      window.prompt('コピーしてください', logs);
+      window.prompt('コピーしてください', payload);
     }
   };
 

--- a/frontend/src/components/DebugLogPanel.tsx
+++ b/frontend/src/components/DebugLogPanel.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { clearAllLogs, readAllLogs } from '@/lib/debugLogger';
+
+/**
+ * `?debug=1` 付きで開くと localStorage に永続化され、右下に Copy / Clear ボタンを表示する。
+ * `?debug=0` で解除。Android PWA で console 取れないときの診断用。
+ */
+
+const STORAGE_KEY = '__fcm_debug_panel__';
+
+const isEnabled = (): boolean => {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('debug');
+    if (q === '1') {
+      localStorage.setItem(STORAGE_KEY, '1');
+      return true;
+    }
+    if (q === '0') {
+      localStorage.removeItem(STORAGE_KEY);
+      return false;
+    }
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+};
+
+const copyText = async (text: string): Promise<boolean> => {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const DebugLogPanel = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(isEnabled());
+  }, []);
+
+  if (!visible) return null;
+
+  const onCopy = async () => {
+    const logs = await readAllLogs();
+    if (!logs) {
+      toast.info('ログなし');
+      return;
+    }
+    const lines = logs.split('\n').length;
+    const ok = await copyText(logs);
+    if (ok) {
+      toast.success(`${lines} 件コピー`);
+    } else {
+      // クリップボード拒否時は prompt で見せて手動コピー
+      window.prompt('コピーしてください', logs);
+    }
+  };
+
+  const onClear = async () => {
+    await clearAllLogs();
+    toast.success('ログをクリア');
+  };
+
+  return (
+    <div className='fixed right-2 bottom-2 z-50 flex gap-1 rounded-lg bg-black/80 p-1 text-10px text-white'>
+      <button type='button' onClick={onCopy} className='cursor-pointer rounded bg-teal-600 px-2 py-1 hover:bg-teal-500'>
+        Copy Logs
+      </button>
+      <button type='button' onClick={onClear} className='cursor-pointer rounded bg-red-600 px-2 py-1 hover:bg-red-500'>
+        Clear
+      </button>
+    </div>
+  );
+};
+
+export { DebugLogPanel };

--- a/frontend/src/components/DebugLogPanel.tsx
+++ b/frontend/src/components/DebugLogPanel.tsx
@@ -1,31 +1,10 @@
-import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { clearAllLogs, readAllLogs } from '@/lib/debugLogger';
 
 /**
- * `?debug=1` 付きで開くと localStorage に永続化され、右下に Copy / Clear ボタンを表示する。
- * `?debug=0` で解除。Android PWA で console 取れないときの診断用。
+ * 診断ブランチ (chore/issue207_debug-logger) 専用: 右下に Copy / Clear ボタンを常時表示する。
+ * PR #216 は Draft & DO NOT MERGE 前提。gate 無しで install 直後から使える状態にしておく。
  */
-
-const STORAGE_KEY = '__fcm_debug_panel__';
-
-const isEnabled = (): boolean => {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    const q = params.get('debug');
-    if (q === '1') {
-      localStorage.setItem(STORAGE_KEY, '1');
-      return true;
-    }
-    if (q === '0') {
-      localStorage.removeItem(STORAGE_KEY);
-      return false;
-    }
-    return localStorage.getItem(STORAGE_KEY) === '1';
-  } catch {
-    return false;
-  }
-};
 
 const copyText = async (text: string): Promise<boolean> => {
   try {
@@ -37,14 +16,6 @@ const copyText = async (text: string): Promise<boolean> => {
 };
 
 const DebugLogPanel = () => {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    setVisible(isEnabled());
-  }, []);
-
-  if (!visible) return null;
-
   const onCopy = async () => {
     const logs = await readAllLogs();
     if (!logs) {

--- a/frontend/src/components/blocks/view/BlockScheduleView.tsx
+++ b/frontend/src/components/blocks/view/BlockScheduleView.tsx
@@ -55,6 +55,7 @@ export function BlockScheduleView({ block, isNow, className }: BlockScheduleView
   return (
     <div
       ref={resizeRef}
+      data-block-id={block.id}
       className={cn(
         'relative flex w-full flex-col gap-2 rounded-lg bg-linear-to-r from-teal-400 px-4 py-2',
         isHovered ? 'to-teal-400' : 'to-teal-500',

--- a/frontend/src/components/blocks/view/BlockTransportationView.tsx
+++ b/frontend/src/components/blocks/view/BlockTransportationView.tsx
@@ -45,6 +45,7 @@ export function BlockTransportationView({ block, isNow, className }: BlockTransp
   return (
     <div
       ref={resizeRef}
+      data-block-id={block.id}
       className={cn(
         'relative flex w-full flex-col gap-2 rounded-lg bg-gradient-to-r from-sky-50 px-2 py-2 sm:px-4',
         isHovered ? 'to-sky-50' : 'to-sky-100',

--- a/frontend/src/hooks/useBlocks.ts
+++ b/frontend/src/hooks/useBlocks.ts
@@ -14,11 +14,22 @@ const BLOCKS_BASE_PATH = '/blocks';
  * pageId に紐づく Block をすべて取得するフック
  */
 export const useBlocks = (pageId: number | null, options?: Pick<SWRConfiguration, 'refreshInterval'>) => {
+  const { mutate: globalMutate, cache } = useSWRConfig();
   const { data, error, isLoading } = useSWR<Block[]>(
     pageId ? `${PAGES_BASE_PATH}/${pageId}/blocks` : null,
     async (url: string) => {
       const res = await fetcher(url);
-      return z.array(blockFromApi).parse(res);
+      const parsed = z.array(blockFromApi).parse(res);
+      // list fetch で得た block を個別 key にも撒いて useBlock(id) の重複 fetch を避ける
+      // (通知タップの deep link 解決経路で効く)。ただし既存値は上書きしない:
+      // 楽観更新中の値を list revalidation の古いサーバ値で巻き戻すのを防ぐため。
+      for (const block of parsed) {
+        const individualKey = `${BLOCKS_BASE_PATH}/${block.id}`;
+        if (cache.get(individualKey)?.data === undefined) {
+          globalMutate(individualKey, block, { revalidate: false });
+        }
+      }
+      return parsed;
     },
     options
   );

--- a/frontend/src/hooks/useFcmNavigationListener.test.tsx
+++ b/frontend/src/hooks/useFcmNavigationListener.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockNavigate = vi.fn();
@@ -26,45 +26,14 @@ const dispatchSwMessage = (data: unknown) => {
   for (const listener of swListeners) listener(event);
 };
 
-// jsdom は Cache API 未実装なのでインメモリスタブを差し込む
-const cacheEntries = new Map<string, string>();
-
-const cacheStub: Cache = {
-  put: async (request: RequestInfo | URL, response: Response) => {
-    const key = typeof request === 'string' ? request : (request as Request).url;
-    cacheEntries.set(key, await response.text());
-  },
-  match: async (request: RequestInfo | URL) => {
-    const key = typeof request === 'string' ? request : (request as Request).url;
-    const value = cacheEntries.get(key);
-    return value === undefined ? undefined : new Response(value);
-  },
-  delete: async (request: RequestInfo | URL) => {
-    const key = typeof request === 'string' ? request : (request as Request).url;
-    return cacheEntries.delete(key);
-  },
-} as unknown as Cache;
-
-const cachesStub: CacheStorage = {
-  open: async () => cacheStub,
-} as unknown as CacheStorage;
-
-const INTENT_KEY = 'http://localhost:3000/__fcm_pending_nav__';
-
-const seedPendingIntent = (url: string) => {
-  cacheEntries.set(INTENT_KEY, url);
-};
-
 describe('useFcmNavigationListener', () => {
   beforeEach(() => {
     swListeners.clear();
-    cacheEntries.clear();
     mockNavigate.mockClear();
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: swStub,
     });
-    vi.stubGlobal('caches', cachesStub);
   });
 
   afterEach(() => {
@@ -72,7 +41,6 @@ describe('useFcmNavigationListener', () => {
       configurable: true,
       value: undefined,
     });
-    vi.unstubAllGlobals();
   });
 
   it('FCM_NAVIGATE メッセージ受信で navigate() を pathname+search+hash 付きで呼ぶ', () => {
@@ -140,52 +108,11 @@ describe('useFcmNavigationListener', () => {
     expect(swListeners.size).toBe(0);
   });
 
-  it('mount 時に Cache Storage に intent があれば navigate する (postMessage 未着 fallback)', async () => {
-    seedPendingIntent('http://localhost:3000/trip/xyz?focusBlock=7');
-
+  it('現在 URL と一致するときは navigate しない', () => {
     renderHook(() => useFcmNavigationListener());
 
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/xyz?focusBlock=7');
-    });
-    expect(cacheEntries.has(INTENT_KEY)).toBe(false);
-  });
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: window.location.href });
 
-  it('mount 時に intent が現在 URL と一致するなら navigate しない', async () => {
-    seedPendingIntent(window.location.href);
-
-    renderHook(() => useFcmNavigationListener());
-
-    await Promise.resolve();
-    await Promise.resolve();
     expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('visibilitychange (visible) で cache 内 intent を消化する', async () => {
-    renderHook(() => useFcmNavigationListener());
-
-    seedPendingIntent('http://localhost:3000/trip/later?focusBlock=99');
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
-    act(() => {
-      document.dispatchEvent(new Event('visibilitychange'));
-    });
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/later?focusBlock=99');
-    });
-  });
-
-  it('postMessage で navigate した場合は cache 内 intent も掃除する (二重 navigate 防止)', async () => {
-    seedPendingIntent('http://localhost:3000/trip/abc?focusBlock=42');
-
-    renderHook(() => useFcmNavigationListener());
-
-    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'http://localhost:3000/trip/abc?focusBlock=42' });
-
-    await waitFor(() => {
-      expect(cacheEntries.has(INTENT_KEY)).toBe(false);
-    });
-    // navigate は message 経由の 1 回のみ。mount 時 applyIntent は cache が既に空になってて no-op
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/useFcmNavigationListener.test.tsx
+++ b/frontend/src/hooks/useFcmNavigationListener.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+import { useFcmNavigationListener } from '@/hooks/useFcmNavigationListener';
+
+type SwEventListener = (event: MessageEvent) => void;
+
+const swListeners = new Set<SwEventListener>();
+
+const swStub = {
+  addEventListener: (type: string, listener: SwEventListener) => {
+    if (type === 'message') swListeners.add(listener);
+  },
+  removeEventListener: (type: string, listener: SwEventListener) => {
+    if (type === 'message') swListeners.delete(listener);
+  },
+};
+
+const dispatchSwMessage = (data: unknown) => {
+  const event = { data } as MessageEvent;
+  for (const listener of swListeners) listener(event);
+};
+
+describe('useFcmNavigationListener', () => {
+  beforeEach(() => {
+    swListeners.clear();
+    mockNavigate.mockClear();
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: swStub,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it('FCM_NAVIGATE メッセージ受信で navigate() を pathname+search+hash 付きで呼ぶ', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'http://localhost:3000/trip/abc?focusBlock=42#top' });
+
+    expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/abc?focusBlock=42#top');
+  });
+
+  it('FCM_NAVIGATE 以外のメッセージは無視する', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'SOME_OTHER', url: 'http://localhost:3000/trip/xxx' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('別 origin の URL は無視する (open-redirect 対策)', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'https://evil.example.com/trip/abc' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('非 http scheme (javascript:) は同 origin にならず遷移しない', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'javascript:alert(1)' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('url が string でなければ無視する', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 42 });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('data が undefined でも throw しない', () => {
+    renderHook(() => useFcmNavigationListener());
+
+    expect(() => dispatchSwMessage(undefined)).not.toThrow();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('unmount 時に listener を解除する', () => {
+    const { unmount } = renderHook(() => useFcmNavigationListener());
+
+    expect(swListeners.size).toBe(1);
+    unmount();
+    expect(swListeners.size).toBe(0);
+  });
+
+  it('navigator.serviceWorker が無い環境では何もしない', () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(() => renderHook(() => useFcmNavigationListener())).not.toThrow();
+    expect(swListeners.size).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useFcmNavigationListener.test.tsx
+++ b/frontend/src/hooks/useFcmNavigationListener.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockNavigate = vi.fn();
@@ -26,14 +26,45 @@ const dispatchSwMessage = (data: unknown) => {
   for (const listener of swListeners) listener(event);
 };
 
+// jsdom は Cache API 未実装なのでインメモリスタブを差し込む
+const cacheEntries = new Map<string, string>();
+
+const cacheStub: Cache = {
+  put: async (request: RequestInfo | URL, response: Response) => {
+    const key = typeof request === 'string' ? request : (request as Request).url;
+    cacheEntries.set(key, await response.text());
+  },
+  match: async (request: RequestInfo | URL) => {
+    const key = typeof request === 'string' ? request : (request as Request).url;
+    const value = cacheEntries.get(key);
+    return value === undefined ? undefined : new Response(value);
+  },
+  delete: async (request: RequestInfo | URL) => {
+    const key = typeof request === 'string' ? request : (request as Request).url;
+    return cacheEntries.delete(key);
+  },
+} as unknown as Cache;
+
+const cachesStub: CacheStorage = {
+  open: async () => cacheStub,
+} as unknown as CacheStorage;
+
+const INTENT_KEY = 'http://localhost:3000/__fcm_pending_nav__';
+
+const seedPendingIntent = (url: string) => {
+  cacheEntries.set(INTENT_KEY, url);
+};
+
 describe('useFcmNavigationListener', () => {
   beforeEach(() => {
     swListeners.clear();
+    cacheEntries.clear();
     mockNavigate.mockClear();
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: swStub,
     });
+    vi.stubGlobal('caches', cachesStub);
   });
 
   afterEach(() => {
@@ -41,6 +72,7 @@ describe('useFcmNavigationListener', () => {
       configurable: true,
       value: undefined,
     });
+    vi.unstubAllGlobals();
   });
 
   it('FCM_NAVIGATE メッセージ受信で navigate() を pathname+search+hash 付きで呼ぶ', () => {
@@ -98,7 +130,7 @@ describe('useFcmNavigationListener', () => {
     expect(swListeners.size).toBe(0);
   });
 
-  it('navigator.serviceWorker が無い環境では何もしない', () => {
+  it('navigator.serviceWorker が無い環境でも throw しない', () => {
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: undefined,
@@ -106,5 +138,54 @@ describe('useFcmNavigationListener', () => {
 
     expect(() => renderHook(() => useFcmNavigationListener())).not.toThrow();
     expect(swListeners.size).toBe(0);
+  });
+
+  it('mount 時に Cache Storage に intent があれば navigate する (postMessage 未着 fallback)', async () => {
+    seedPendingIntent('http://localhost:3000/trip/xyz?focusBlock=7');
+
+    renderHook(() => useFcmNavigationListener());
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/xyz?focusBlock=7');
+    });
+    expect(cacheEntries.has(INTENT_KEY)).toBe(false);
+  });
+
+  it('mount 時に intent が現在 URL と一致するなら navigate しない', async () => {
+    seedPendingIntent(window.location.href);
+
+    renderHook(() => useFcmNavigationListener());
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('visibilitychange (visible) で cache 内 intent を消化する', async () => {
+    renderHook(() => useFcmNavigationListener());
+
+    seedPendingIntent('http://localhost:3000/trip/later?focusBlock=99');
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/trip/later?focusBlock=99');
+    });
+  });
+
+  it('postMessage で navigate した場合は cache 内 intent も掃除する (二重 navigate 防止)', async () => {
+    seedPendingIntent('http://localhost:3000/trip/abc?focusBlock=42');
+
+    renderHook(() => useFcmNavigationListener());
+
+    dispatchSwMessage({ type: 'FCM_NAVIGATE', url: 'http://localhost:3000/trip/abc?focusBlock=42' });
+
+    await waitFor(() => {
+      expect(cacheEntries.has(INTENT_KEY)).toBe(false);
+    });
+    // navigate は message 経由の 1 回のみ。mount 時 applyIntent は cache が既に空になってて no-op
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -66,11 +66,15 @@ const parseSameOriginPath = (rawUrl: string): string | null => {
   return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 };
 
+// 1 通知タップに対して message + intent の 2 経路が近接発火するのを dedupe する時間窓。
+// これ以上経過したら別イベント扱いで同 URL への遷移も許可する (通知を連続タップした時等)。
+const NAV_DEDUPE_WINDOW_MS = 1000;
+
 export const useFcmNavigationListener = () => {
   const navigate = useNavigate();
-  // fast path (message) と safety net (cache) が同一 URL に対して二重発火するのを防ぐ。
-  // 直近の遷移先を保持し、同値なら skip する。
-  const lastNavigatedRef = useRef<string | null>(null);
+  // 直近の遷移先とタイムスタンプ。時間窓を過ぎたら別イベントとして再遷移を許可する。
+  // 以前は unmount まで保持する ref で「一度行った URL には二度と行けない」バグがあった。
+  const lastNavRef = useRef<{ url: string; at: number } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -81,11 +85,13 @@ export const useFcmNavigationListener = () => {
         void debugLog('CL', 'navigateOnce skip (== current)', { target, source });
         return;
       }
-      if (lastNavigatedRef.current === target) {
-        void debugLog('CL', 'navigateOnce skip (== last)', { target, source });
+      const last = lastNavRef.current;
+      const now = performance.now();
+      if (last !== null && last.url === target && now - last.at < NAV_DEDUPE_WINDOW_MS) {
+        void debugLog('CL', 'navigateOnce skip (dedupe window)', { target, source, ageMs: now - last.at });
         return;
       }
-      lastNavigatedRef.current = target;
+      lastNavRef.current = { url: target, at: now };
       void debugLog('CL', 'navigate() called', { target, source });
       navigate(target);
     };

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -128,6 +128,44 @@ export const useFcmNavigationListener = () => {
       currentUrl: window.location.href,
       clientVersion: DEBUG_LOG_VERSION,
     });
+
+    // FCM SW は root scope に居ないので navigation では update check されず、
+    // register() は起動時 1 回のみ (lib/messaging.ts の promise cache のため)。
+    // 明示的に update() を叩いて Chrome に新 SW の byte-diff check を促し、
+    // waiting になった SW があれば SKIP_WAITING message で即 activate に持ち込む。
+    void (async () => {
+      if (!sw) return;
+      try {
+        const reg = await sw.getRegistration('/firebase-cloud-messaging-push-scope');
+        if (!reg) {
+          void debugLog('CL', 'fcm registration not found');
+          return;
+        }
+        reg.addEventListener('updatefound', () => {
+          const newSw = reg.installing;
+          void debugLog('CL', 'fcm updatefound', { installingUrl: newSw?.scriptURL ?? null });
+          newSw?.addEventListener('statechange', () => {
+            void debugLog('CL', 'fcm new sw statechange', { state: newSw.state });
+            if (newSw.state === 'installed' && reg.waiting) {
+              reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+              void debugLog('CL', 'sent SKIP_WAITING (post-install)');
+            }
+          });
+        });
+        await reg.update();
+        void debugLog('CL', 'fcm update() done', {
+          activeUrl: reg.active?.scriptURL ?? null,
+          waitingUrl: reg.waiting?.scriptURL ?? null,
+          installingUrl: reg.installing?.scriptURL ?? null,
+        });
+        if (reg.waiting) {
+          reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+          void debugLog('CL', 'sent SKIP_WAITING (existing waiting)');
+        }
+      } catch (err) {
+        void debugLog('CL', 'fcm update fail', { err: String(err) });
+      }
+    })();
     // 全 SW registration の state を吐き出す。root scope (VitePWA) と
     // /firebase-cloud-messaging-push-scope (FCM) の new/waiting/active を可視化して、
     // 古い FCM SW が waiting のまま残ってないか確認する。

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * firebase-messaging-sw.js の notificationclick が postMessage する
+ * `{ type: 'FCM_NAVIGATE', url }` を受けて React Router で navigate する。
+ * App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
+ */
+export const useFcmNavigationListener = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // 参照を effect スコープに固定: cleanup 時に navigator.serviceWorker が消えていても
+    // (テスト環境で差し替えると起こる) removeEventListener で crash させない。
+    const sw = typeof navigator !== 'undefined' ? navigator.serviceWorker : undefined;
+    if (!sw) return;
+
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type !== 'FCM_NAVIGATE') return;
+      const rawUrl = event.data.url;
+      if (typeof rawUrl !== 'string') return;
+
+      let parsed: URL;
+      try {
+        parsed = new URL(rawUrl, window.location.origin);
+      } catch {
+        return;
+      }
+      // SW 側でも弾いているが、payload 経路の open-redirect 対策として二重防御。
+      if (parsed.origin !== window.location.origin) return;
+
+      navigate(`${parsed.pathname}${parsed.search}${parsed.hash}`);
+    };
+
+    sw.addEventListener('message', handler);
+    return () => {
+      sw.removeEventListener('message', handler);
+    };
+  }, [navigate]);
+};

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -7,9 +7,11 @@ import { DEBUG_LOG_VERSION, debugLog } from '@/lib/debugLogger';
  * React Router で navigate する。
  * App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
  *
- * [Round 1 の削減版] postMessage 経路のみ。
- * 元は Cache Storage safety net / dedupe / registration.update() 経路も持っていたが、
- * SW 更新問題が根本 fix された今、safety net が本当に必要か検証する削減。
+ * [Round 2] Round 1 では registration.update() まで削除して壊れた
+ * (実機で FCM SW が更新されず古い版が残り続けた)。
+ * FCM SW は root scope 外で navigation 由来の update check が起きず、register() の
+ * byte-diff check も初回 1 回のみのため、明示 update() が唯一の SW 更新経路になる。
+ * Cache Storage safety net と dedupe は Round 2 段階でもまだ削除継続。
  */
 
 const parseSameOriginPath = (rawUrl: string): string | null => {
@@ -21,6 +23,30 @@ const parseSameOriginPath = (rawUrl: string): string | null => {
   }
   if (parsed.origin !== window.location.origin) return null;
   return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+};
+
+// PWA セッション中 1 回だけ SW 更新を promote する。App の unmount/remount で hook が
+// 何度も走っても update() は 1 回に絞る。
+let fcmSwUpdateTriggered = false;
+
+const promoteFcmSwUpdate = async (sw: ServiceWorkerContainer): Promise<void> => {
+  if (fcmSwUpdateTriggered) return;
+  fcmSwUpdateTriggered = true;
+  try {
+    const reg = await sw.getRegistration('/firebase-cloud-messaging-push-scope');
+    if (!reg) {
+      void debugLog('CL', 'fcm registration not found');
+      return;
+    }
+    await reg.update();
+    void debugLog('CL', 'fcm update() done', {
+      activeUrl: reg.active?.scriptURL ?? null,
+      waitingUrl: reg.waiting?.scriptURL ?? null,
+      installingUrl: reg.installing?.scriptURL ?? null,
+    });
+  } catch (err) {
+    void debugLog('CL', 'fcm update fail', { err: String(err) });
+  }
 };
 
 export const useFcmNavigationListener = () => {
@@ -54,6 +80,7 @@ export const useFcmNavigationListener = () => {
       currentUrl: window.location.href,
       clientVersion: DEBUG_LOG_VERSION,
     });
+    if (sw) void promoteFcmSwUpdate(sw);
 
     return () => {
       sw?.removeEventListener('message', handler);

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -128,6 +128,25 @@ export const useFcmNavigationListener = () => {
       currentUrl: window.location.href,
       clientVersion: DEBUG_LOG_VERSION,
     });
+    // 全 SW registration の state を吐き出す。root scope (VitePWA) と
+    // /firebase-cloud-messaging-push-scope (FCM) の new/waiting/active を可視化して、
+    // 古い FCM SW が waiting のまま残ってないか確認する。
+    void (async () => {
+      if (!sw) return;
+      try {
+        const regs = await sw.getRegistrations();
+        void debugLog('CL', 'registrations', {
+          registrations: regs.map(r => ({
+            scope: r.scope,
+            active: r.active?.scriptURL ?? null,
+            waiting: r.waiting?.scriptURL ?? null,
+            installing: r.installing?.scriptURL ?? null,
+          })),
+        });
+      } catch (err) {
+        void debugLog('CL', 'getRegistrations fail', { err: String(err) });
+      }
+    })();
     void applyIntent();
 
     return () => {

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { debugLog } from '@/lib/debugLogger';
+import { DEBUG_LOG_VERSION, debugLog } from '@/lib/debugLogger';
 
 /**
  * firebase-messaging-sw.js の notificationclick が伝えてくる遷移先 URL を受けて
@@ -122,7 +122,12 @@ export const useFcmNavigationListener = () => {
 
     sw?.addEventListener('message', handler);
     document.addEventListener('visibilitychange', onVisibility);
-    void debugLog('CL', 'listener mounted', { hasSw: !!sw });
+    void debugLog('CL', 'listener mounted', {
+      hasSw: !!sw,
+      swControllerUrl: sw?.controller?.scriptURL ?? null,
+      currentUrl: window.location.href,
+      clientVersion: DEBUG_LOG_VERSION,
+    });
     void applyIntent();
 
     return () => {

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DEBUG_LOG_VERSION, debugLog } from '@/lib/debugLogger';
 
@@ -7,53 +7,10 @@ import { DEBUG_LOG_VERSION, debugLog } from '@/lib/debugLogger';
  * React Router で navigate する。
  * App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
  *
- * 経路は 2 系統:
- * - fast path: SW からの postMessage `{ type: 'FCM_NAVIGATE', url }` を message event で受ける
- * - safety net: SW が Cache Storage (INTENT_CACHE / INTENT_KEY) に書き残した URL を
- *   mount + visibilitychange のたびに読む。PWA が Android にキルされて postMessage が
- *   届かないケース / cold start で listener 未登録のケースを両方救う
- *
- * 両方の経路が同じ URL に対して発火するので、直近の遷移 URL を ref に持たせて重複 navigate を防ぐ。
+ * [Round 1 の削減版] postMessage 経路のみ。
+ * 元は Cache Storage safety net / dedupe / registration.update() 経路も持っていたが、
+ * SW 更新問題が根本 fix された今、safety net が本当に必要か検証する削減。
  */
-
-const INTENT_CACHE = 'fcm-nav-intent-v1';
-const INTENT_KEY_PATH = '/__fcm_pending_nav__';
-
-const intentKeyUrl = () => new URL(INTENT_KEY_PATH, window.location.origin).href;
-
-const openIntentCache = async (): Promise<Cache | null> => {
-  if (typeof caches === 'undefined') return null;
-  try {
-    return await caches.open(INTENT_CACHE);
-  } catch {
-    return null;
-  }
-};
-
-const readAndClearPendingIntent = async (): Promise<string | null> => {
-  const cache = await openIntentCache();
-  if (!cache) return null;
-  const key = intentKeyUrl();
-  try {
-    const res = await cache.match(key);
-    if (!res) return null;
-    const url = await res.text();
-    await cache.delete(key);
-    return url;
-  } catch {
-    return null;
-  }
-};
-
-const clearPendingIntent = async (): Promise<void> => {
-  const cache = await openIntentCache();
-  if (!cache) return;
-  try {
-    await cache.delete(intentKeyUrl());
-  } catch {
-    // best effort
-  }
-};
 
 const parseSameOriginPath = (rawUrl: string): string | null => {
   let parsed: URL;
@@ -66,45 +23,10 @@ const parseSameOriginPath = (rawUrl: string): string | null => {
   return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 };
 
-// 1 通知タップに対して message + intent の 2 経路が近接発火するのを dedupe する時間窓。
-// これ以上経過したら別イベント扱いで同 URL への遷移も許可する (通知を連続タップした時等)。
-const NAV_DEDUPE_WINDOW_MS = 1000;
-
 export const useFcmNavigationListener = () => {
   const navigate = useNavigate();
-  // 直近の遷移先とタイムスタンプ。時間窓を過ぎたら別イベントとして再遷移を許可する。
-  // 以前は unmount まで保持する ref で「一度行った URL には二度と行けない」バグがあった。
-  const lastNavRef = useRef<{ url: string; at: number } | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
-
-    const navigateOnce = (target: string, source: string) => {
-      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-      if (target === current) {
-        void debugLog('CL', 'navigateOnce skip (== current)', { target, source });
-        return;
-      }
-      const last = lastNavRef.current;
-      const now = performance.now();
-      if (last !== null && last.url === target && now - last.at < NAV_DEDUPE_WINDOW_MS) {
-        void debugLog('CL', 'navigateOnce skip (dedupe window)', { target, source, ageMs: now - last.at });
-        return;
-      }
-      lastNavRef.current = { url: target, at: now };
-      void debugLog('CL', 'navigate() called', { target, source });
-      navigate(target);
-    };
-
-    const applyIntent = async () => {
-      const url = await readAndClearPendingIntent();
-      void debugLog('CL', 'applyIntent', { url });
-      if (cancelled || !url) return;
-      const target = parseSameOriginPath(url);
-      if (!target) return;
-      navigateOnce(target, 'intent');
-    };
-
     // 参照を effect スコープに固定: cleanup 時に navigator.serviceWorker が消えていても
     // (テスト環境で差し替えると起こる) removeEventListener で crash させない。
     const sw = typeof navigator !== 'undefined' ? navigator.serviceWorker : undefined;
@@ -116,18 +38,16 @@ export const useFcmNavigationListener = () => {
       if (typeof rawUrl !== 'string') return;
       const target = parseSameOriginPath(rawUrl);
       if (!target) return;
-      // message 経由で消化するので safety net の Cache は掃除する (二重 navigate 防止)
-      void clearPendingIntent();
-      navigateOnce(target, 'message');
-    };
-
-    const onVisibility = () => {
-      void debugLog('CL', 'visibilitychange', { state: document.visibilityState });
-      if (document.visibilityState === 'visible') void applyIntent();
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (target === current) {
+        void debugLog('CL', 'navigate skip (== current)', { target });
+        return;
+      }
+      void debugLog('CL', 'navigate() called', { target });
+      navigate(target);
     };
 
     sw?.addEventListener('message', handler);
-    document.addEventListener('visibilitychange', onVisibility);
     void debugLog('CL', 'listener mounted', {
       hasSw: !!sw,
       swControllerUrl: sw?.controller?.scriptURL ?? null,
@@ -135,68 +55,8 @@ export const useFcmNavigationListener = () => {
       clientVersion: DEBUG_LOG_VERSION,
     });
 
-    // FCM SW は root scope に居ないので navigation では update check されず、
-    // register() は起動時 1 回のみ (lib/messaging.ts の promise cache のため)。
-    // 明示的に update() を叩いて Chrome に新 SW の byte-diff check を促し、
-    // waiting になった SW があれば SKIP_WAITING message で即 activate に持ち込む。
-    void (async () => {
-      if (!sw) return;
-      try {
-        const reg = await sw.getRegistration('/firebase-cloud-messaging-push-scope');
-        if (!reg) {
-          void debugLog('CL', 'fcm registration not found');
-          return;
-        }
-        reg.addEventListener('updatefound', () => {
-          const newSw = reg.installing;
-          void debugLog('CL', 'fcm updatefound', { installingUrl: newSw?.scriptURL ?? null });
-          newSw?.addEventListener('statechange', () => {
-            void debugLog('CL', 'fcm new sw statechange', { state: newSw.state });
-            if (newSw.state === 'installed' && reg.waiting) {
-              reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-              void debugLog('CL', 'sent SKIP_WAITING (post-install)');
-            }
-          });
-        });
-        await reg.update();
-        void debugLog('CL', 'fcm update() done', {
-          activeUrl: reg.active?.scriptURL ?? null,
-          waitingUrl: reg.waiting?.scriptURL ?? null,
-          installingUrl: reg.installing?.scriptURL ?? null,
-        });
-        if (reg.waiting) {
-          reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-          void debugLog('CL', 'sent SKIP_WAITING (existing waiting)');
-        }
-      } catch (err) {
-        void debugLog('CL', 'fcm update fail', { err: String(err) });
-      }
-    })();
-    // 全 SW registration の state を吐き出す。root scope (VitePWA) と
-    // /firebase-cloud-messaging-push-scope (FCM) の new/waiting/active を可視化して、
-    // 古い FCM SW が waiting のまま残ってないか確認する。
-    void (async () => {
-      if (!sw) return;
-      try {
-        const regs = await sw.getRegistrations();
-        void debugLog('CL', 'registrations', {
-          registrations: regs.map(r => ({
-            scope: r.scope,
-            active: r.active?.scriptURL ?? null,
-            waiting: r.waiting?.scriptURL ?? null,
-            installing: r.installing?.scriptURL ?? null,
-          })),
-        });
-      } catch (err) {
-        void debugLog('CL', 'getRegistrations fail', { err: String(err) });
-      }
-    })();
-    void applyIntent();
-
     return () => {
-      cancelled = true;
       sw?.removeEventListener('message', handler);
-      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [navigate]);
 };

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,40 +1,122 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 /**
- * firebase-messaging-sw.js の notificationclick が postMessage する
- * `{ type: 'FCM_NAVIGATE', url }` を受けて React Router で navigate する。
+ * firebase-messaging-sw.js の notificationclick が伝えてくる遷移先 URL を受けて
+ * React Router で navigate する。
  * App.tsx で 1 回のみ呼ぶ (Router の内側必須)。
+ *
+ * 経路は 2 系統:
+ * - fast path: SW からの postMessage `{ type: 'FCM_NAVIGATE', url }` を message event で受ける
+ * - safety net: SW が Cache Storage (INTENT_CACHE / INTENT_KEY) に書き残した URL を
+ *   mount + visibilitychange のたびに読む。PWA が Android にキルされて postMessage が
+ *   届かないケース / cold start で listener 未登録のケースを両方救う
+ *
+ * 両方の経路が同じ URL に対して発火するので、直近の遷移 URL を ref に持たせて重複 navigate を防ぐ。
  */
+
+const INTENT_CACHE = 'fcm-nav-intent-v1';
+const INTENT_KEY_PATH = '/__fcm_pending_nav__';
+
+const intentKeyUrl = () => new URL(INTENT_KEY_PATH, window.location.origin).href;
+
+const openIntentCache = async (): Promise<Cache | null> => {
+  if (typeof caches === 'undefined') return null;
+  try {
+    return await caches.open(INTENT_CACHE);
+  } catch {
+    return null;
+  }
+};
+
+const readAndClearPendingIntent = async (): Promise<string | null> => {
+  const cache = await openIntentCache();
+  if (!cache) return null;
+  const key = intentKeyUrl();
+  try {
+    const res = await cache.match(key);
+    if (!res) return null;
+    const url = await res.text();
+    await cache.delete(key);
+    return url;
+  } catch {
+    return null;
+  }
+};
+
+const clearPendingIntent = async (): Promise<void> => {
+  const cache = await openIntentCache();
+  if (!cache) return;
+  try {
+    await cache.delete(intentKeyUrl());
+  } catch {
+    // best effort
+  }
+};
+
+const parseSameOriginPath = (rawUrl: string): string | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl, window.location.origin);
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== window.location.origin) return null;
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+};
+
 export const useFcmNavigationListener = () => {
   const navigate = useNavigate();
+  // fast path (message) と safety net (cache) が同一 URL に対して二重発火するのを防ぐ。
+  // 直近の遷移先を保持し、同値なら skip する。
+  const lastNavigatedRef = useRef<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
+    const navigateOnce = (target: string) => {
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (target === current) return;
+      if (lastNavigatedRef.current === target) return;
+      lastNavigatedRef.current = target;
+      navigate(target);
+    };
+
+    const applyIntent = async () => {
+      const url = await readAndClearPendingIntent();
+      if (cancelled || !url) return;
+      const target = parseSameOriginPath(url);
+      if (!target) return;
+      navigateOnce(target);
+    };
+
     // 参照を effect スコープに固定: cleanup 時に navigator.serviceWorker が消えていても
     // (テスト環境で差し替えると起こる) removeEventListener で crash させない。
     const sw = typeof navigator !== 'undefined' ? navigator.serviceWorker : undefined;
-    if (!sw) return;
 
     const handler = (event: MessageEvent) => {
       if (event.data?.type !== 'FCM_NAVIGATE') return;
       const rawUrl = event.data.url;
       if (typeof rawUrl !== 'string') return;
-
-      let parsed: URL;
-      try {
-        parsed = new URL(rawUrl, window.location.origin);
-      } catch {
-        return;
-      }
-      // SW 側でも弾いているが、payload 経路の open-redirect 対策として二重防御。
-      if (parsed.origin !== window.location.origin) return;
-
-      navigate(`${parsed.pathname}${parsed.search}${parsed.hash}`);
+      const target = parseSameOriginPath(rawUrl);
+      if (!target) return;
+      // message 経由で消化するので safety net の Cache は掃除する (二重 navigate 防止)
+      void clearPendingIntent();
+      navigateOnce(target);
     };
 
-    sw.addEventListener('message', handler);
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void applyIntent();
+    };
+
+    sw?.addEventListener('message', handler);
+    document.addEventListener('visibilitychange', onVisibility);
+    void applyIntent();
+
     return () => {
-      sw.removeEventListener('message', handler);
+      cancelled = true;
+      sw?.removeEventListener('message', handler);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [navigate]);
 };

--- a/frontend/src/hooks/useFcmNavigationListener.ts
+++ b/frontend/src/hooks/useFcmNavigationListener.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { debugLog } from '@/lib/debugLogger';
 
 /**
  * firebase-messaging-sw.js の notificationclick が伝えてくる遷移先 URL を受けて
@@ -74,20 +75,28 @@ export const useFcmNavigationListener = () => {
   useEffect(() => {
     let cancelled = false;
 
-    const navigateOnce = (target: string) => {
+    const navigateOnce = (target: string, source: string) => {
       const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-      if (target === current) return;
-      if (lastNavigatedRef.current === target) return;
+      if (target === current) {
+        void debugLog('CL', 'navigateOnce skip (== current)', { target, source });
+        return;
+      }
+      if (lastNavigatedRef.current === target) {
+        void debugLog('CL', 'navigateOnce skip (== last)', { target, source });
+        return;
+      }
       lastNavigatedRef.current = target;
+      void debugLog('CL', 'navigate() called', { target, source });
       navigate(target);
     };
 
     const applyIntent = async () => {
       const url = await readAndClearPendingIntent();
+      void debugLog('CL', 'applyIntent', { url });
       if (cancelled || !url) return;
       const target = parseSameOriginPath(url);
       if (!target) return;
-      navigateOnce(target);
+      navigateOnce(target, 'intent');
     };
 
     // 参照を effect スコープに固定: cleanup 時に navigator.serviceWorker が消えていても
@@ -95,6 +104,7 @@ export const useFcmNavigationListener = () => {
     const sw = typeof navigator !== 'undefined' ? navigator.serviceWorker : undefined;
 
     const handler = (event: MessageEvent) => {
+      void debugLog('CL', 'sw message', { data: event.data });
       if (event.data?.type !== 'FCM_NAVIGATE') return;
       const rawUrl = event.data.url;
       if (typeof rawUrl !== 'string') return;
@@ -102,15 +112,17 @@ export const useFcmNavigationListener = () => {
       if (!target) return;
       // message 経由で消化するので safety net の Cache は掃除する (二重 navigate 防止)
       void clearPendingIntent();
-      navigateOnce(target);
+      navigateOnce(target, 'message');
     };
 
     const onVisibility = () => {
+      void debugLog('CL', 'visibilitychange', { state: document.visibilityState });
       if (document.visibilityState === 'visible') void applyIntent();
     };
 
     sw?.addEventListener('message', handler);
     document.addEventListener('visibilitychange', onVisibility);
+    void debugLog('CL', 'listener mounted', { hasSw: !!sw });
     void applyIntent();
 
     return () => {

--- a/frontend/src/hooks/useFocusBlockOnMount.test.tsx
+++ b/frontend/src/hooks/useFocusBlockOnMount.test.tsx
@@ -1,0 +1,196 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { Provider as JotaiProvider } from 'jotai';
+import { HttpResponse, http } from 'msw';
+import type { ReactNode } from 'react';
+import { BrowserRouter, MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { selectedPageIdAtom } from '@/atoms/tripPage';
+import { useFocusBlockOnMount } from '@/hooks/useFocusBlockOnMount';
+import { appStore } from '@/lib/store';
+import { server } from '../../tests/msw/server';
+
+// jsdom は scrollIntoView を提供しないので prototype に stub を生やす
+const scrollIntoViewMock = vi.fn();
+Element.prototype.scrollIntoView = scrollIntoViewMock as unknown as Element['scrollIntoView'];
+
+const scheduleBlockJson = (id: number, pageId: number) => ({
+  id,
+  page_id: pageId,
+  block_type: 'event' as const,
+  title: 'schedule block',
+  start_time: '2026-01-01T09:00:00',
+  end_time: '2026-01-01T10:00:00',
+  detail: null,
+  location_id: null,
+  location: null,
+});
+
+const LocationCapture = ({ onLocation }: { onLocation: (search: string) => void }) => {
+  const location = useLocation();
+  onLocation(location.search);
+  return null;
+};
+
+const HookHost = () => {
+  useFocusBlockOnMount();
+  return <div data-block-id='42'>target</div>;
+};
+
+const renderWithRouter = (initialPath: string, onLocation: (search: string) => void) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={appStore}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <LocationCapture onLocation={onLocation} />
+        <Routes>
+          <Route path='*' element={children} />
+        </Routes>
+      </MemoryRouter>
+    </JotaiProvider>
+  );
+  return render(<HookHost />, { wrapper: Wrapper });
+};
+
+describe('useFocusBlockOnMount', () => {
+  beforeEach(() => {
+    appStore.set(selectedPageIdAtom, undefined);
+    scrollIntoViewMock.mockReset();
+  });
+
+  it('?focusBlock が無ければ何もしない', async () => {
+    let currentSearch = '';
+    renderWithRouter('/trip/abc', s => {
+      currentSearch = s;
+    });
+
+    // マウント直後に副作用が完了する
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('非数値の focusBlock は block fetch せず query param のみ掃除する', async () => {
+    let apiCalled = false;
+    server.use(
+      http.get('*/blocks/*', () => {
+        apiCalled = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=abc', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(apiCalled).toBe(false);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('block ロード成功時に selectedPageId 切り替え + scrollIntoView + query param 掃除を行う', async () => {
+    server.use(http.get('*/blocks/42', () => HttpResponse.json(scheduleBlockJson(42, 7))));
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=42', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    });
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+  });
+
+  it('block が 404 の場合は selectedPageId を変えず query param のみ掃除する', async () => {
+    server.use(http.get('*/blocks/999', () => new HttpResponse(null, { status: 404 })));
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=999', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('同一マウント中に focusBlock が 42→99 と変わったら 2 回目も再処理する', async () => {
+    server.use(
+      http.get('*/blocks/42', () => HttpResponse.json(scheduleBlockJson(42, 7))),
+      http.get('*/blocks/99', () => HttpResponse.json(scheduleBlockJson(99, 11)))
+    );
+
+    // SW → postMessage → useFcmNavigationListener の navigate() で同一マウント中に
+    // URL の focusBlock が差し替わるフローを再現するため、テスト内で navigate を外に取り出す。
+    const navigateHandle: { current: ((to: string) => void) | null } = { current: null };
+    const NavigateHandle = () => {
+      navigateHandle.current = useNavigate();
+      return null;
+    };
+
+    const searchRef = { current: '' };
+    const captureSearch = (s: string) => {
+      searchRef.current = s;
+    };
+
+    // 初期 URL を含めて BrowserRouter に載せる (window.history 経由で navigate 可能)
+    window.history.replaceState({}, '', '/trip/abc?focusBlock=42');
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={appStore}>
+        <BrowserRouter>
+          <NavigateHandle />
+          <LocationCapture onLocation={captureSearch} />
+          <Routes>
+            <Route path='*' element={children} />
+          </Routes>
+        </BrowserRouter>
+      </JotaiProvider>
+    );
+
+    render(
+      <>
+        <HookHost />
+        <div data-block-id='99'>target-99</div>
+      </>,
+      { wrapper: Wrapper }
+    );
+
+    // 1 回目: focusBlock=42 の処理完了を待つ
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+    // 2 回目: SPA navigate で URL に別の focusBlock を差し込む
+    scrollIntoViewMock.mockClear();
+    act(() => {
+      navigateHandle.current?.('/trip/abc?focusBlock=99');
+    });
+
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(11);
+    });
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+  });
+});

--- a/frontend/src/hooks/useFocusBlockOnMount.test.tsx
+++ b/frontend/src/hooks/useFocusBlockOnMount.test.tsx
@@ -175,7 +175,9 @@ describe('useFocusBlockOnMount', () => {
     await waitFor(() => {
       expect(searchRef.current).toBe('');
     });
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    });
 
     // 2 回目: SPA navigate で URL に別の focusBlock を差し込む
     scrollIntoViewMock.mockClear();
@@ -258,7 +260,9 @@ describe('useFocusBlockOnMount', () => {
     await waitFor(() => {
       expect(searchRef.current).toBe('');
     });
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    });
 
     // 2 回目: URL が /trip/abc に戻った状態から、同じ block へ再通知タップを再現
     scrollIntoViewMock.mockClear();

--- a/frontend/src/hooks/useFocusBlockOnMount.test.tsx
+++ b/frontend/src/hooks/useFocusBlockOnMount.test.tsx
@@ -193,4 +193,88 @@ describe('useFocusBlockOnMount', () => {
       expect(searchRef.current).toBe('');
     });
   });
+
+  it('focusBlock=0 は block ID として無効なので query 掃除だけ行う', async () => {
+    let apiCalled = false;
+    server.use(
+      http.get('*/blocks/*', () => {
+        apiCalled = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    let currentSearch = 'initial';
+    renderWithRouter('/trip/abc?focusBlock=0', s => {
+      currentSearch = s;
+    });
+
+    await waitFor(() => {
+      expect(currentSearch).toBe('');
+    });
+    expect(apiCalled).toBe(false);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(appStore.get(selectedPageIdAtom)).toBeUndefined();
+  });
+
+  it('同じ focusBlock=42 が clearParam 後にもう一度来ても再処理する', async () => {
+    server.use(http.get('*/blocks/42', () => HttpResponse.json(scheduleBlockJson(42, 7))));
+
+    const navigateHandle: { current: ((to: string) => void) | null } = { current: null };
+    const NavigateHandle = () => {
+      navigateHandle.current = useNavigate();
+      return null;
+    };
+
+    const searchRef = { current: '' };
+    const captureSearch = (s: string) => {
+      searchRef.current = s;
+    };
+
+    window.history.replaceState({}, '', '/trip/abc?focusBlock=42');
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <JotaiProvider store={appStore}>
+        <BrowserRouter>
+          <NavigateHandle />
+          <LocationCapture onLocation={captureSearch} />
+          <Routes>
+            <Route path='*' element={children} />
+          </Routes>
+        </BrowserRouter>
+      </JotaiProvider>
+    );
+
+    render(
+      <>
+        <HookHost />
+      </>,
+      { wrapper: Wrapper }
+    );
+
+    // 1 回目: focusBlock=42 の処理完了 (page 切替 + scroll + clearParam) を待つ
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+    // 2 回目: URL が /trip/abc に戻った状態から、同じ block へ再通知タップを再現
+    scrollIntoViewMock.mockClear();
+    appStore.set(selectedPageIdAtom, undefined);
+    act(() => {
+      navigateHandle.current?.('/trip/abc?focusBlock=42');
+    });
+
+    await waitFor(() => {
+      expect(appStore.get(selectedPageIdAtom)).toBe(7);
+    });
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    });
+    await waitFor(() => {
+      expect(searchRef.current).toBe('');
+    });
+  });
 });

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -1,0 +1,84 @@
+import { useSetAtom } from 'jotai';
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { selectedPageIdAtom } from '@/atoms/tripPage';
+import { useBlock } from '@/hooks/useBlocks';
+
+/**
+ * `?focusBlock={id}` を消費して該当 block まで scroll する。
+ *
+ * block が 404 (通知送信 → タップ間で削除) や非数値ゴミの場合は黙って query param 掃除だけ行う。
+ * urlId は URL path で保持されているので trip 画面自体は通常表示される。
+ */
+
+const FOCUS_BLOCK_PARAM = 'focusBlock';
+const SCROLL_WAIT_MAX_MS = 3000;
+
+const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => boolean): Promise<HTMLElement | null> =>
+  new Promise(resolve => {
+    const selector = `[data-block-id="${blockId}"]`;
+    const start = performance.now();
+    const tick = () => {
+      if (isCancelled()) return resolve(null);
+      const el = document.querySelector<HTMLElement>(selector);
+      if (el) return resolve(el);
+      if (performance.now() - start > maxMs) return resolve(null);
+      requestAnimationFrame(tick);
+    };
+    tick();
+  });
+
+export const useFocusBlockOnMount = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawFocusBlock = searchParams.get(FOCUS_BLOCK_PARAM);
+  const focusBlockId = rawFocusBlock != null && /^\d+$/.test(rawFocusBlock) ? Number(rawFocusBlock) : null;
+  const hasInvalidParam = rawFocusBlock != null && focusBlockId == null;
+
+  const setSelectedPageId = useSetAtom(selectedPageIdAtom);
+  const { block, error } = useBlock(focusBlockId);
+  // TripPage は unmount せず SPA navigate で URL だけ差し替わるため、boolean 一度きりゲートだと
+  // 通知連続タップ (42 → 99) の 2 回目が無視される。値ゲートにして rawFocusBlock が変わったら再処理する。
+  const consumedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (consumedKeyRef.current === rawFocusBlock) return;
+
+    const clearParam = () =>
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          next.delete(FOCUS_BLOCK_PARAM);
+          return next;
+        },
+        { replace: true }
+      );
+
+    if (hasInvalidParam) {
+      consumedKeyRef.current = rawFocusBlock;
+      clearParam();
+      return;
+    }
+    if (focusBlockId == null) return;
+    if (error) {
+      consumedKeyRef.current = rawFocusBlock;
+      clearParam();
+      return;
+    }
+    if (!block) return;
+
+    consumedKeyRef.current = rawFocusBlock;
+    setSelectedPageId(block.pageId);
+
+    let cancelled = false;
+    (async () => {
+      const el = await waitForBlockElement(focusBlockId, SCROLL_WAIT_MAX_MS, () => cancelled);
+      if (cancelled) return;
+      el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      clearParam();
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rawFocusBlock, focusBlockId, hasInvalidParam, block, error, setSelectedPageId, setSearchParams]);
+};

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { selectedPageIdAtom } from '@/atoms/tripPage';
 import { useBlock } from '@/hooks/useBlocks';
+import { debugLog } from '@/lib/debugLogger';
 
 /**
  * `?focusBlock={id}` を消費して該当 block まで scroll する。
@@ -75,6 +76,13 @@ export const useFocusBlockOnMount = () => {
   const consumedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
+    void debugLog('FB', 'effect', {
+      rawFocusBlock,
+      focusBlockId,
+      hasBlock: !!block,
+      hasError: !!error,
+      consumed: consumedKeyRef.current,
+    });
     if (rawFocusBlock === null) {
       consumedKeyRef.current = null;
       return;
@@ -109,6 +117,7 @@ export const useFocusBlockOnMount = () => {
     let cancelled = false;
     (async () => {
       const el = await waitForBlockElement(focusBlockId, SCROLL_WAIT_MAX_MS, () => cancelled);
+      void debugLog('FB', 'wait done', { found: !!el, cancelled });
       if (cancelled) return;
       if (el) scrollIntoViewOnNextFrame(el);
       clearParam();

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -28,19 +28,35 @@ const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => 
     tick();
   });
 
+// block ID は BIGSERIAL PRIMARY KEY (正の整数) のみ有効。"0" / 桁溢れ / 非数値は不正値扱いで
+// query 掃除だけ行う。useBlock(0) が SWR の falsy key で fetch を止めるため、そのまま 0 を渡すと
+// block も error も来ず ref も query も更新されずスタックする。
+const parseFocusBlockId = (raw: string | null): number | null => {
+  if (raw == null || !/^[1-9]\d*$/.test(raw)) return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) ? n : null;
+};
+
 export const useFocusBlockOnMount = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawFocusBlock = searchParams.get(FOCUS_BLOCK_PARAM);
-  const focusBlockId = rawFocusBlock != null && /^\d+$/.test(rawFocusBlock) ? Number(rawFocusBlock) : null;
+  const focusBlockId = parseFocusBlockId(rawFocusBlock);
   const hasInvalidParam = rawFocusBlock != null && focusBlockId == null;
 
   const setSelectedPageId = useSetAtom(selectedPageIdAtom);
   const { block, error } = useBlock(focusBlockId);
-  // TripPage は unmount せず SPA navigate で URL だけ差し替わるため、boolean 一度きりゲートだと
-  // 通知連続タップ (42 → 99) の 2 回目が無視される。値ゲートにして rawFocusBlock が変わったら再処理する。
+  // 直前の rawFocusBlock を保持し、値が変わるまで再処理をブロックする。ref なので rerender は起こさない。
+  // - TripPage は SPA navigate で unmount しないので、連続通知 (42 → 99) の 2 回目を処理する
+  // - 消費済み記録は uncancelled 完了後 (async 内) にセット。StrictMode の double-fire で最初の async が
+  //   cancelled になっても 2 度目で確実に完走するため
+  // - query 掃除後 (rawFocusBlock === null) は ref をリセット。同一 block の再通知にも応答するため
   const consumedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
+    if (rawFocusBlock === null) {
+      consumedKeyRef.current = null;
+      return;
+    }
     if (consumedKeyRef.current === rawFocusBlock) return;
 
     const clearParam = () =>
@@ -66,7 +82,6 @@ export const useFocusBlockOnMount = () => {
     }
     if (!block) return;
 
-    consumedKeyRef.current = rawFocusBlock;
     setSelectedPageId(block.pageId);
 
     let cancelled = false;
@@ -75,6 +90,7 @@ export const useFocusBlockOnMount = () => {
       if (cancelled) return;
       el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
       clearParam();
+      consumedKeyRef.current = rawFocusBlock;
     })();
 
     return () => {

--- a/frontend/src/hooks/useFocusBlockOnMount.ts
+++ b/frontend/src/hooks/useFocusBlockOnMount.ts
@@ -12,21 +12,43 @@ import { useBlock } from '@/hooks/useBlocks';
  */
 
 const FOCUS_BLOCK_PARAM = 'focusBlock';
-const SCROLL_WAIT_MAX_MS = 3000;
+// 通知タップ → block 描画までに 2 段の非同期がある:
+//   1. useBlock(id) 単発 fetch → block.pageId 判明 → selectedPageId 切替
+//   2. useBlocks(pageId) list fetch 完了 → ViewTripLayout の Skeleton が Timeline に差し替わる
+// (2) が cold start で遅れると DOM に data-block-id が出るのに数秒かかることがある。
+// rAF ポーリングだと 1 フレーム単位で無駄回転するので MutationObserver で DOM 変化を待つ。
+const SCROLL_WAIT_MAX_MS = 8000;
 
 const waitForBlockElement = (blockId: number, maxMs: number, isCancelled: () => boolean): Promise<HTMLElement | null> =>
   new Promise(resolve => {
     const selector = `[data-block-id="${blockId}"]`;
-    const start = performance.now();
-    const tick = () => {
-      if (isCancelled()) return resolve(null);
-      const el = document.querySelector<HTMLElement>(selector);
-      if (el) return resolve(el);
-      if (performance.now() - start > maxMs) return resolve(null);
-      requestAnimationFrame(tick);
+
+    const found = document.querySelector<HTMLElement>(selector);
+    if (found) return resolve(found);
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const finish = (el: HTMLElement | null) => {
+      observer.disconnect();
+      if (timeoutId !== null) clearTimeout(timeoutId);
+      resolve(el);
     };
-    tick();
+
+    const observer = new MutationObserver(() => {
+      if (isCancelled()) return finish(null);
+      const el = document.querySelector<HTMLElement>(selector);
+      if (el) finish(el);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    timeoutId = setTimeout(() => finish(null), maxMs);
   });
+
+// layout flush を 1 フレーム待ってから scroll する。Timeline が差し替わった直後は要素の
+// 位置計算がまだ確定していないことがあり、そのタイミングで scrollIntoView すると外れる。
+const scrollIntoViewOnNextFrame = (el: HTMLElement) => {
+  requestAnimationFrame(() => {
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  });
+};
 
 // block ID は BIGSERIAL PRIMARY KEY (正の整数) のみ有効。"0" / 桁溢れ / 非数値は不正値扱いで
 // query 掃除だけ行う。useBlock(0) が SWR の falsy key で fetch を止めるため、そのまま 0 を渡すと
@@ -88,7 +110,7 @@ export const useFocusBlockOnMount = () => {
     (async () => {
       const el = await waitForBlockElement(focusBlockId, SCROLL_WAIT_MAX_MS, () => cancelled);
       if (cancelled) return;
-      el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (el) scrollIntoViewOnNextFrame(el);
       clearParam();
       consumedKeyRef.current = rawFocusBlock;
     })();

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -11,8 +11,16 @@ const DB_NAME = 'fcm-debug-log';
 const STORE_NAME = 'entries';
 const MAX_ENTRIES = 500;
 
+/**
+ * 診断コード修正のたびに手動で bump する。firebase-messaging-sw.js 側の DEBUG_LOG_VERSION と
+ * 揃えて更新。ログの各行に埋め込まれるので、共有されたログのバージョンが古い環境か新しい環境か
+ * を確認しやすくする。
+ */
+export const DEBUG_LOG_VERSION = 'v02-cl-2026-08-01';
+
 interface LogEntry {
   ts: number;
+  version: string;
   tag: string;
   message: string;
   data: unknown;
@@ -54,7 +62,13 @@ export const debugLog = async (tag: string, message: string, data?: unknown): Pr
     const db = await getDb();
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
-    const entry: LogEntry = { ts: Date.now(), tag, message, data: safeSerialize(data) };
+    const entry: LogEntry = {
+      ts: Date.now(),
+      version: DEBUG_LOG_VERSION,
+      tag,
+      message,
+      data: safeSerialize(data),
+    };
     store.add(entry);
     const countReq = store.count();
     countReq.onsuccess = () => {
@@ -78,7 +92,8 @@ export const debugLog = async (tag: string, message: string, data?: unknown): Pr
 const formatEntry = (e: LogEntry): string => {
   const t = new Date(e.ts).toISOString();
   const data = e.data == null ? '' : ` | ${JSON.stringify(e.data)}`;
-  return `[${t}] [${e.tag}] ${e.message}${data}`;
+  const version = e.version ?? '?';
+  return `[${t}] [${version}] [${e.tag}] ${e.message}${data}`;
 };
 
 export const readAllLogs = async (): Promise<string> => {

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -16,7 +16,7 @@ const MAX_ENTRIES = 500;
  * 揃えて更新。ログの各行に埋め込まれるので、共有されたログのバージョンが古い環境か新しい環境か
  * を確認しやすくする。
  */
-export const DEBUG_LOG_VERSION = 'v04-cl-2026-08-01';
+export const DEBUG_LOG_VERSION = 'v05-cl-2026-08-01';
 
 interface LogEntry {
   ts: number;

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -16,7 +16,7 @@ const MAX_ENTRIES = 500;
  * 揃えて更新。ログの各行に埋め込まれるので、共有されたログのバージョンが古い環境か新しい環境か
  * を確認しやすくする。
  */
-export const DEBUG_LOG_VERSION = 'v07-cl-2026-08-01';
+export const DEBUG_LOG_VERSION = 'v08-cl-2026-08-01';
 
 interface LogEntry {
   ts: number;

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -16,7 +16,7 @@ const MAX_ENTRIES = 500;
  * 揃えて更新。ログの各行に埋め込まれるので、共有されたログのバージョンが古い環境か新しい環境か
  * を確認しやすくする。
  */
-export const DEBUG_LOG_VERSION = 'v02-cl-2026-08-01';
+export const DEBUG_LOG_VERSION = 'v04-cl-2026-08-01';
 
 interface LogEntry {
   ts: number;

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -16,7 +16,7 @@ const MAX_ENTRIES = 500;
  * 揃えて更新。ログの各行に埋め込まれるので、共有されたログのバージョンが古い環境か新しい環境か
  * を確認しやすくする。
  */
-export const DEBUG_LOG_VERSION = 'v06-cl-2026-08-01';
+export const DEBUG_LOG_VERSION = 'v07-cl-2026-08-01';
 
 interface LogEntry {
   ts: number;

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -16,7 +16,7 @@ const MAX_ENTRIES = 500;
  * 揃えて更新。ログの各行に埋め込まれるので、共有されたログのバージョンが古い環境か新しい環境か
  * を確認しやすくする。
  */
-export const DEBUG_LOG_VERSION = 'v08-cl-2026-08-01';
+export const DEBUG_LOG_VERSION = 'v09-cl-2026-08-01';
 
 interface LogEntry {
   ts: number;

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -16,7 +16,7 @@ const MAX_ENTRIES = 500;
  * 揃えて更新。ログの各行に埋め込まれるので、共有されたログのバージョンが古い環境か新しい環境か
  * を確認しやすくする。
  */
-export const DEBUG_LOG_VERSION = 'v05-cl-2026-08-01';
+export const DEBUG_LOG_VERSION = 'v06-cl-2026-08-01';
 
 interface LogEntry {
   ts: number;

--- a/frontend/src/lib/debugLogger.ts
+++ b/frontend/src/lib/debugLogger.ts
@@ -1,0 +1,116 @@
+/**
+ * Android PWA など console が取りづらい環境向けの診断ロガー。
+ *
+ * IndexedDB に ring buffer (最大 500 件) で書き、client 側から readAll で
+ * 一括取得できる。SW からも同じ DB / store に書けるよう、SW 側は
+ * `firebase-messaging-sw.js` に同じロジックを inline 実装している (importScripts
+ * 経由の shared module にすると build 側の設定が要るため duplicate で運用)。
+ */
+
+const DB_NAME = 'fcm-debug-log';
+const STORE_NAME = 'entries';
+const MAX_ENTRIES = 500;
+
+interface LogEntry {
+  ts: number;
+  tag: string;
+  message: string;
+  data: unknown;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+const getDb = (): Promise<IDBDatabase> => {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') return reject(new Error('no idb'));
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { autoIncrement: true });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  }).catch(err => {
+    dbPromise = null;
+    throw err;
+  });
+  return dbPromise;
+};
+
+const safeSerialize = (data: unknown): unknown => {
+  if (data === undefined) return null;
+  try {
+    return JSON.parse(JSON.stringify(data));
+  } catch {
+    return String(data);
+  }
+};
+
+export const debugLog = async (tag: string, message: string, data?: unknown): Promise<void> => {
+  try {
+    const db = await getDb();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const entry: LogEntry = { ts: Date.now(), tag, message, data: safeSerialize(data) };
+    store.add(entry);
+    const countReq = store.count();
+    countReq.onsuccess = () => {
+      const excess = countReq.result - MAX_ENTRIES;
+      if (excess <= 0) return;
+      const cursorReq = store.openCursor();
+      let remaining = excess;
+      cursorReq.onsuccess = e => {
+        const cursor = (e.target as IDBRequest<IDBCursorWithValue | null>).result;
+        if (!cursor || remaining <= 0) return;
+        cursor.delete();
+        remaining -= 1;
+        cursor.continue();
+      };
+    };
+  } catch {
+    // logger must not throw
+  }
+};
+
+const formatEntry = (e: LogEntry): string => {
+  const t = new Date(e.ts).toISOString();
+  const data = e.data == null ? '' : ` | ${JSON.stringify(e.data)}`;
+  return `[${t}] [${e.tag}] ${e.message}${data}`;
+};
+
+export const readAllLogs = async (): Promise<string> => {
+  try {
+    const db = await getDb();
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    return await new Promise<string>((resolve, reject) => {
+      const entries: LogEntry[] = [];
+      const cursorReq = store.openCursor();
+      cursorReq.onsuccess = e => {
+        const cursor = (e.target as IDBRequest<IDBCursorWithValue | null>).result;
+        if (cursor) {
+          entries.push(cursor.value as LogEntry);
+          cursor.continue();
+        } else {
+          resolve(entries.map(formatEntry).join('\n'));
+        }
+      };
+      cursorReq.onerror = () => reject(cursorReq.error);
+    });
+  } catch {
+    return '';
+  }
+};
+
+export const clearAllLogs = async (): Promise<void> => {
+  try {
+    const db = await getDb();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).clear();
+  } catch {
+    // ignore
+  }
+};

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -14,6 +14,7 @@ import { TimelineSkeleton } from '@/components/timeline';
 import { Button } from '@/components/ui/button';
 import { useActivePage } from '@/hooks/useActivePage';
 import { useDragAutoScroll } from '@/hooks/useDragAutoScroll';
+import { useFocusBlockOnMount } from '@/hooks/useFocusBlockOnMount';
 import { usePages } from '@/hooks/usePages';
 import { useTripByUrlId } from '@/hooks/useTrips';
 import { useVisitedTrips } from '@/hooks/useVisitedTrips';
@@ -44,6 +45,7 @@ const TripPage = () => {
   const { pages, error: pagesError, isLoading: isPagesLoading } = usePages(trip?.id ?? null, { refreshInterval });
   const { addVisitedTrip } = useVisitedTrips();
   const { storedPageId, isActivePageInitialized, saveActivePageId } = useActivePage(trip?.id ?? null);
+  useFocusBlockOnMount();
 
   const isLoading = isTripLoading || isPagesLoading || !minLoadingComplete;
   const isError = tripError || pagesError;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,6 +64,12 @@ export default defineConfig({
       workbox: {
         navigateFallback: '/index.html',
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        // firebase-messaging-sw.js は Firebase JS SDK が別 scope で管理する SW なので、
+        // VitePWA の precache に入れると Chrome が register 時に古い版を cache から受け取り、
+        // 新版 handler が実機で永遠に active にならない (実機で observed)。除外必須。
+        globIgnores: ['**/firebase-messaging-sw.js'],
+        // 通常の runtime caching で /firebase-messaging-sw.js を横取りしないよう明示。
+        navigateFallbackDenylist: [/^\/firebase-messaging-sw\.js$/],
       },
     }),
   ],


### PR DESCRIPTION
Related: #207, #209

## 目的

PR #209 の実装で「PWA background + 別 trip の通知タップで trip が切り替わらない」ケースが観測された。console が実機 (Android PWA / iOS PWA) から取りづらいため、**IndexedDB 経由でログ収集して client の Copy ボタンで貼り付けできる診断ロガー**をこのブランチに切って作業する。

**このブランチはマージしない**。切り分けが終わったら delete。

## ベース

`feature/issue207_sw-notificationclick-deeplink` (#209) + 診断コミット 1 本 (\`71cb265\`)。

## 使い方

1. Draft PR の preview URL を Android PWA に install
2. \`?debug=1\` を付けて開く → 右下に **Copy Logs / Clear** ボタンが出る (localStorage 永続化)
3. Clear で空にしてから再現手順を実行
4. Copy Logs で貼り付け → 共有

**解除**: \`?debug=0\`

## checkpoint

| tag | 意味 |
|---|---|
| \`SW notificationclick\` | 通知タップで SW handler 到達 |
| \`SW link extracted\` | payload から deep link 抽出 |
| \`SW origin mismatch\` | preview で staging リンクをタップした等 |
| \`SW intent stored\` | Cache Storage 書き込み完了 |
| \`SW matchAll\` | 生きている client 一覧 (url/focused/vis) |
| \`SW target picked\` | 選んだ client。null なら openWindow へ |
| \`SW postMessage sent\` | SPA navigate 指示送信 |
| \`SW focus ok/fail\` | PWA 前面化 |
| \`SW openWindow fallback\` | client 不在時 |
| \`CL listener mounted\` | useFcmNavigationListener setup |
| \`CL sw message\` | SW → client の message 受信 |
| \`CL visibilitychange\` | PWA 前後面変化 |
| \`CL applyIntent\` | Cache 内 intent 消化 |
| \`CL navigate() called\` | React Router navigate 発火 |
| \`CL navigateOnce skip\` | dedupe |
| \`FB effect\` | useFocusBlockOnMount 発火時状態 |
| \`FB wait done\` | data-block-id 発見 or timeout |

## 期待パターン / 故障パターン

**正常 (別 trip 通知タップ)**:
\`\`\`
SW notificationclick → SW link extracted → SW intent stored
→ SW matchAll (client あり) → SW target picked → SW postMessage sent → SW focus ok
→ CL sw message → CL navigate() called (source: message)
\`\`\`

**postMessage 未着 (PWA freeze 疑い)**:
\`\`\`
SW ... postMessage sent → SW focus ok
→ CL sw message 出ない
→ CL visibilitychange (visible)
→ CL applyIntent → CL navigate() called (source: intent)   ← Cache safety net で救えるはず
\`\`\`

**両経路とも効かない場合**:
\`\`\`
SW ... postMessage sent
→ CL 側にログが一切出ない or navigate skip が出続ける
\`\`\`

原因層が特定できたら、正しい fix を #209 に別コミットで反映してこの Draft PR は close。