### PR TITLE
fix(#187): 旅程削除時・編集モード離脱時にトップページへ遷移するよう修正

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -210,7 +210,7 @@ function HeaderFull({ className, scrollContainer, isDraggingRef, ...props }: Omi
         open={editTripDialogOpen}
         onOpenChange={setEditTripDialogOpen}
         trip={trip}
-        onDeleted={() => navigate('/')}
+        onDeleted={() => navigate('/', { replace: true })}
       />
 
       {/* Walica iframe ビューア */}

--- a/frontend/src/dialogs/EditTripDialog.tsx
+++ b/frontend/src/dialogs/EditTripDialog.tsx
@@ -61,7 +61,9 @@ export const EditTripDialog = ({ open, onOpenChange, trip, onDeleted }: EditTrip
         variant: 'destructive',
       });
       if (!ok) return;
-      deleteTrip(trip.id);
+      deleteTrip({ id: trip.id, urlId: trip.urlId }).catch(() => {
+        // エラーは useDeleteTrip の onError がトーストで通知するため握り潰す
+      });
       removeVisitedTrip(trip.urlId);
       onDeleted?.();
       onOpenChange(false);

--- a/frontend/src/hooks/useEditModeBackGuard.test.tsx
+++ b/frontend/src/hooks/useEditModeBackGuard.test.tsx
@@ -1,0 +1,58 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider as JotaiProvider } from 'jotai';
+import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { tripModeAtom } from '@/atoms/tripPage';
+import { useEditModeBackGuard } from '@/hooks/useEditModeBackGuard';
+import { appStore } from '@/lib/store';
+
+const TripPageHost = () => {
+  useEditModeBackGuard();
+  return <Link to='/'>トップへ</Link>;
+};
+
+const renderTripPage = () =>
+  render(
+    <JotaiProvider store={appStore}>
+      <BrowserRouter>
+        <Routes>
+          <Route path='/' element={<div>HOME PAGE</div>} />
+          <Route path='/trip/:urlId' element={<TripPageHost />} />
+        </Routes>
+      </BrowserRouter>
+    </JotaiProvider>
+  );
+
+describe('useEditModeBackGuard', () => {
+  beforeEach(() => {
+    appStore.set(tripModeAtom, 'edit');
+    window.history.pushState({}, '', '/trip/abc');
+  });
+
+  // #187: cleanup の history.back() が画面遷移時にも走り、旅程ページへ引き戻していた
+  it('Editモード中に画面遷移した場合は back せず遷移先に留まる', async () => {
+    const backSpy = vi.spyOn(window.history, 'back');
+    renderTripPage();
+
+    await userEvent.click(screen.getByRole('link', { name: 'トップへ' }));
+    await waitFor(() => expect(screen.getByText('HOME PAGE')).toBeInTheDocument());
+
+    expect(backSpy).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/');
+    backSpy.mockRestore();
+  });
+
+  it('ページ内でViewモードに戻った場合はダミー履歴エントリを back で消す', async () => {
+    const backSpy = vi.spyOn(window.history, 'back');
+    renderTripPage();
+
+    expect((window.history.state as { editMode?: boolean } | null)?.editMode).toBe(true);
+
+    act(() => appStore.set(tripModeAtom, 'view'));
+
+    await waitFor(() => expect(backSpy).toHaveBeenCalledTimes(1));
+    expect(window.location.pathname).toBe('/trip/abc');
+    backSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useEditModeBackGuard.ts
+++ b/frontend/src/hooks/useEditModeBackGuard.ts
@@ -1,0 +1,34 @@
+import { useAtom } from 'jotai';
+import { useEffect } from 'react';
+import { tripModeAtom } from '@/atoms/tripPage';
+
+/**
+ * Editモード中のブラウザバックを阻止し、Viewモードに戻す。
+ * ダミー履歴エントリを1件積み、その popstate をViewモード復帰に読み替える。
+ */
+export const useEditModeBackGuard = () => {
+  const [mode, setMode] = useAtom(tripModeAtom);
+
+  useEffect(() => {
+    if (mode !== 'edit') return;
+
+    history.pushState({ editMode: true }, '', location.href);
+    let poppedByBack = false;
+
+    const handlePopState = () => {
+      poppedByBack = true;
+      setMode('view');
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+      // 画面遷移による unmount では current entry が遷移先のものに変わっている。
+      // ここで back() すると遷移先から旅程ページへ引き戻される (#187)
+      const isDummyEntryCurrent = (history.state as { editMode?: boolean } | null)?.editMode === true;
+      if (!poppedByBack && isDummyEntryCurrent) {
+        history.back();
+      }
+    };
+  }, [mode, setMode]);
+};

--- a/frontend/src/hooks/useTrips.ts
+++ b/frontend/src/hooks/useTrips.ts
@@ -197,17 +197,17 @@ export const useUpdateTrip = () => {
   };
 };
 
-type DeleteTripArg = Trip['id'];
+type DeleteTripArg = { id: Trip['id']; urlId: Trip['urlId'] };
 
 /**
  * Tripを削除する
  */
 export const useDeleteTrip = () => {
-  const { mutate } = useSWRConfig();
+  const { mutate, cache } = useSWRConfig();
 
-  const deleteTripFetcher = async (_: string | null, { arg: id }: { arg: DeleteTripArg }) => {
-    z.number().parse(id);
-    await apiClient.delete(`${TRIPS_BASE_PATH}/${id}`);
+  const deleteTripFetcher = async (_: string | null, { arg }: { arg: DeleteTripArg }) => {
+    z.number().parse(arg.id);
+    await apiClient.delete(`${TRIPS_BASE_PATH}/${arg.id}`);
     return undefined;
   };
 
@@ -219,19 +219,25 @@ export const useDeleteTrip = () => {
     }
   );
 
-  const deleteTrip = async (id: DeleteTripArg) => {
+  const deleteTrip = async (arg: DeleteTripArg) => {
     // リスト側の楽観的更新
-    await trigger(id, {
+    await trigger(arg, {
       optimisticData: (currentTrips: Trip[] | undefined) => {
         if (!currentTrips) return [];
-        return currentTrips.filter(trip => trip.id !== id);
+        return currentTrips.filter(trip => trip.id !== arg.id);
       },
       revalidate: true, // 念のためリストをサーバーと同期する（不要ならfalse）
       rollbackOnError: true,
     });
 
-    // 個別キャッシュ（/trips/:id）の削除
-    mutate(`${TRIPS_BASE_PATH}/${id}`, undefined, false);
+    // 個別キャッシュを id/urlId 両方削除する。残すと再訪時に削除済み Trip が描画される。
+    // mutate は購読中コンポーネントへの通知用で、IndexedDB まで消せるのは cache.delete だけ
+    const idKey = `${TRIPS_BASE_PATH}/${arg.id}`;
+    const urlKey = `${TRIPS_BASE_PATH}/url/${arg.urlId}`;
+    mutate(idKey, undefined, false);
+    cache.delete(idKey);
+    mutate(urlKey, undefined, false);
+    cache.delete(urlKey);
   };
 
   return {

--- a/frontend/src/hooks/useVisitedTrips.test.ts
+++ b/frontend/src/hooks/useVisitedTrips.test.ts
@@ -148,6 +148,17 @@ describe('useVisitedTrips', () => {
       expect(mockDbPut).toHaveBeenCalledWith(expect.objectContaining({ key: 'visitedTripUrlIds', value: ['alive-1'] }));
     });
     expect(result.current.trips?.map(trip => trip.urlId)).toEqual(['alive-1']);
+
+    // 除去が state にも反映されていないと、後続の追加で永続化 effect が 404 の ID を復活させる
+    act(() => {
+      result.current.addVisitedTrip('new-url');
+    });
+
+    await waitFor(() => {
+      expect(mockDbPut).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'visitedTripUrlIds', value: ['alive-1', 'new-url'] })
+      );
+    });
   });
 
   it('localStorageにデータがある場合、IndexedDBへマイグレーションされる', async () => {

--- a/frontend/src/hooks/useVisitedTrips.test.ts
+++ b/frontend/src/hooks/useVisitedTrips.test.ts
@@ -119,6 +119,37 @@ describe('useVisitedTrips', () => {
     });
   });
 
+  // #187: apiClient が AxiosError を AppError に変換するため、旧 isAxiosError 判定では除去できていなかった
+  it('取得が404になったurlIdは訪問済みリストから除去される', async () => {
+    mockDbGet.mockResolvedValue({ key: 'visitedTripUrlIds', value: ['deleted-1', 'alive-1'] });
+    server.use(
+      http.get('*/trips/url/:urlId', ({ params }) => {
+        if (params.urlId === 'deleted-1') {
+          return HttpResponse.json({ message: 'Trip not found', code: 'not_found', detail: null }, { status: 404 });
+        }
+        return HttpResponse.json({
+          id: 1,
+          title: 'mock',
+          detail: null,
+          people_num: null,
+          url_id: String(params.urlId),
+          start_date: null,
+          end_date: null,
+          walica_url: null,
+          created_at: '2026-01-01T00:00:00+09:00',
+          last_edited_at: '2026-01-01T00:00:00+09:00',
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useVisitedTrips());
+
+    await waitFor(() => {
+      expect(mockDbPut).toHaveBeenCalledWith(expect.objectContaining({ key: 'visitedTripUrlIds', value: ['alive-1'] }));
+    });
+    expect(result.current.trips?.map(trip => trip.urlId)).toEqual(['alive-1']);
+  });
+
   it('localStorageにデータがある場合、IndexedDBへマイグレーションされる', async () => {
     localStorage.setItem('visitedTripUrlIds', JSON.stringify(['migrated-1']));
     // IndexedDBは空

--- a/frontend/src/hooks/useVisitedTrips.ts
+++ b/frontend/src/hooks/useVisitedTrips.ts
@@ -1,8 +1,8 @@
-import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 import { fetcher } from '@/lib/apiClient';
 import { db } from '@/lib/db';
+import { isNotFoundError } from '@/lib/errors';
 import { type Trip, tripFromApi } from '@/types/trip';
 
 const VISITED_TRIPS_KEY = 'visitedTripUrlIds';
@@ -127,21 +127,25 @@ export const useVisitedTrips = () => {
     error,
     isLoading: swrIsLoading,
   } = useSWR<Trip[]>(isInitialized && urlIds.length > 0 ? [VISITED_TRIPS_CACHE_KEY, ...urlIds] : null, async () => {
+    const deletedUrlIds = new Set<string>();
     const results = await Promise.all(
       urlIds.map(async urlId => {
         try {
           const res = await fetcher(`/trips/url/${urlId}`);
           return tripFromApi.parse(res);
         } catch (err) {
-          // 404 "Trip not found" の場合は訪問済みリストから除去
-          if (isAxiosError(err) && err.response?.status === 404 && err.response.data?.detail === 'Trip not found') {
-            const current = await getUrlIdsFromDB();
-            await saveUrlIdsToDB(current.filter(id => id !== urlId));
-          }
+          if (isNotFoundError(err)) deletedUrlIds.add(urlId);
           return null;
         }
       })
     );
+
+    // 削除済み Trip を訪問済みリストから除去する。
+    // 404 ごとに read-modify-write すると互いの結果を打ち消し合うため、まとめて1回だけ書き込む
+    if (deletedUrlIds.size > 0) {
+      const current = await getUrlIdsFromDB();
+      await saveUrlIdsToDB(current.filter(id => !deletedUrlIds.has(id)));
+    }
     return results.filter((trip): trip is Trip => trip !== null);
   });
 

--- a/frontend/src/hooks/useVisitedTrips.ts
+++ b/frontend/src/hooks/useVisitedTrips.ts
@@ -141,10 +141,10 @@ export const useVisitedTrips = () => {
     );
 
     // 削除済み Trip を訪問済みリストから除去する。
-    // 404 ごとに read-modify-write すると互いの結果を打ち消し合うため、まとめて1回だけ書き込む
+    // IndexedDB を直接書くと state に残った ID が後続の永続化 effect で復活し、
+    // SWR key も stale なまま 404 を引き続けるため、state 経由で更新する
     if (deletedUrlIds.size > 0) {
-      const current = await getUrlIdsFromDB();
-      await saveUrlIdsToDB(current.filter(id => !deletedUrlIds.has(id)));
+      setUrlIds(prev => prev.filter(id => !deletedUrlIds.has(id)));
     }
     return results.filter((trip): trip is Trip => trip !== null);
   });

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -78,5 +78,8 @@ export class OfflineError extends AppError {
 /** OfflineError の型ガード */
 export const isOfflineError = (err: unknown): err is OfflineError => err instanceof OfflineError;
 
+/** 削除済み・存在しないリソースの型ガード */
+export const isNotFoundError = (err: unknown): err is AppError => err instanceof AppError && err.statusCode === 404;
+
 /** axios の型ガード（インターセプターから使用） */
 export const isAxiosError = axios.isAxiosError;

--- a/frontend/src/pages/TripPage.tsx
+++ b/frontend/src/pages/TripPage.tsx
@@ -1,7 +1,8 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { Plus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
 import { isOfflineReadAtom } from '@/atoms/network';
 import { selectedPageIdAtom, tripAtom, tripModeAtom, tripPagesAtom } from '@/atoms/tripPage';
 import { FetchErrorView } from '@/components/FetchErrorView';
@@ -14,10 +15,12 @@ import { TimelineSkeleton } from '@/components/timeline';
 import { Button } from '@/components/ui/button';
 import { useActivePage } from '@/hooks/useActivePage';
 import { useDragAutoScroll } from '@/hooks/useDragAutoScroll';
+import { useEditModeBackGuard } from '@/hooks/useEditModeBackGuard';
 import { useFocusBlockOnMount } from '@/hooks/useFocusBlockOnMount';
 import { usePages } from '@/hooks/usePages';
 import { useTripByUrlId } from '@/hooks/useTrips';
 import { useVisitedTrips } from '@/hooks/useVisitedTrips';
+import { isNotFoundError } from '@/lib/errors';
 import { cn } from '@/lib/utils';
 import { EditTripLayout } from './TripPage/EditTripLayout';
 import { ViewTripLayout } from './TripPage/ViewTripLayout';
@@ -38,6 +41,7 @@ const TripPage = () => {
   const setAddPageDialogOpen = useSetAtom(addPageDialogOpenAtom);
   const [minLoadingComplete, setMinLoadingComplete] = useState(false);
   const { urlId } = useParams<{ urlId: string }>();
+  const navigate = useNavigate();
 
   const isOffline = useAtomValue(isOfflineReadAtom);
   const refreshInterval = isOffline ? 0 : mode === 'edit' ? 5000 : 0;
@@ -46,9 +50,12 @@ const TripPage = () => {
   const { addVisitedTrip } = useVisitedTrips();
   const { storedPageId, isActivePageInitialized, saveActivePageId } = useActivePage(trip?.id ?? null);
   useFocusBlockOnMount();
+  useEditModeBackGuard();
 
   const isLoading = isTripLoading || isPagesLoading || !minLoadingComplete;
   const isError = tripError || pagesError;
+  // pages 側は存在しない trip でも 403 を返すため、404 判定は trip の取得結果で行う
+  const isTripNotFound = isNotFoundError(tripError);
 
   // マウント解除時に atom をリセット
   useEffect(() => {
@@ -103,28 +110,6 @@ const TripPage = () => {
     }
   }, [mode]);
 
-  // Editモード中のブラウザバックを阻止し、Viewモードに戻す
-  useEffect(() => {
-    if (mode !== 'edit') return;
-
-    history.pushState({ editMode: true }, '', location.href);
-    let poppedByBack = false;
-
-    const handlePopState = () => {
-      poppedByBack = true;
-      setMode('view');
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-      // ボタン等でViewに戻った場合、pushStateで追加したエントリを消す
-      if (!poppedByBack) {
-        history.back();
-      }
-    };
-  }, [mode, setMode]);
-
   // オフライン時は編集モードを強制解除
   useEffect(() => {
     if (isOffline && mode === 'edit') {
@@ -139,7 +124,16 @@ const TripPage = () => {
     }
   }, [trip, addVisitedTrip]);
 
-  if (isError) {
+  // 削除済み・存在しない旅程URL（自身の削除操作、共有相手による削除、ブックマーク等）はトップへ逃がす
+  useEffect(() => {
+    if (!isTripNotFound) return;
+    // StrictMode の二重実行やポーリング再失敗でトーストが重ならないよう id で dedupe する
+    toast.error('旅程が見つかりませんでした', { id: 'trip-not-found' });
+    navigate('/', { replace: true });
+  }, [isTripNotFound, navigate]);
+
+  // 404 はトップへ遷移するだけなのでエラー表示は出さず、遷移までスケルトンを見せる
+  if (isError && !isTripNotFound) {
     return (
       <div className='flex h-dvh w-full flex-col'>
         <HeaderSkeleton />
@@ -150,7 +144,7 @@ const TripPage = () => {
     );
   }
 
-  if (isLoading) {
+  if (isLoading || isTripNotFound) {
     return (
       <div className='flex h-dvh w-full flex-col'>
         <HeaderSkeleton />


### PR DESCRIPTION
## サマリ

旅程を削除してもトップページに遷移せず、削除済みの旅程ページに留まって画面が描画されない不具合を修正しました。

根本原因は削除処理ではなく、**Editモード中のブラウザバック抑止処理**にありました。同じ原因で「編集モード中はヘッダーロゴを2回押さないとトップに戻れない」「編集モード中の通知タップ遷移も引き戻される」も発生しており、あわせて解消しています。

Closes #187

## 原因

`TripPage` の Editモード用 effect は、edit 突入時に `history.pushState({editMode:true})` でダミー履歴を積み、cleanup で**無条件に** `history.back()` していました。削除ボタンは Editモードからしか到達できないため、必ずこの経路を通ります。

| # | 処理 | history |
|---|---|---|
| 1 | edit 突入時に pushState | `[/trip/x, /trip/x(dummy)]` |
| 2 | 削除 → `navigate('/')` | `[/trip/x, /trip/x(dummy), /]` |
| 3 | TripPage unmount → cleanup が `back()` | — |
| 4 | popstate | **`/trip/x` に逆戻り** |

戻った先では旅程が削除済みのため、`GET /trips/url/:urlId` が 404 になり描画できない状態でした。

## やったこと

- **Editモードの履歴制御を `useEditModeBackGuard` に切り出し、`back()` をガード**
  「ダミー履歴エントリが current の時だけ戻す」ことで、画面遷移による unmount と、ページ内での edit→view 復帰を区別する
- **削除済み・存在しない旅程URLのフォールバック追加**
  trip 取得が 404 ならトップへ replace 遷移。共有相手による削除、ブックマーク、通知ディープリンク経由もカバーする
- **削除時のキャッシュ後始末を修正**
  SWR の個別キャッシュを id / urlId 両方破棄。訪問済みリストの 404 除去が動作していなかった不具合も修正
- **デグレテスト追加**（履歴制御2ケース / 訪問済みリストの404除去1ケース）

## 設計判断

**なぜ `history.state` を見てガードするのか**

react-router の push / replace は `history.state` を自身の形式 (`{usr, key, idx}`) で上書きします。そのため「自分が積んだダミーが current かどうか」を見るだけで、離脱かモード復帰かを判別できます。effect の cleanup 実行順に依存する ref 方式より意図が明示的で壊れにくいと判断しました。`BrowserRouter` 構成のため `useBlocker` は使えず、pushState ダミー方式自体は維持しています。

**404 判定を trip 側だけで行う理由**

`/trips/{id}/pages` は存在しない trip でも 403 を返す実装（ID の実在を第三者に判別させないため）なので、404 で判定できるのは trip 取得のみです。

**訪問済みリストの 404 除去が動いていなかった件**

`useVisitedTrips` の除去処理は `isAxiosError(err) && err.response.data?.detail === 'Trip not found'` で判定していましたが、以下2点により**デッドコード**でした。

- `apiClient` の interceptor が AxiosError を `AppError` に変換して reject するため `isAxiosError` が常に false
- サーバの `NotFound` は `{message, code, detail: null}` を返すため `detail` に文字列が入らない

結果として削除済み urlId が IndexedDB に残り続け、ホーム表示のたびに 404 リクエストが増えていく状態でした。`isNotFoundError` 型ガードでの判定に修正しています。あわせて、404 ごとに IndexedDB を read-modify-write していた処理が互いの書き込みを打ち消し合う問題も、1回の書き込みに集約して解消しました。

**`cache.delete` を併用する理由**

`swrCacheProvider` は IndexedDB への write-through 構成ですが、`mutate(key, undefined)` は `data === undefined` のため書き込みをスキップするだけで**行を消しません**。次回起動の hydrate で復活するため、購読者通知用の `mutate` と IndexedDB 削除用の `cache.delete` を併用しています。

なお「`set(key, {data: undefined})` を delete 扱いにする」一般化は、SWR が初回ロード中のキーにも `data: undefined` を set するため、コールドフェッチのたびにキャッシュを破壊してしまうので採用していません。

## 既知の残課題（本PRスコープ外）

- **同一ルート内 navigate ではダミー履歴が残留する**
  `/trip/:urlId` に `key` が無く TripPage が unmount しないため、通知から別 trip へ遷移した場合などに cleanup が走らずダミーが履歴に埋もれます。引き戻される問題は解消済みですが「戻る」が1回余分に必要な状態は残ります。根治には `key={urlId}` での remount か、FCM 遷移の `replace` 化が必要です（**本PRによる退行ではなく従来からの挙動**）。
- **`useDeletePage` / ブロック削除にも同じ IndexedDB 残留がある**
  今回 trip 削除のみ修正しています。同じ対処が必要なため別issue化を想定しています。
- **`useVisitedTrips.test.ts` の共通フィクスチャが `created_at` / `last_edited_at` を欠いている**
  既存テストで `trips` が常に空配列になっています。影響範囲が読めないため共通側は触っていません。

## 動作確認

`type-check` / `lint:check` / `format:check` / `vitest`（226 tests）すべてパス。
追加したデグレテストは、修正を戻すと fail することを確認済みです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 編集モード中のブラウザバックを安全に処理し、意図しないページ遷移を防止。
  * 存在しない旅程を検知し、エラー通知後にトップページへ移動。

* **不具合修正**
  * 旅程削除後の一覧や訪問済み旅程への反映を改善。
  * 削除完了時の遷移で不要な履歴が残らないよう修正。
  * 存在しない訪問済み旅程を自動的にリストから除去。

* **テスト**
  * 編集モードの戻る操作と、存在しない旅程の処理を追加検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->