### PR TITLE
fix(#223): /auth/link で別アカウント再ログイン時に既存アカウントを壊さない

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -61,12 +61,13 @@
     - デバイス間での旅程一覧同期
     - Cookie 消失 (ブラウザデータクリア、機種変更、iOS Safari の ITP 7 日パージ) 時のリカバリ
   - `signInWithPopup(GoogleAuthProvider)` で OAuth。認証時は同一 `firebase_uid` の user に session を紐付けて統合する
+    - ただし統合の対象は**匿名 user のみ**。既に別アカウントで認証済みの session に別 `firebase_uid` が来た場合は「アカウント切り替え」として session の紐付け先を変えるだけにし、元アカウントの昇格・マージ・削除は行わない (issue #223)
     - `signInWithRedirect` は使わない: redirect フローは authDomain (`<project>.firebaseapp.com`) 上のクロスオリジン iframe に依存し、サードパーティストレージをブロックするブラウザ (Safari 16.1+ / Firefox 109+ / Chrome M115+) で `getRedirectResult` が黙って null を返す。authDomain を自ドメインに変える回避策は Hosting preview チャンネルの URL が動的で OAuth リダイレクト URI を事前登録できないため採れない
 - **デバイス引き継ぎ** (8 桁ペアリングコード + Firebase Custom Token):
   - iOS PWA (ホーム画面追加) は Safari とストレージが分離され、OAuth リダイレクトも常に Safari 側で開かれるため **Google 認証によるリカバリが PWA では機能しない**。この抜け穴を塞ぐための機構
   - 認証済みデバイスで 8 桁コード (base32 = 40 bits) を発行し、実体の Firebase Custom Token とのマッピングは Firestore に短命保存 (5 分 TTL + one-time consume)
   - 受信側デバイスがコードを入力すると `POST /pair/redeem` で Custom Token を交換し、`signInWithCustomToken` で認証状態を移送
-  - 受信側は既存の `/auth/link` (パターン 2: マージ) が自動発火し、匿名 session が同 user_id に統合される。PostgreSQL 側の追加スキーマは不要 (Firestore に完結)
+  - 受信側は既存の `/auth/link` が自動発火し、匿名 session なら同 user_id に統合される (パターン 2: マージ)。受信側が既に別アカウントで認証済みだった場合は切り替え扱いになる。PostgreSQL 側の追加スキーマは不要 (Firestore に完結)
 
 ### Phase 2
 

--- a/server/app/routers/auth.py
+++ b/server/app/routers/auth.py
@@ -11,6 +11,7 @@ from firebase_admin import auth as fb_auth
 from firebase_admin.exceptions import FirebaseError
 from pydantic import BaseModel
 from sqlalchemy import select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -51,6 +52,28 @@ def _verify_id_token(id_token: str) -> str:
     return uid
 
 
+async def _insert_or_get_user_id(db: AsyncSession, firebase_uid: str) -> int:
+    """firebase_uid を持つ user の id を返す。存在しなければ作成する。
+
+    同時初回リンクによる unique 違反は ON CONFLICT DO NOTHING で吸収する。例外経路を
+    使わないので `ensure_session` が同一トランザクションで積んだ変更を巻き戻さずに済む。
+    競合時の SELECT フォールバックは READ COMMITTED (PostgreSQL 既定) 前提。
+    """
+    inserted_id = (
+        await db.execute(
+            pg_insert(User)
+            .values(firebase_uid=firebase_uid)
+            .on_conflict_do_nothing(index_elements=["firebase_uid"])
+            .returning(User.id)
+        )
+    ).scalar_one_or_none()
+    if inserted_id is not None:
+        return inserted_id
+    return (
+        await db.execute(select(User.id).where(User.firebase_uid == firebase_uid))
+    ).scalar_one()
+
+
 @router.post(
     "/link",
     summary="Firebase 認証情報を現在の session に紐付ける",
@@ -69,14 +92,18 @@ async def link_firebase(
     匿名 session を先に発行してから紐付ける。これで「Cookie 消失時のリカバリ」
     という本機能の主要ユースケースが成立する。
 
-    ケース分岐 (issue #194 の grill-me 議論参照):
-    - パターン 1 (初認証): 同 firebase_uid の user が DB に無い
+    ケース分岐 (issue #194 の grill-me 議論、issue #223):
+    - パターン 1 (匿名 × 初認証): 同 firebase_uid の user が DB に無い
       → 匿名 user の firebase_uid を UPDATE で埋める (昇格)
-    - パターン 2 (別デバイスで先に認証済み): 同 firebase_uid の user が既に存在
+    - パターン 2 (匿名 × 別デバイスで先に認証済み): 同 firebase_uid の user が既に存在
       → 匿名 user の user_trip_access を INSERT ON CONFLICT DO NOTHING でマージし、
         session.user_id を振り替え、匿名 user を削除。archived フラグは既存側優先
     - パターン 3 (再認証): session が既に該当認証済 user に属している → 何もしない
       (Cookie パージ後の再ログインでもここに落ちるだけで副作用なし)
+    - パターン 4 (アカウント切り替え): session の user が既に別の firebase_uid を持つ
+      → 元 user には触れず、切り替え先 user (無ければ作成) へ session を張り替えるだけ。
+        昇格すると元アカウントが DB から辿れなくなり、マージすると元アカウントが消える
+        ため (issue #223)。切り替えは正当な操作なので 409 では弾かない
     """
     firebase_uid = _verify_id_token(body.id_token)
     session = await ensure_session(request, response, db)
@@ -88,9 +115,26 @@ async def link_firebase(
         )
     session_id = session.id
 
+    if current_user.firebase_uid == firebase_uid:
+        # パターン 3: ensure_session の last_seen_at 更新だけを確定させる
+        await db.commit()
+        return LinkFirebaseOut(firebase_uid=firebase_uid)
+
     existing = (
         await db.execute(select(User).where(User.firebase_uid == firebase_uid))
     ).scalar_one_or_none()
+
+    if current_user.firebase_uid is not None:
+        # パターン 4: session 行は作り直さず user_id だけ張り替える (作り直すと、
+        # レスポンスが届かなかった端末が既存 session を失う)
+        target_id = (
+            existing.id
+            if existing is not None
+            else await _insert_or_get_user_id(db, firebase_uid)
+        )
+        session.user_id = target_id
+        await db.commit()
+        return LinkFirebaseOut(firebase_uid=firebase_uid)
 
     if existing is None:
         # パターン 1: 匿名 user を認証済に昇格する。並行昇格 (別デバイスから同時に

--- a/server/tests/routers/test_auth_router.py
+++ b/server/tests/routers/test_auth_router.py
@@ -13,7 +13,10 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import SESSION_COOKIE_NAME, generate_session_id
+from app.cruds import trips as trips_cruds
 from app.models import User, UserSession
+from app.routers.auth import _insert_or_get_user_id
+from app.schemas.trip import TripCreateIn
 from tests.conftest import _make_session_cookie_value
 
 
@@ -73,10 +76,6 @@ async def test_link_merges_into_existing_user(
     existing = User(firebase_uid="firebase-uid-existing")
     db_session.add(existing)
     await db_session.flush()
-
-    # マージ対象の trip を作成 (users を先に作った後で trip を FK 有効な状態で追加)
-    from app.cruds import trips as trips_cruds
-    from app.schemas.trip import TripCreateIn
 
     trip_shared = await trips_cruds.create_trip(
         db=db_session, trip=TripCreateIn(title="shared", detail=""), url_id="shared"
@@ -170,6 +169,127 @@ async def test_link_is_idempotent_on_reauth(
     assert len(users) == 1  # 増減なし
 
 
+async def _make_authed_session(db: AsyncSession, firebase_uid: str) -> UserSession:
+    """認証済み user + session を作成して session を返す"""
+    user = User(firebase_uid=firebase_uid)
+    db.add(user)
+    await db.flush()
+    session = UserSession(id=generate_session_id(), user_id=user.id)
+    db.add(session)
+    await db.commit()
+    return session
+
+
+async def _grant_access(db: AsyncSession, user_id: int, trip_id: int) -> None:
+    """アクセス権を仕込む"""
+    await db.execute(
+        text("INSERT INTO user_trip_access (user_id, trip_id) VALUES (:uid, :tid)"),
+        {"uid": user_id, "tid": trip_id},
+    )
+    await db.commit()
+
+
+async def _trip_ids_of(db: AsyncSession, user_id: int) -> list[int]:
+    """user が持つ trip_id 一覧を返す"""
+    rows = await db.execute(
+        text(
+            "SELECT trip_id FROM user_trip_access WHERE user_id = :uid ORDER BY trip_id"
+        ),
+        {"uid": user_id},
+    )
+    return list(rows.scalars())
+
+
+async def test_link_switches_to_unknown_account_without_touching_current_user(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """パターン 4 (切り替え先 user 無し): 認証済み session に別 uid が来ても元アカウントは無傷 (issue #223)"""
+    session = await _make_authed_session(db_session, firebase_uid="uid-current")
+    current_user_id = session.user_id
+    trip_id = await trips_cruds.create_trip(
+        db=db_session, trip=TripCreateIn(title="x", detail=""), url_id="switch-new"
+    )
+    await _grant_access(db_session, current_user_id, trip_id)
+
+    _mock_verify_id_token(monkeypatch, uid="uid-other")
+    client.cookies.set(SESSION_COOKIE_NAME, _make_session_cookie_value(session.id))
+
+    r = await client.post("/auth/link", json={"id_token": "any"})
+    assert r.status_code == 200
+    assert r.json() == {"firebase_uid": "uid-other"}
+
+    # 元アカウントは firebase_uid を奪われず、旅程も保持したまま存在し続ける
+    current_uid = (
+        await db_session.execute(
+            text("SELECT firebase_uid FROM users WHERE id = :uid"),
+            {"uid": current_user_id},
+        )
+    ).scalar()
+    assert current_uid == "uid-current"
+    assert await _trip_ids_of(db_session, current_user_id) == [trip_id]
+
+    # session は新規作成された切り替え先 user を指し、旅程はマージされていない
+    new_user_id = (
+        await db_session.execute(
+            text("SELECT user_id FROM sessions WHERE id = :sid"), {"sid": session.id}
+        )
+    ).scalar()
+    assert new_user_id != current_user_id
+    new_uid = (
+        await db_session.execute(
+            text("SELECT firebase_uid FROM users WHERE id = :uid"), {"uid": new_user_id}
+        )
+    ).scalar()
+    assert new_uid == "uid-other"
+    assert await _trip_ids_of(db_session, new_user_id) == []
+
+
+async def test_link_switches_to_existing_account_without_merging(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """パターン 4 (切り替え先 user あり): 元アカウントは削除もマージもされない (issue #223)"""
+    session = await _make_authed_session(db_session, firebase_uid="uid-current-2")
+    current_user_id = session.user_id
+    other = User(firebase_uid="uid-other-2")
+    db_session.add(other)
+    await db_session.flush()
+    other_user_id = other.id
+
+    trip_current = await trips_cruds.create_trip(
+        db=db_session, trip=TripCreateIn(title="cur", detail=""), url_id="switch-cur"
+    )
+    trip_other = await trips_cruds.create_trip(
+        db=db_session, trip=TripCreateIn(title="oth", detail=""), url_id="switch-oth"
+    )
+    await _grant_access(db_session, current_user_id, trip_current)
+    await _grant_access(db_session, other_user_id, trip_other)
+
+    _mock_verify_id_token(monkeypatch, uid="uid-other-2")
+    client.cookies.set(SESSION_COOKIE_NAME, _make_session_cookie_value(session.id))
+
+    r = await client.post("/auth/link", json={"id_token": "any"})
+    assert r.status_code == 200
+
+    # 元アカウントは残存し、旅程も他アカウントに混ざっていない
+    assert await _trip_ids_of(db_session, current_user_id) == [trip_current]
+    assert await _trip_ids_of(db_session, other_user_id) == [trip_other]
+    current_uid = (
+        await db_session.execute(
+            text("SELECT firebase_uid FROM users WHERE id = :uid"),
+            {"uid": current_user_id},
+        )
+    ).scalar()
+    assert current_uid == "uid-current-2"
+
+    # session だけが切り替え先へ張り替わる (session_id は維持)
+    session_user_id = (
+        await db_session.execute(
+            text("SELECT user_id FROM sessions WHERE id = :sid"), {"sid": session.id}
+        )
+    ).scalar()
+    assert session_user_id == other_user_id
+
+
 async def test_link_without_cookie_creates_anonymous_session_and_promotes(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ):
@@ -196,3 +316,47 @@ async def test_link_invalid_id_token_returns_401(
 
     r = await client.post("/auth/link", json={"id_token": "invalid"})
     assert r.status_code == 401
+
+
+async def test_link_switch_is_idempotent(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """パターン 4 を 2 回叩いても 2 回目はパターン 3 に落ち、user は増えない"""
+    _mock_verify_id_token(monkeypatch, uid="uid-switch-twice")
+    session = await _make_authed_session(db_session, firebase_uid="uid-before-switch")
+    client.cookies.set(SESSION_COOKIE_NAME, _make_session_cookie_value(session.id))
+
+    assert (
+        await client.post("/auth/link", json={"id_token": "any"})
+    ).status_code == 200
+    assert (
+        await client.post("/auth/link", json={"id_token": "any"})
+    ).status_code == 200
+
+    user_count = (await db_session.execute(text("SELECT COUNT(*) FROM users"))).scalar()
+    assert user_count == 2  # 元アカウント + 切り替え先のみ
+    session_uid = (
+        await db_session.execute(
+            text(
+                "SELECT u.firebase_uid FROM users u "
+                "JOIN sessions s ON s.user_id = u.id WHERE s.id = :sid"
+            ),
+            {"sid": session.id},
+        )
+    ).scalar()
+    assert session_uid == "uid-switch-twice"
+
+
+async def test_insert_or_get_user_id_returns_existing_on_conflict(
+    db_session: AsyncSession,
+):
+    """ON CONFLICT DO NOTHING で 0 行になった場合も SELECT フォールバックで同じ id を返す"""
+    first = await _insert_or_get_user_id(db_session, "uid-conflict")
+    second = await _insert_or_get_user_id(db_session, "uid-conflict")
+    assert first == second
+    duplicated = (
+        await db_session.execute(
+            text("SELECT COUNT(*) FROM users WHERE firebase_uid = 'uid-conflict'")
+        )
+    ).scalar()
+    assert duplicated == 1


### PR DESCRIPTION
Closes #223

## サマリ

認証済みの状態で**別の Google アカウントにログインし直すと、元のアカウントが DB 上で破壊される**問題を修正しました。`useAuthStateSync` が `onAuthStateChanged` で `/auth/link` を自動的に叩くため、悪意も特殊操作も不要で踏める経路です。

## 原因

`POST /auth/link` は「現在の session の user が既に別の `firebase_uid` を持っているか」を見ておらず、分岐が「送られてきた uid の user が存在するか」だけで決まっていました。session が user A (`firebase_uid = X`) の状態で uid `Y` のトークンが来ると:

| uid Y の user | 起きていたこと |
|---|---|
| 無い | A の `firebase_uid` を X → Y に**上書き**。uid X は DB から辿れなくなり、次に X でログインすると新規 user が作られて旅程一覧を失う |
| ある | A の `user_trip_access` をマージした上で **A を DELETE**。アカウント X が消滅し、旅程が Y 側に混ざる |

## やったこと

- **パターン 4「アカウント切り替え」を追加**。現 user が既に別の `firebase_uid` を持つ場合は、元 user に一切触れず `session.user_id` を切り替え先へ張り替えるだけにした
- 切り替え先 user が存在しない場合は `INSERT ... ON CONFLICT DO NOTHING RETURNING` で作成
- パターン 3（同一 uid = 再認証）を早期 return し、以降の分岐を「現 user は匿名」前提に整理
- テストを 5 本 → 9 本に拡充、`docs/requirements.md` に統合対象が匿名 user のみである旨を追記

## 設計上の意思決定

**409 で弾かず「切り替え」を成立させた**
「個人用と仕事用の使い分け」「共用端末で別の人がログイン」は正当なユースケースです。409 を返すとログインし直せなくなるため、切り替えを正式にサポートする方向にしました。

**session 行は作り直さず `user_id` だけ張り替えた**
新しい `session_id` を発行すると、レスポンスが届かなかった端末が既存 session を失います。新旧いずれの Cookie も同じ端末のものなので張り替えで十分です。なお session fixation 対策としての session_id ローテーションはパターン 1 / 2 にも共通する既存論点であり、本 PR のスコープ外としています。

**`ON CONFLICT DO NOTHING` を選び、例外経路を使わなかった**
`try/except IntegrityError` + rollback だと `ensure_session` が同一トランザクションで積んだ変更まで巻き戻ります。競合時の SELECT フォールバックは READ COMMITTED (PostgreSQL 既定) 前提で、docstring に明記しています。

## スコープ外

- **切り替え後、ローカル訪問履歴経由で前アカウントの旅程が新アカウントへ流入する件**: ホーム一覧の真実を IndexedDB から `/me/trips` へ一本化する別対応でカバーされます（本 PR による退行ではなく、修正前も同じ結果でした）
- **signOut / session を匿名に戻す手段の不在**: 共用端末で切り替えた後、次の利用者が前の人のアカウントで編集できます。設計上の穴として認識していますが今回は保留です
- **昇格時の `IntegrityError` フォールバック経路**: rollback 後の再取得中に同一 session が別の認証済み user へ差し替わると同種の破壊が再発しうるものの、`onAuthStateChanged` は認証状態の変化ごとに 1 回しか発火せず実質到達不能なため、ガードは入れていません

## テスト

`server/tests/routers/test_auth_router.py` に 4 本追加（全体 182 passed）。

- 切り替え先 user が**無い**場合: 元 user の `firebase_uid` が奪われない / 旅程を保持 / 新 user にマージされない
- 切り替え先 user が**ある**場合: 元 user が削除されない / 双方の旅程が混ざらない / `session_id` は維持
- 切り替えの冪等性: 2 回叩いても user が増えない（2 回目はパターン 3 に落ちる）
- `_insert_or_get_user_id` の ON CONFLICT → SELECT フォールバックと、重複行を作らないこと


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Google認証時のアカウント切り替え仕様を明確化しました。
  * 認証済みセッションで別アカウントに切り替える場合、既存データを統合・削除せず、セッションのみ切り替えるようになりました。
  * 匿名セッションでは従来どおりアカウント統合を行います。
  * 同じ切り替え操作を繰り返しても、重複アカウントが作成されなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->