### PR TITLE
fix(#227): iOS Safari で通知ボタンが表示されない問題を修正

### DIFF
--- a/frontend/src/components/NotificationToggleButton.test.tsx
+++ b/frontend/src/components/NotificationToggleButton.test.tsx
@@ -25,10 +25,10 @@ vi.mock('@/lib/messaging', () => ({
   requestNotificationPermission: () => mockRequestNotificationPermission(),
 }));
 
-const mockIsNotificationSupported = vi.fn();
+const mockShouldShowButton = vi.fn();
 const mockNeedsIOSInstall = vi.fn();
 vi.mock('@/lib/platform', () => ({
-  isNotificationSupported: () => mockIsNotificationSupported(),
+  shouldShowNotificationButton: () => mockShouldShowButton(),
   needsIOSInstallForNotification: () => mockNeedsIOSInstall(),
 }));
 
@@ -64,16 +64,23 @@ describe('NotificationToggleButton', () => {
     mockConfirm.mockResolvedValue(true);
     mockFetchFcmToken.mockResolvedValue('token-abc');
     mockRequestNotificationPermission.mockResolvedValue('granted');
-    mockIsNotificationSupported.mockReturnValue(true);
+    mockShouldShowButton.mockReturnValue(true);
     mockNeedsIOSInstall.mockReturnValue(false);
     setNotificationPermission('default');
   });
 
   describe('OFF → ON (購読フロー)', () => {
-    it('ブラウザ非対応時はボタン自体を出さない', () => {
-      mockIsNotificationSupported.mockReturnValue(false);
+    it('ブラウザ非対応かつ iOS 以外ならボタン自体を出さない', () => {
+      mockShouldShowButton.mockReturnValue(false);
       render(<NotificationToggleButton tripId={1} tripHasStartDate={true} />);
       expect(screen.queryByRole('button', { name: '通知を有効にする' })).toBeNull();
+    });
+
+    it('iOS 非 PWA (Notification API 未露出) でもボタンを出す', () => {
+      mockShouldShowButton.mockReturnValue(true);
+      mockNeedsIOSInstall.mockReturnValue(true);
+      render(<NotificationToggleButton tripId={1} tripHasStartDate={true} />);
+      expect(screen.getByRole('button', { name: '通知を有効にする' })).toBeInTheDocument();
     });
 
     it('OS 設定で既に denied なら OS 設定への誘導トーストを出し requestPermission を呼ばない', async () => {

--- a/frontend/src/components/NotificationToggleButton.tsx
+++ b/frontend/src/components/NotificationToggleButton.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { useTripSubscription } from '@/hooks/useTripSubscription';
 import { useConfirm } from '@/lib/confirm';
 import { fetchFcmToken, requestNotificationPermission } from '@/lib/messaging';
-import { isNotificationSupported, needsIOSInstallForNotification } from '@/lib/platform';
+import { needsIOSInstallForNotification, shouldShowNotificationButton } from '@/lib/platform';
 import { cn } from '@/lib/utils';
 import { IOSInstallInstructionDialog } from './IOSInstallInstructionDialog';
 import { Button } from './ui/button';
@@ -91,6 +91,12 @@ export const NotificationToggleButton = ({ tripId, tripHasStartDate, className }
   const handleClick = useCallback(async () => {
     if (tripId == null || isPending) return;
 
+    // iOS Safari は PWA install 後でないと permission リクエスト自体できない
+    if (needsIOSInstallForNotification()) {
+      setIosDialogOpen(true);
+      return;
+    }
+
     if (isSubscribed) {
       setIsPending(true);
       try {
@@ -108,12 +114,6 @@ export const NotificationToggleButton = ({ tripId, tripHasStartDate, className }
       } finally {
         setIsPending(false);
       }
-      return;
-    }
-
-    // iOS Safari は PWA install 後でないと permission リクエスト自体不可なので誘導ダイアログへ
-    if (needsIOSInstallForNotification()) {
-      setIosDialogOpen(true);
       return;
     }
 
@@ -185,10 +185,7 @@ export const NotificationToggleButton = ({ tripId, tripHasStartDate, className }
     }
   }, [tripId, isPending, isSubscribed, tripHasStartDate, subscribe, unsubscribe, confirm, handleTestSend]);
 
-  // Web Push 非対応ブラウザではボタン自体を出さない (macOS Safari 非 PWA / insecure context 等)。
-  // iOS Safari (未 install) は Notification API は生えている前提でここでは弾かず、
-  // click 時に needsIOSInstallForNotification() で install 誘導ダイアログへ回す。
-  if (!isNotificationSupported()) return null;
+  if (!shouldShowNotificationButton()) return null;
 
   const showLoading = isLoading || isPending;
   return (

--- a/frontend/src/lib/platform.test.ts
+++ b/frontend/src/lib/platform.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { shouldShowNotificationButton } from './platform';
+
+const IPHONE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36';
+
+const setUserAgent = (ua: string) => {
+  vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua);
+};
+
+const setStandalone = (standalone: boolean) => {
+  vi.spyOn(window, 'matchMedia').mockImplementation(
+    query => ({ matches: standalone && query.includes('standalone') }) as MediaQueryList
+  );
+};
+
+/** iOS Safari のタブは Notification / PushManager を露出しない */
+const setWebPushApis = (available: boolean) => {
+  for (const key of ['Notification', 'PushManager'] as const) {
+    if (available) {
+      vi.stubGlobal(key, class {});
+    } else {
+      Reflect.deleteProperty(window, key);
+    }
+  }
+  Object.defineProperty(navigator, 'serviceWorker', { value: {}, configurable: true });
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('shouldShowNotificationButton', () => {
+  it('iOS 非 PWA は Web Push API が無くても true (install で解決できるため)', () => {
+    setUserAgent(IPHONE_UA);
+    setStandalone(false);
+    setWebPushApis(false);
+    expect(shouldShowNotificationButton()).toBe(true);
+  });
+
+  it('iOS PWA は true', () => {
+    setUserAgent(IPHONE_UA);
+    setStandalone(true);
+    setWebPushApis(true);
+    expect(shouldShowNotificationButton()).toBe(true);
+  });
+
+  it('対応ブラウザは true', () => {
+    setUserAgent(ANDROID_UA);
+    setStandalone(false);
+    setWebPushApis(true);
+    expect(shouldShowNotificationButton()).toBe(true);
+  });
+
+  it('iOS 以外の非対応ブラウザは false', () => {
+    setUserAgent(ANDROID_UA);
+    setStandalone(false);
+    setWebPushApis(false);
+    expect(shouldShowNotificationButton()).toBe(false);
+  });
+});

--- a/frontend/src/lib/platform.ts
+++ b/frontend/src/lib/platform.ts
@@ -18,3 +18,8 @@ export const needsIOSInstallForNotification = (): boolean => {
 export const isNotificationSupported = (): boolean => {
   return 'Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window;
 };
+
+/** iOS Safari のタブは Notification / PushManager 未露出だが、install すれば購読できるのでボタンは出す */
+export const shouldShowNotificationButton = (): boolean => {
+  return isNotificationSupported() || needsIOSInstallForNotification();
+};


### PR DESCRIPTION
Closes #227

## サマリ

iOS Safari（非 PWA）で通知ボタンが表示されない不具合を修正した。併せて、これまで iOS から到達不能な死にコードになっていた PWA インストール誘導ダイアログが機能するようになる。

## 原因

`isNotificationSupported()` は Web Push API 一式の feature detection をしている。

```ts
'Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window
```

**iOS Safari のタブでは Notification / PushManager が window に露出しない。** iOS 16.4+ で Web Push が来た後も、公開されるのは「ホーム画面に追加」した standalone web app のみ。

| 環境 | `isNotificationSupported()` | ボタン |
|---|---|---|
| iOS Safari タブ | **false** | 出ない ← 不具合 |
| iOS PWA | true | 出る |
| Android / PC | true | 出る |

実装は「iOS Safari でも Notification API は生えている」前提で書かれており、install 誘導は click ハンドラ側に置かれていた。しかしボタン自体が描画されないため、`IOSInstallInstructionDialog` は iOS から一度も表示されない状態だった。

## やったこと

- 表示判定 `shouldShowNotificationButton()` を追加し、「購読できるか」と「ボタンを出す意味があるか」を分離
- `handleClick` の iOS 分岐を `isSubscribed` 分岐より前に繰り上げ
- `platform.ts` のテストを新規追加、`NotificationToggleButton` に iOS 非 PWA ケースを追加

## 設計判断

**「打つ手がある環境」でだけボタンを出す。** issue の TOBE は「全デバイスで通知ボタンは出す」だが、文字通り常時表示にはしていない。

- iOS 非 PWA → **出す**。インストールという出口があり、誘導ダイアログに価値がある
- Firefox プライベート / insecure context / 旧ブラウザ → **従来どおり出さない**。押しても打つ手がなく、機能しないボタンは誤解を招くだけ

判定を `isNotificationSupported()` の書き換えではなく別関数の追加にしたのは、「実際に購読できるか」の意味を保ったまま表示ポリシーだけを差し替えるため。両者を混ぜると今回と同種の取り違えが再発する。

## 動作確認

- frontend 全 223 テスト green（`platform.test.ts` 4 件、`NotificationToggleButton.test.tsx` 20 件を含む）
- type-check / lint / format 通過
- **実機での確認は未実施。** iOS Safari 実機でボタン表示 → インストール誘導 → ホーム画面から起動 → 通知有効化まで要確認

## 既知の許容

iPhone から HTTP（`pnpm run dev`）でアクセスすると、`serviceWorker` 不在で `isNotificationSupported()` が false のままボタンが出る。インストールしても HTTPS でないと通知できないが、開発時限定のため許容（`dev:https` を使えば再現しない）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * iOSの未インストール環境でも通知ボタンを表示し、購読前にインストール案内を表示するようになりました。

* **改善**
  * 通知に対応していないブラウザでは、通知ボタンを表示しないよう判定を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->