### PR TITLE
fix(#220): 途中ブロックがグルーピングされない問題を sweep-line で解消

### DIFF
--- a/frontend/src/components/timeline/Timeline.stories.tsx
+++ b/frontend/src/components/timeline/Timeline.stories.tsx
@@ -162,6 +162,45 @@ export const OverlappingNoNull: Story = {
   },
 };
 
+/** issue #220: 長いブロックの区間内で別ブロックが始まるケース (containment) */
+export const OverlappingContainment: Story = {
+  args: {
+    blocks: [
+      {
+        id: 1,
+        type: 'transportation',
+        transportationType: 'car',
+        title: '車移動',
+        startTime: new Date(2024, 0, 1, 10, 0),
+        endTime: new Date(2024, 0, 1, 14, 0),
+        detail: '休憩 1時間込み',
+        pageId: 1,
+        location: null,
+        destinationLocation: null,
+      },
+      {
+        id: 2,
+        type: 'schedule',
+        title: '天満橋着',
+        startTime: new Date(2024, 0, 1, 10, 30),
+        endTime: null,
+        pageId: 1,
+        location: null,
+      },
+      {
+        id: 3,
+        type: 'schedule',
+        title: 'ガラス美術館',
+        startTime: new Date(2024, 0, 1, 15, 0),
+        endTime: new Date(2024, 0, 1, 16, 45),
+        pageId: 1,
+        location: null,
+      },
+    ] satisfies Block[],
+    type: 'view',
+  },
+};
+
 /** ケース3: グループ + gap + 単独ブロック */
 export const OverlappingWithGap: Story = {
   args: {

--- a/frontend/src/components/timeline/ViewTimeline.test.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.test.tsx
@@ -3,7 +3,7 @@ import { vi } from 'vitest';
 
 import { sortBlocks } from '@/lib/sortBlocks';
 import type { Block, ScheduleBlock, TransportationBlock } from '@/types/block';
-import { buildTimelineItems, groupByStartTime, ViewTimeline } from './ViewTimeline';
+import { buildTimelineItems, groupOverlappingBlocks, ViewTimeline } from './ViewTimeline';
 
 vi.mock('../blocks/view/BlockScheduleView', () => ({
   BlockScheduleView: ({ block, isNow }: { block: ScheduleBlock; isNow?: boolean }) => (
@@ -55,14 +55,14 @@ const countBorderDashed = (container: HTMLElement): number => {
   return container.querySelectorAll('.border-dashed').length;
 };
 
-describe('groupByStartTime', () => {
+describe('groupOverlappingBlocks', () => {
   it('空配列を渡すと空配列を返す', () => {
-    expect(groupByStartTime([])).toEqual([]);
+    expect(groupOverlappingBlocks([])).toEqual([]);
   });
 
   it('単一ブロックは1グループになり、groupEnd は endTime と一致する', () => {
     const block = makeSchedule(1, at(9), at(10));
-    const groups = groupByStartTime([block]);
+    const groups = groupOverlappingBlocks([block]);
 
     expect(groups).toHaveLength(1);
     expect(groups[0].blocks).toEqual([block]);
@@ -72,10 +72,10 @@ describe('groupByStartTime', () => {
     expect(groups[0].containerBlocks).toEqual([block]);
   });
 
-  it('異なる startTime のブロックは別々のグループに分かれる', () => {
+  it('時間帯が重ならない異なる startTime のブロックは別々のグループに分かれる', () => {
     const a = makeSchedule(1, at(9), at(10));
     const b = makeSchedule(2, at(11), at(12));
-    const groups = groupByStartTime([a, b]);
+    const groups = groupOverlappingBlocks([a, b]);
 
     expect(groups).toHaveLength(2);
     expect(groups[0].blocks).toEqual([a]);
@@ -85,7 +85,7 @@ describe('groupByStartTime', () => {
   it('同一 startTime の複数ブロックは1グループにまとめられる', () => {
     const a = makeSchedule(1, at(9), at(10));
     const b = makeSchedule(2, at(9), at(11));
-    const groups = groupByStartTime([a, b]);
+    const groups = groupOverlappingBlocks([a, b]);
 
     expect(groups).toHaveLength(1);
     expect(groups[0].blocks).toHaveLength(2);
@@ -96,7 +96,7 @@ describe('groupByStartTime', () => {
     const headerCandidate = makeSchedule(1, at(9), null, 'header');
     const other = makeSchedule(2, at(9), at(10), 'other');
     // sortBlocks 後は endTime=null が先頭になる前提
-    const groups = groupByStartTime([headerCandidate, other]);
+    const groups = groupOverlappingBlocks(sortBlocks([headerCandidate, other]));
 
     expect(groups).toHaveLength(1);
     expect(groups[0].headerBlock).toBe(headerCandidate);
@@ -106,7 +106,7 @@ describe('groupByStartTime', () => {
   it('グループの全ブロックが endTime=null のとき groupEnd は null になる', () => {
     const a = makeSchedule(1, at(9), null);
     const b = makeSchedule(2, at(9), null);
-    const groups = groupByStartTime([a, b]);
+    const groups = groupOverlappingBlocks([a, b]);
 
     expect(groups).toHaveLength(1);
     expect(groups[0].groupEnd).toBeNull();
@@ -116,10 +116,76 @@ describe('groupByStartTime', () => {
     const a = makeSchedule(1, at(9), at(10));
     const b = makeSchedule(2, at(9), at(13));
     const c = makeSchedule(3, at(9), at(11));
-    const groups = groupByStartTime([a, b, c]);
+    const groups = groupOverlappingBlocks([a, b, c]);
 
     expect(groups).toHaveLength(1);
     expect(groups[0].groupEnd).toEqual(at(13));
+  });
+
+  // --- issue #220: 途中ブロックのグルーピング (containment / partial overlap) ---
+
+  it('長いブロックの区間内で始まる別ブロックは同じグループに取り込まれる (containment)', () => {
+    // 車移動 10:00-14:00 の内側で始まる 天満橋着 10:30 のケース
+    const container = makeTransport(1, at(10), at(14), '車移動');
+    const inner = makeSchedule(2, at(10, 30), null, '天満橋着');
+    const groups = groupOverlappingBlocks(sortBlocks([container, inner]));
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].blocks).toEqual([container, inner]);
+    // container 側は endTime を持つので headerBlock にはならない
+    expect(groups[0].headerBlock).toBeNull();
+    expect(groups[0].containerBlocks).toEqual([container, inner]);
+    expect(groups[0].groupStart).toEqual(at(10));
+    expect(groups[0].groupEnd).toEqual(at(14));
+  });
+
+  it('部分的にオーバーラップするブロックは同じグループに取り込まれ groupEnd が伸びる', () => {
+    const a = makeSchedule(1, at(10), at(12));
+    const b = makeSchedule(2, at(11), at(13));
+    const groups = groupOverlappingBlocks(sortBlocks([a, b]));
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].groupEnd).toEqual(at(13));
+  });
+
+  it('3つ以上のブロックが連鎖して重なる場合、全て 1 グループに集約される (sweep-line)', () => {
+    const a = makeSchedule(1, at(10), at(12));
+    const b = makeSchedule(2, at(11), at(14));
+    const c = makeSchedule(3, at(13), at(15));
+    const groups = groupOverlappingBlocks(sortBlocks([a, b, c]));
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].blocks).toEqual([a, b, c]);
+    expect(groups[0].groupEnd).toEqual(at(15));
+  });
+
+  it('隣接する (前グループの終端 = 次ブロックの開始) は同じグループにしない', () => {
+    const a = makeSchedule(1, at(10), at(11));
+    const b = makeSchedule(2, at(11), at(12));
+    const groups = groupOverlappingBlocks(sortBlocks([a, b]));
+
+    expect(groups).toHaveLength(2);
+  });
+
+  it('headerBlock (endTime=null) のみで開始したグループには同時刻ブロックしか合流しない', () => {
+    // 9:00 の point event と、後続の 10:00-11:00 ブロック
+    const header = makeSchedule(1, at(9), null);
+    const later = makeSchedule(2, at(10), at(11));
+    const groups = groupOverlappingBlocks(sortBlocks([header, later]));
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].headerBlock).toBe(header);
+    expect(groups[1].blocks).toEqual([later]);
+  });
+
+  it('長いブロックの内側で発生する endTime=null は container 側に入る (headerBlock にはならない)', () => {
+    const container = makeTransport(1, at(10), at(14), '車移動');
+    const inner = makeSchedule(2, at(10, 30), null, '天満橋着');
+    const groups = groupOverlappingBlocks(sortBlocks([container, inner]));
+
+    // opener (container) が endTime を持つので、後続の null は headerBlock ではなく container 側
+    expect(groups[0].headerBlock).toBeNull();
+    expect(groups[0].containerBlocks).toContain(inner);
   });
 });
 
@@ -435,7 +501,7 @@ describe('buildTimelineItems - NOW 挿入位置', () => {
     location: null,
   });
   const buildFromBlocks = (blocks: Block[], now: Date | null) =>
-    buildTimelineItems(groupByStartTime(sortBlocks(blocks)), now);
+    buildTimelineItems(groupOverlappingBlocks(sortBlocks(blocks)), now);
 
   it('明示的 gap 内で ratio が gap アイテムに乗って計算される', () => {
     const a = makeSchedule(1, at(10), at(11));

--- a/frontend/src/components/timeline/ViewTimeline.tsx
+++ b/frontend/src/components/timeline/ViewTimeline.tsx
@@ -50,43 +50,49 @@ interface ViewTimelineProps {
 
 // --- グループ化 ---
 
-/** 同一 startTime のブロックを OverlapGroup にまとめる */
-export const groupByStartTime = (sortedBlocks: Block[]): OverlapGroup[] => {
-  if (sortedBlocks.length === 0) return [];
-
-  const groups: OverlapGroup[] = [];
-  let i = 0;
-
-  while (i < sortedBlocks.length) {
-    const startMs = sortedBlocks[i].startTime.getTime();
-    const groupBlocks: Block[] = [sortedBlocks[i]];
-    i++;
-
-    // 同じ startTime のブロックを集める
-    while (i < sortedBlocks.length && sortedBlocks[i].startTime.getTime() === startMs) {
-      groupBlocks.push(sortedBlocks[i]);
-      i++;
-    }
-
-    // headerBlock: endTime === null のブロック（最初の1つ）
-    const headerBlock = groupBlocks.find(b => b.endTime === null) ?? null;
-    const containerBlocks = headerBlock ? groupBlocks.filter(b => b !== headerBlock) : groupBlocks;
-
-    // groupEnd: endTime を持つブロックの中で最も遅い endTime
-    const endTimes = groupBlocks.map(b => b.endTime?.getTime()).filter((t): t is number => t != null);
-    const groupEnd = endTimes.length > 0 ? new Date(Math.max(...endTimes)) : null;
-
-    groups.push({
-      blocks: groupBlocks,
-      headerBlock,
-      containerBlocks,
-      groupStart: sortedBlocks[i - 1].startTime, // 全て同じ startTime
-      groupEnd,
-    });
-  }
-
-  return groups;
+/**
+ * 時間帯が重なるブロックを OverlapGroup にまとめる (sweep-line)。
+ * - 判定は「次ブロックの startTime が running max endTime より前」か「groupStart と一致」。
+ *   → 完全一致 (同時刻開始) と包含 (長いブロックの内側で開始) を同じロジックで扱う。
+ * - groupEnd が null (headerBlock のみで開始) の場合は完全一致のみ merge する。
+ * - グループの opener が endTime=null の場合、その opener を headerBlock としてコンテナ外に描画。
+ *   後発 (mid-group) の endTime=null は containerBlocks 側に置く。
+ */
+const shouldMergeIntoGroup = (group: OverlapGroup, block: Block): boolean => {
+  const startMs = block.startTime.getTime();
+  return startMs === group.groupStart.getTime() || (group.groupEnd !== null && startMs < group.groupEnd.getTime());
 };
+
+const openGroup = (block: Block): OverlapGroup => {
+  const isHeader = block.endTime === null;
+  return {
+    blocks: [block],
+    headerBlock: isHeader ? block : null,
+    containerBlocks: isHeader ? [] : [block],
+    groupStart: block.startTime,
+    groupEnd: block.endTime,
+  };
+};
+
+const extendGroup = (group: OverlapGroup, block: Block): void => {
+  group.blocks.push(block);
+  group.containerBlocks.push(block);
+  const endMs = block.endTime?.getTime();
+  if (endMs !== undefined && (group.groupEnd === null || endMs > group.groupEnd.getTime())) {
+    group.groupEnd = new Date(endMs);
+  }
+};
+
+export const groupOverlappingBlocks = (sortedBlocks: Block[]): OverlapGroup[] =>
+  sortedBlocks.reduce<OverlapGroup[]>((groups, block) => {
+    const last = groups.length > 0 ? groups[groups.length - 1] : null;
+    if (last && shouldMergeIntoGroup(last, block)) {
+      extendGroup(last, block);
+    } else {
+      groups.push(openGroup(block));
+    }
+    return groups;
+  }, []);
 
 // --- NOW 判定ヘルパー ---
 
@@ -205,7 +211,7 @@ export const buildTimelineItems = (groups: OverlapGroup[], now: Date | null = nu
 export function ViewTimeline({ blocks, pageDate, now, className }: ViewTimelineProps) {
   // React Compiler が pageDate/now/blocks 変化時のみ再計算するようメモ化する
   const effectiveNow = pageDate && now && isSameLocalDate(pageDate, now) ? now : null;
-  const groups = groupByStartTime(sortBlocks(blocks));
+  const groups = groupOverlappingBlocks(sortBlocks(blocks));
   const timelineItems = buildTimelineItems(groups, effectiveNow);
 
   return (


### PR DESCRIPTION
## Summary

- Fixes #220
- ブロック一覧のグルーピング判定を「同一 startTime」の等価比較から sweep-line (interval overlap) に置き換え、**長いブロックの区間内で始まる別ブロックが取りこぼされる問題**を解消
- `groupByStartTime` → `groupOverlappingBlocks` にリネーム (等価比較を止めたので名前が実態に合わなくなったため)

## 再現ケース

`OverlappingContainment` Story として追加:

| ブロック | 時刻 |
|---|---|
| 車移動 | 10:00-14:00 (4h コンテナ) |
| 天満橋着 | 10:30 (endTime=null / 途中の point event) |
| ガラス美術館 | 15:00-16:45 |

修正前は `車移動` と `天満橋着` が別グループとして描画され、コンテナ枠外に浮いたレイアウトになっていた。

## 判定ロジック (設計上の意思決定)

merge 条件を関数 `shouldMergeIntoGroup` に閉じ込め、次の 2 条件の OR で判定:

```
startTime === group.groupStart   // 同時刻開始 (従来からの挙動を包含)
||
group.groupEnd !== null && startTime < group.groupEnd   // 区間内で開始
```

- **strict `<` を採用**: 「前グループの終端 = 次ブロックの開始」は adjacency として別グループのまま扱う (既存の `isConnectedWithNextGroup` の意味論を保持)
- **groupEnd=null (opener が endTime=null) の場合は同時刻一致のみ許可**: header 単独開始のグループに、時間的に後ろの別ブロックを吸い込ませない
- **mid-group の endTime=null は containerBlocks 側**: `headerBlock` は「グループ opener が endTime=null の場合の opener 自身」に限定。長いブロックの中で発生する point event は container 内に時刻ラベル付きで並ぶ

## 実装スタイル

`while` の index 管理を廃止して `reduce` + 小ヘルパー (`openGroup` / `extendGroup` / `shouldMergeIntoGroup`) に分解。判定条件を今後変更したくなった場合 (例: 「gap 10分以内は同グループ」) は `shouldMergeIntoGroup` 単体を触れば済む。

## 回帰テスト

`ViewTimeline.test.tsx` の `groupOverlappingBlocks` describe に追加:

- containment (長いブロック内で別ブロックが開始)
- 部分オーバーラップ (groupEnd が伸びる)
- 3連鎖 (sweep-line 挙動確認)
- 隣接 (前終端 = 次開始) は非マージ
- headerBlock のみで開いたグループには同時刻ブロックしか合流しない
- 長いブロック内の endTime=null は containerBlocks 側

既存 49 テストは全て pass。frontend 全体 215 テスト pass、type-check / format:check 緑。

## Test plan

- [ ] Storybook `Components/Timeline/OverlappingContainment` を開いて、車移動コンテナ内に天満橋着が並んで描画されることを確認
- [ ] 既存 Story (`ViewMode` / `OverlappingSameStart` / `OverlappingNoNull` / `OverlappingWithGap` / NOW 系) に回帰がないことを確認
- [ ] 実機で issue #220 の再現ケースを含む旅程を開いて修正を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - タイムライン上で、包含関係や部分的な重複を含む予定・移動ブロックを、実際の重なりに基づいて適切にグループ表示できるようになりました。
  - 終了時刻が設定されていない予定を含むケースでも、タイムラインの見出し表示が正しく処理されます。

- **表示例**
  - 長時間の移動中に開始する予定など、複雑な重なり方を確認できるサンプルを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->