### PR TITLE
feat(#233): 通知デバッグページを追加

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -488,13 +488,14 @@ curl -X POST https://<staging-cloud-run-url>/internal/notify/tick \
 
 実機で DevTools を繋げないとき用。[デバッグモード](debug_logger.md)を有効にすると、ホームの
 3 点リーダに「デバッグ > 通知デバッグ」が出る (PWA は URL 直打ちできないため導線が必須)。
+デバッグモードが無効なときはルート自体がホームへリダイレクトする。
 
 | セクション | 用途 |
 |---|---|
 | 環境 | display-mode / permission / FCM token / **build ID** (診断ログの SW 行とズレていれば古い SW が動いたまま) |
 | Service Worker | 登録ごとの scope / script / state / push endpoint。PWA とブラウザで endpoint が一致 = ストレージ共有 |
 | ローカル通知 | FCM を経由せず scope 別に `showNotification`。icon 有無・画像を絶対 URL にするかも切り替えられる |
-| サーバ経路 | その context の token だけで購読 / 解除 / テスト送信。**10 秒後に送信**は裏に回す猶予を作って SW 経路を狙うためのもの |
+| サーバ経路 | その context の token だけで購読 / 解除 / テスト送信。**裏に回したら送信**は hidden になった瞬間に送るので、SW 経路 (可視クライアント 0) を確実に踏める |
 
 **経路の見分け方**: FCM SW は可視クライアントが 1 つでもあると自分では表示せずページに postMessage
 する (`@firebase/messaging` の `onPush`)。診断ログに `[FCM] foreground message` があればページ経路、

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -484,6 +484,22 @@ curl -X POST https://<staging-cloud-run-url>/internal/notify/tick \
 - **iOS Safari 実機**: localhost からの PWA install が事実上できないため、通知系は **staging 環境で verify する**
 - 5 分前通知の end-to-end 確認は **staging (Cloud Scheduler + Cloud Run 揃った環境) で行う**のが本命
 
+### 10.7 通知デバッグページ (`/debug/notify`)
+
+実機で DevTools を繋げないとき用。[デバッグモード](debug_logger.md)を有効にすると、ホームの
+3 点リーダに「デバッグ > 通知デバッグ」が出る (PWA は URL 直打ちできないため導線が必須)。
+
+| セクション | 用途 |
+|---|---|
+| 環境 | display-mode / permission / FCM token / **build ID** (診断ログの SW 行とズレていれば古い SW が動いたまま) |
+| Service Worker | 登録ごとの scope / script / state / push endpoint。PWA とブラウザで endpoint が一致 = ストレージ共有 |
+| ローカル通知 | FCM を経由せず scope 別に `showNotification`。icon 有無・画像を絶対 URL にするかも切り替えられる |
+| サーバ経路 | その context の token だけで購読 / 解除 / テスト送信。**10 秒後に送信**は裏に回す猶予を作って SW 経路を狙うためのもの |
+
+**経路の見分け方**: FCM SW は可視クライアントが 1 つでもあると自分では表示せずページに postMessage
+する (`@firebase/messaging` の `onPush`)。診断ログに `[FCM] foreground message` があればページ経路、
+無ければ SW 経路。前景/背景で見た目が食い違うときはここを最初に見る。
+
 ## 11. 運用
 
 ### 11.1 通知機能の一時停止

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,11 @@
 import { useAtomValue } from 'jotai';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
 import { isOfflineReadAtom } from './atoms/network';
 import { DebugLogPanel } from './components/DebugLogPanel';
 import { NoIndex } from './components/NoIndex';
 import { Title } from './components/Title';
 import { useAuthStateSync } from './hooks/useAuth';
-import { useDebugPanel } from './hooks/useDebugPanel';
+import { DEBUG_PARAM, useDebugPanel } from './hooks/useDebugPanel';
 import { useFcmNavigationListener } from './hooks/useFcmNavigationListener';
 import { useForegroundNotificationToast } from './hooks/useForegroundNotificationToast';
 import { useNetworkToast } from './hooks/useNetworkToast';
@@ -18,6 +18,18 @@ import { NotifyDebugPage } from './pages/NotifyDebugPage';
 import { TripPage } from './pages/TripPage';
 
 const isProduction = detectEnv() === 'production';
+
+/**
+ * デバッグモードが無効なら描画せずホームへ返す。メニューを隠すだけでは URL 直打ちで開けてしまい、
+ * FCM token / push endpoint / 購読操作が通常利用者に露出する (NoIndex はアクセス制御ではない)。
+ *
+ * `?debug=1` を同時に見るのは、atom への反映が effect 経由で初回描画に間に合わないため。
+ */
+const DebugOnly = ({ enabled, children }: { enabled: boolean; children: React.ReactNode }) => {
+  const [searchParams] = useSearchParams();
+  if (!(enabled || searchParams.get(DEBUG_PARAM) === '1')) return <Navigate replace to='/' />;
+  return <>{children}</>;
+};
 
 const App = () => {
   const isOffline = useAtomValue(isOfflineReadAtom);
@@ -54,10 +66,10 @@ const App = () => {
         <Route
           path='/debug/notify'
           element={
-            <>
+            <DebugOnly enabled={isDebugPanelEnabled}>
               <NoIndex />
               <NotifyDebugPage />
-            </>
+            </DebugOnly>
           }
         />
         <Route

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { detectEnv } from './lib/envBranding';
 import { cn } from './lib/utils';
 import { HomePage } from './pages/HomePage';
 import { NotFoundPage } from './pages/NotFoundPage';
+import { NotifyDebugPage } from './pages/NotifyDebugPage';
 import { TripPage } from './pages/TripPage';
 
 const isProduction = detectEnv() === 'production';
@@ -46,6 +47,16 @@ const App = () => {
             <>
               <NoIndex />
               <TripPage />
+            </>
+          }
+        />
+        {/* 通知デバッグ。導線は HomeMenu の「デバッグ」から (デバッグモード時のみ) */}
+        <Route
+          path='/debug/notify'
+          element={
+            <>
+              <NoIndex />
+              <NotifyDebugPage />
             </>
           }
         />

--- a/frontend/src/components/HomeMenu.tsx
+++ b/frontend/src/components/HomeMenu.tsx
@@ -1,7 +1,9 @@
 import { useAtomValue } from 'jotai';
-import { Download, LogInIcon, MoreVerticalIcon, SendIcon, SmartphoneIcon } from 'lucide-react';
+import { BellRingIcon, Download, LogInIcon, MoreVerticalIcon, SendIcon, SmartphoneIcon } from 'lucide-react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { authUserAtom } from '@/atoms/auth';
+import { debugPanelEnabledAtom } from '@/atoms/debug';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -28,6 +30,9 @@ export const HomeMenu = ({ className }: { className?: string }) => {
   const { isReady: pwaReady, installApp } = usePWAInstall();
   const [transferOpen, setTransferOpen] = useState(false);
   const [receiveOpen, setReceiveOpen] = useState(false);
+  // PWA はアドレスバーが無く URL 直打ちできないため、デバッグ画面へはメニュー経由でしか入れない
+  const isDebugEnabled = useAtomValue(debugPanelEnabledAtom);
+  const navigate = useNavigate();
 
   // authUser が undefined (初期化前) の間はメニュー項目は仮描画 (Google 認証・受け取り経路として)
   const isAuthed = authUser != null;
@@ -66,6 +71,16 @@ export const HomeMenu = ({ className }: { className?: string }) => {
               <DropdownMenuItem onSelect={() => void installApp()}>
                 <Download className='size-4' />
                 アプリとしてインストール
+              </DropdownMenuItem>
+            </>
+          )}
+          {isDebugEnabled && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>デバッグ</DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => navigate('/debug/notify')}>
+                <BellRingIcon className='size-4' />
+                通知デバッグ
               </DropdownMenuItem>
             </>
           )}

--- a/frontend/src/hooks/useDebugPanel.ts
+++ b/frontend/src/hooks/useDebugPanel.ts
@@ -9,7 +9,8 @@ import { debugPanelEnabledAtom } from '@/atoms/debug';
  * 詳細は [@docs/debug_logger.md](../../../docs/debug_logger.md)。
  */
 
-const DEBUG_PARAM = 'debug';
+/** 有効化状態は atom の effect 反映を待つ必要があるため、初回描画で判定したい側にも公開する */
+export const DEBUG_PARAM = 'debug';
 
 /** ロゴ連打で切り替えるまでのタップ数と、連打とみなすタップ間隔 */
 const REQUIRED_TAPS = 7;

--- a/frontend/src/hooks/useForegroundNotificationToast.ts
+++ b/frontend/src/hooks/useForegroundNotificationToast.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
+import { debugLog } from '@/lib/debugLogger';
 import { subscribeForegroundMessages } from '@/lib/messaging';
+import { getDisplayMode } from '@/lib/platform';
 
 /**
  * フォアグラウンド (タブがアクティブ) で FCM メッセージを受け取った際に、
@@ -18,6 +20,14 @@ export const useForegroundNotificationToast = () => {
 
     subscribeForegroundMessages(async payload => {
       const { title, body, kind, tripId, urlId, blockId, icon } = payload;
+      // FCM SW は可視クライアントが 1 つでもあると自分では表示せずページに postMessage する。
+      // この行が残っていれば「SW ではなくページが表示した」と判別できる
+      void debugLog('FCM', 'foreground message', {
+        title,
+        kind,
+        displayMode: getDisplayMode(),
+        visibility: document.visibilityState,
+      });
       if (!title) return;
       if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
 

--- a/frontend/src/hooks/useForegroundNotificationToast.ts
+++ b/frontend/src/hooks/useForegroundNotificationToast.ts
@@ -21,9 +21,9 @@ export const useForegroundNotificationToast = () => {
     subscribeForegroundMessages(async payload => {
       const { title, body, kind, tripId, urlId, blockId, icon } = payload;
       // FCM SW は可視クライアントが 1 つでもあると自分では表示せずページに postMessage する。
-      // この行が残っていれば「SW ではなくページが表示した」と判別できる
+      // この行が残っていれば「SW ではなくページが表示した」と判別できる。
+      // 通知本文 (title/body) は通常利用でも端末に残るため載せない
       void debugLog('FCM', 'foreground message', {
-        title,
         kind,
         displayMode: getDisplayMode(),
         visibility: document.visibilityState,

--- a/frontend/src/lib/platform.ts
+++ b/frontend/src/lib/platform.ts
@@ -3,6 +3,12 @@ export const isIOS = (): boolean => {
   return /iPad|iPhone|iPod/.test(ua) || (ua.includes('Mac') && 'ontouchend' in document);
 };
 
+const DISPLAY_MODES = ['standalone', 'fullscreen', 'minimal-ui', 'browser'] as const;
+
+/** PWA として開いているかブラウザタブかを診断ログ / デバッグ画面で見分けるための表示 */
+export const getDisplayMode = (): string =>
+  DISPLAY_MODES.find(mode => window.matchMedia(`(display-mode: ${mode})`).matches) ?? 'unknown';
+
 export const isPWAInstalled = (): boolean => {
   if (window.matchMedia('(display-mode: standalone)').matches) return true;
   if (window.matchMedia('(display-mode: fullscreen)').matches) return true;

--- a/frontend/src/pages/NotifyDebugPage.tsx
+++ b/frontend/src/pages/NotifyDebugPage.tsx
@@ -1,0 +1,321 @@
+import { CheckIcon, CopyIcon, RefreshCwIcon } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { apiClient } from '@/lib/apiClient';
+import { DEBUG_LOG_VERSION } from '@/lib/debugLogger';
+import { detectEnv } from '@/lib/envBranding';
+import { fetchFcmToken } from '@/lib/messaging';
+import { getDisplayMode, isIOS, isNotificationSupported, isPWAInstalled } from '@/lib/platform';
+
+/**
+ * 通知まわりの実機デバッグページ (`/debug/notify`)。導線は HomeMenu の「デバッグ」から。
+ *
+ * PWA とブラウザで同じ URL を開いて出力を突き合わせる用途を想定している。ログ自体は
+ * 診断ロガー ([@docs/debug_logger.md](../../../docs/debug_logger.md)) に集約されるので、
+ * ここでは「今この context がどうなっているか」と「手で通知を撃つ手段」だけを持つ。
+ */
+
+/** サーバ (`_frontend_base`) が icon/badge に使う絶対 URL。非 production は stg 固定 */
+const SERVER_ASSET_BASE = 'https://st.tabishare.net';
+/** テスト送信は即時配信なので、SW 経路を試すには裏に回す猶予が要る */
+const BACKGROUND_TEST_DELAY_SECONDS = 10;
+
+type RegistrationInfo = {
+  registration: ServiceWorkerRegistration;
+  scope: string;
+  scriptURL: string;
+  states: string;
+  isController: boolean;
+  endpoint: string;
+};
+
+const describeStates = (registration: ServiceWorkerRegistration): string =>
+  (
+    [
+      ['installing', registration.installing],
+      ['waiting', registration.waiting],
+      ['active', registration.active],
+    ] as const
+  )
+    .filter(([, worker]) => worker != null)
+    .map(([slot, worker]) => `${slot}:${worker?.state}`)
+    .join(' / ');
+
+const readEndpoint = async (registration: ServiceWorkerRegistration): Promise<string> => {
+  if (!('pushManager' in registration)) return '(PushManager 非対応)';
+  try {
+    const subscription = await registration.pushManager.getSubscription();
+    return subscription?.endpoint ?? '(購読なし)';
+  } catch (error) {
+    return `(取得失敗: ${String(error)})`;
+  }
+};
+
+const collectRegistrations = async (): Promise<RegistrationInfo[]> => {
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  const controllerScript = navigator.serviceWorker.controller?.scriptURL ?? null;
+  return Promise.all(
+    registrations.map(async registration => ({
+      registration,
+      scope: registration.scope,
+      scriptURL: registration.active?.scriptURL ?? '(active なし)',
+      states: describeStates(registration),
+      isController: registration.active?.scriptURL === controllerScript,
+      endpoint: await readEndpoint(registration),
+    }))
+  );
+};
+
+const Section = ({
+  title,
+  hint,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) => (
+  <details className='mb-2 rounded-lg border border-gray-200 bg-white' open={defaultOpen}>
+    <summary className='cursor-pointer list-none px-3 py-2 font-bold text-12px'>
+      {title}
+      {hint != null && <span className='ml-2 font-normal text-10px text-gray-500'>{hint}</span>}
+    </summary>
+    <div className='border-gray-100 border-t px-3 py-2'>{children}</div>
+  </details>
+);
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div className='flex gap-2 border-gray-100 border-b py-1 last:border-b-0'>
+    <span className='w-24 shrink-0 text-10px text-gray-500'>{label}</span>
+    <span className='min-w-0 flex-1 break-all font-mono text-10px'>{value}</span>
+  </div>
+);
+
+const CopyButton = ({ label, getText }: { label: string; getText: () => string }) => {
+  const [copied, setCopied] = useState(false);
+  return (
+    <Button
+      size='sm'
+      variant='outline'
+      onClick={() =>
+        void navigator.clipboard.writeText(getText()).then(() => {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1500);
+        })
+      }
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+      {copied ? 'コピーした' : label}
+    </Button>
+  );
+};
+
+const NotifyDebugPage = () => {
+  const [registrations, setRegistrations] = useState<RegistrationInfo[]>([]);
+  const [token, setToken] = useState('(未取得)');
+  const [withIcon, setWithIcon] = useState(true);
+  const [absoluteAssets, setAbsoluteAssets] = useState(false);
+  const [urlId, setUrlId] = useState('');
+  const [serverStatus, setServerStatus] = useState('(未実行)');
+
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+    let cancelled = false;
+    void collectRegistrations().then(infos => {
+      if (!cancelled) setRegistrations(infos);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const env: [string, string][] = [
+    ['env', detectEnv()],
+    ['build ID', DEBUG_LOG_VERSION],
+    ['display-mode', getDisplayMode()],
+    ['PWA', String(isPWAInstalled())],
+    ['iOS', String(isIOS())],
+    ['通知サポート', String(isNotificationSupported())],
+    ['permission', typeof Notification === 'undefined' ? '(Notification なし)' : Notification.permission],
+    ['origin', window.location.origin],
+    ['controller', navigator.serviceWorker?.controller?.scriptURL ?? '(なし)'],
+    ['userAgent', navigator.userAgent],
+  ];
+
+  const buildDump = (): string =>
+    [
+      ...env.map(([label, value]) => `${label}: ${value}`),
+      `fcmToken: ${token}`,
+      '',
+      ...registrations.flatMap(info => [
+        `scope: ${info.scope}`,
+        `  script: ${info.scriptURL}`,
+        `  states: ${info.states}${info.isController ? ' (controller)' : ''}`,
+        `  endpoint: ${info.endpoint}`,
+      ]),
+      '',
+      `server: ${serverStatus}`,
+    ].join('\n');
+
+  const showLocal = async (info: RegistrationInfo): Promise<void> => {
+    const path = new URL(info.scope).pathname;
+    // サーバは icon/badge を絶対 URL で送るため、オリジンが違うと挙動が変わりうる。その差を切り出せるようにする
+    const base = absoluteAssets ? SERVER_ASSET_BASE : '';
+    const options: NotificationOptions & { renotify?: boolean } = {
+      body: `scope=${path}\nmode=${getDisplayMode()}`,
+      icon: withIcon ? `${base}/icons/notify/test.png` : undefined,
+      badge: `${base}/icons/notify/badge.png`,
+      tag: `debug-${path}`,
+      renotify: true,
+      data: { link: '/debug/notify' },
+    };
+    await info.registration.showNotification(`debug ${path}`, options);
+  };
+
+  /**
+   * この context の token でサーバ経路を叩く。
+   * delaySeconds を入れると、押してから裏に回す時間を作れる (可視クライアント 0 = SW 経路)。
+   */
+  const callServer = async (
+    action: 'status' | 'subscribe' | 'unsubscribe' | 'test',
+    delaySeconds = 0
+  ): Promise<void> => {
+    for (let remaining = delaySeconds; remaining > 0; remaining--) {
+      setServerStatus(`${remaining} 秒後に送信 — 今すぐアプリを裏に回して`);
+      await new Promise(resolve => window.setTimeout(resolve, 1000));
+    }
+    setServerStatus('実行中...');
+    try {
+      const fcmToken = await fetchFcmToken();
+      if (!fcmToken) throw new Error('FCM トークンが取れない');
+      setToken(fcmToken);
+      const trip = await apiClient.get(`/trips/url/${urlId.trim().split('/').pop()}`);
+      const tripId = Number(trip.data.id);
+      const headers = { 'X-FCM-Token': fcmToken };
+
+      if (action === 'subscribe') {
+        await apiClient.post(`/trips/${tripId}/subscription`, {
+          fcm_token: fcmToken,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          user_agent: navigator.userAgent,
+        });
+      } else if (action === 'unsubscribe') {
+        await apiClient.delete(`/trips/${tripId}/subscription`, { headers });
+      } else if (action === 'test') {
+        await apiClient.post(`/trips/${tripId}/subscription/test`, null, { headers });
+      }
+
+      const res = await apiClient.get(`/trips/${tripId}/subscription`, { headers });
+      setServerStatus(`tripId=${tripId} / この token は ${res.data == null ? '未購読' : '購読済み'}`);
+    } catch (error) {
+      setServerStatus(`失敗: ${String(error)}`);
+    }
+  };
+
+  return (
+    <div className='min-h-dvh bg-teal-50/50 pb-16'>
+      <div className='mx-auto max-w-2xl p-3'>
+        <div className='mb-3 flex items-center justify-between'>
+          <h1 className='font-bold text-16px'>通知デバッグ</h1>
+          <Link className='text-12px text-gray-500 underline' to='/'>
+            ホームへ
+          </Link>
+        </div>
+        <p className='mb-3 text-10px text-gray-500'>
+          受信ログは診断パネル（右下）の「ログをコピー」に出ます。SW の行と build ID がズレていれば古い SW
+          が動いたままです。
+        </p>
+
+        <Section title='環境' defaultOpen>
+          {env.map(([label, value]) => (
+            <Row key={label} label={label} value={value} />
+          ))}
+          <Row label='fcmToken' value={token} />
+          <Button
+            className='mt-2'
+            size='sm'
+            variant='outline'
+            onClick={() =>
+              void fetchFcmToken().then(
+                t => setToken(t ?? '(null)'),
+                e => setToken(`(失敗: ${String(e)})`)
+              )
+            }
+          >
+            FCM トークン取得
+          </Button>
+        </Section>
+
+        <Section title='Service Worker' hint={`${registrations.length} 件`} defaultOpen>
+          {registrations.map(info => (
+            <div key={info.scope} className='mb-2 last:mb-0'>
+              <Row label='scope' value={`${new URL(info.scope).pathname}${info.isController ? ' (controller)' : ''}`} />
+              <Row label='script' value={info.scriptURL} />
+              <Row label='states' value={info.states} />
+              <Row label='endpoint' value={info.endpoint} />
+            </div>
+          ))}
+        </Section>
+
+        <Section title='ローカル通知' hint='FCM を経由せず表示だけを試す'>
+          <label className='mb-1 flex items-center gap-2 text-10px'>
+            <input type='checkbox' checked={withIcon} onChange={e => setWithIcon(e.target.checked)} />
+            icon を付ける
+          </label>
+          <label className='mb-2 flex items-center gap-2 text-10px'>
+            <input type='checkbox' checked={absoluteAssets} onChange={e => setAbsoluteAssets(e.target.checked)} />
+            画像をサーバと同じ絶対 URL ({SERVER_ASSET_BASE}) にする
+          </label>
+          <div className='flex flex-wrap gap-2'>
+            {registrations.map(info => (
+              <Button key={info.scope} size='sm' variant='outline' onClick={() => void showLocal(info)}>
+                {new URL(info.scope).pathname} で出す
+              </Button>
+            ))}
+          </div>
+        </Section>
+
+        <Section title='サーバ経路' hint='この context の token で購読 / 送信'>
+          <Input
+            className='mb-2 text-12px'
+            placeholder='旅程の URL か urlId'
+            value={urlId}
+            onChange={e => setUrlId(e.target.value)}
+          />
+          <div className='flex flex-wrap gap-2'>
+            <Button size='sm' variant='outline' onClick={() => void callServer('status')}>
+              購読状態
+            </Button>
+            <Button size='sm' variant='outline' onClick={() => void callServer('subscribe')}>
+              購読する
+            </Button>
+            <Button size='sm' variant='outline' onClick={() => void callServer('unsubscribe')}>
+              解除する
+            </Button>
+            <Button size='sm' onClick={() => void callServer('test')}>
+              テスト送信
+            </Button>
+            <Button size='sm' onClick={() => void callServer('test', BACKGROUND_TEST_DELAY_SECONDS)}>
+              {BACKGROUND_TEST_DELAY_SECONDS} 秒後に送信
+            </Button>
+          </div>
+          <Row label='結果' value={serverStatus} />
+        </Section>
+      </div>
+
+      <div className='fixed inset-x-0 bottom-0 flex justify-center gap-2 border-gray-200 border-t bg-white/90 p-2 backdrop-blur-sm'>
+        <CopyButton label='全部コピー' getText={buildDump} />
+        <Button size='sm' variant='outline' onClick={() => void collectRegistrations().then(setRegistrations)}>
+          <RefreshCwIcon />
+          再読込
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export { NotifyDebugPage };

--- a/frontend/src/pages/NotifyDebugPage.tsx
+++ b/frontend/src/pages/NotifyDebugPage.tsx
@@ -32,6 +32,18 @@ const extractUrlId = (input: string): string | null => {
   }
 };
 
+type ServerTarget = { fcmToken: string; tripId: number; headers: Record<string, string> };
+
+/** サーバ経路を叩く前の解決処理。「裏に回したら送信」でも可視のうちにここまで済ませる */
+const resolveTarget = async (input: string): Promise<ServerTarget> => {
+  const id = extractUrlId(input);
+  if (!id) throw new Error('旅程の URL か urlId を入力して');
+  const fcmToken = await fetchFcmToken();
+  if (!fcmToken) throw new Error('FCM トークンが取れない');
+  const trip = await apiClient.get(`/trips/url/${id}`);
+  return { fcmToken, tripId: Number(trip.data.id), headers: { 'X-FCM-Token': fcmToken } };
+};
+
 type RegistrationInfo = {
   registration: ServiceWorkerRegistration;
   scope: string;
@@ -195,14 +207,8 @@ const NotifyDebugPage = () => {
   const callServer = async (action: 'status' | 'subscribe' | 'unsubscribe' | 'test'): Promise<void> => {
     setServerStatus('実行中...');
     try {
-      const id = extractUrlId(urlId);
-      if (!id) throw new Error('旅程の URL か urlId を入力して');
-      const fcmToken = await fetchFcmToken();
-      if (!fcmToken) throw new Error('FCM トークンが取れない');
+      const { fcmToken, tripId, headers } = await resolveTarget(urlId);
       setToken(fcmToken);
-      const trip = await apiClient.get(`/trips/url/${id}`);
-      const tripId = Number(trip.data.id);
-      const headers = { 'X-FCM-Token': fcmToken };
 
       if (action === 'subscribe') {
         await apiClient.post(`/trips/${tripId}/subscription`, {
@@ -229,20 +235,34 @@ const NotifyDebugPage = () => {
    * タイマーで遅延させると background では throttle されて送信タイミングが読めないので、
    * hidden になった瞬間を visibilitychange で捉えて送る。判定条件そのものを trigger にするので
    * 待ち時間の見積もりが要らない。
+   *
+   * token 解決と trip 解決は可視のうちに済ませ、hidden 後に走るのは送信の POST 1 本だけにする。
+   * hidden 直後の凍結は起きないが、非同期の連鎖が短いほど取りこぼしの余地が小さい。
    */
-  const armBackgroundTest = (): void => {
+  const armBackgroundTest = async (): Promise<void> => {
     disarmRef.current?.();
-    const onVisibilityChange = (): void => {
-      if (document.visibilityState !== 'hidden') return;
-      disarmRef.current?.();
-      void callServer('test');
-    };
-    document.addEventListener('visibilitychange', onVisibilityChange);
-    disarmRef.current = () => {
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-      disarmRef.current = null;
-    };
-    setServerStatus('待機中 — アプリを裏に回すと送信します');
+    setServerStatus('準備中...');
+    try {
+      const { fcmToken, tripId, headers } = await resolveTarget(urlId);
+      setToken(fcmToken);
+
+      const onVisibilityChange = (): void => {
+        if (document.visibilityState !== 'hidden') return;
+        disarmRef.current?.();
+        apiClient.post(`/trips/${tripId}/subscription/test`, null, { headers }).then(
+          () => setServerStatus('裏に回った瞬間に送信した'),
+          error => setServerStatus(`送信失敗: ${String(error)}`)
+        );
+      };
+      document.addEventListener('visibilitychange', onVisibilityChange);
+      disarmRef.current = () => {
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        disarmRef.current = null;
+      };
+      setServerStatus(`tripId=${tripId} / 待機中 — アプリを裏に回すと送信します`);
+    } catch (error) {
+      setServerStatus(`失敗: ${String(error)}`);
+    }
   };
 
   return (
@@ -331,7 +351,7 @@ const NotifyDebugPage = () => {
             <Button size='sm' onClick={() => void callServer('test')}>
               テスト送信
             </Button>
-            <Button size='sm' onClick={armBackgroundTest}>
+            <Button size='sm' onClick={() => void armBackgroundTest()}>
               裏に回したら送信
             </Button>
           </div>

--- a/frontend/src/pages/NotifyDebugPage.tsx
+++ b/frontend/src/pages/NotifyDebugPage.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon, RefreshCwIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -19,8 +19,18 @@ import { getDisplayMode, isIOS, isNotificationSupported, isPWAInstalled } from '
 
 /** サーバ (`_frontend_base`) が icon/badge に使う絶対 URL。非 production は stg 固定 */
 const SERVER_ASSET_BASE = 'https://st.tabishare.net';
-/** テスト送信は即時配信なので、SW 経路を試すには裏に回す猶予が要る */
-const BACKGROUND_TEST_DELAY_SECONDS = 10;
+
+/** 旅程 URL 貼り付け / urlId 直打ちのどちらも受ける。trailing slash と query は落とす */
+const extractUrlId = (input: string): string | null => {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  try {
+    const segments = new URL(trimmed, window.location.origin).pathname.split('/').filter(Boolean);
+    return segments.length > 0 ? segments[segments.length - 1] : null;
+  } catch {
+    return null;
+  }
+};
 
 type RegistrationInfo = {
   registration: ServiceWorkerRegistration;
@@ -122,6 +132,9 @@ const NotifyDebugPage = () => {
   const [urlId, setUrlId] = useState('');
   const [serverStatus, setServerStatus] = useState('(未実行)');
 
+  /** 「裏に回したら送信」の待機解除。離脱時に listener を残さないため ref で持つ */
+  const disarmRef = useRef<(() => void) | null>(null);
+
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
     let cancelled = false;
@@ -133,23 +146,25 @@ const NotifyDebugPage = () => {
     };
   }, []);
 
+  useEffect(() => () => disarmRef.current?.(), []);
+
   const env: [string, string][] = [
-    ['env', detectEnv()],
-    ['build ID', DEBUG_LOG_VERSION],
-    ['display-mode', getDisplayMode()],
+    ['環境', detectEnv()],
+    ['ビルドID', DEBUG_LOG_VERSION],
+    ['表示モード', getDisplayMode()],
     ['PWA', String(isPWAInstalled())],
     ['iOS', String(isIOS())],
     ['通知サポート', String(isNotificationSupported())],
-    ['permission', typeof Notification === 'undefined' ? '(Notification なし)' : Notification.permission],
-    ['origin', window.location.origin],
-    ['controller', navigator.serviceWorker?.controller?.scriptURL ?? '(なし)'],
-    ['userAgent', navigator.userAgent],
+    ['通知許可', typeof Notification === 'undefined' ? '(Notification なし)' : Notification.permission],
+    ['オリジン', window.location.origin],
+    ['制御中のSW', navigator.serviceWorker?.controller?.scriptURL ?? '(なし)'],
+    ['UA', navigator.userAgent],
   ];
 
   const buildDump = (): string =>
     [
       ...env.map(([label, value]) => `${label}: ${value}`),
-      `fcmToken: ${token}`,
+      `FCMトークン: ${token}`,
       '',
       ...registrations.flatMap(info => [
         `scope: ${info.scope}`,
@@ -176,24 +191,16 @@ const NotifyDebugPage = () => {
     await info.registration.showNotification(`debug ${path}`, options);
   };
 
-  /**
-   * この context の token でサーバ経路を叩く。
-   * delaySeconds を入れると、押してから裏に回す時間を作れる (可視クライアント 0 = SW 経路)。
-   */
-  const callServer = async (
-    action: 'status' | 'subscribe' | 'unsubscribe' | 'test',
-    delaySeconds = 0
-  ): Promise<void> => {
-    for (let remaining = delaySeconds; remaining > 0; remaining--) {
-      setServerStatus(`${remaining} 秒後に送信 — 今すぐアプリを裏に回して`);
-      await new Promise(resolve => window.setTimeout(resolve, 1000));
-    }
+  /** この context の token でサーバ経路を叩く */
+  const callServer = async (action: 'status' | 'subscribe' | 'unsubscribe' | 'test'): Promise<void> => {
     setServerStatus('実行中...');
     try {
+      const id = extractUrlId(urlId);
+      if (!id) throw new Error('旅程の URL か urlId を入力して');
       const fcmToken = await fetchFcmToken();
       if (!fcmToken) throw new Error('FCM トークンが取れない');
       setToken(fcmToken);
-      const trip = await apiClient.get(`/trips/url/${urlId.trim().split('/').pop()}`);
+      const trip = await apiClient.get(`/trips/url/${id}`);
       const tripId = Number(trip.data.id);
       const headers = { 'X-FCM-Token': fcmToken };
 
@@ -216,6 +223,28 @@ const NotifyDebugPage = () => {
     }
   };
 
+  /**
+   * 「裏に回したら送信」。SW 経路 (可視クライアント 0) を狙うための仕掛け。
+   *
+   * タイマーで遅延させると background では throttle されて送信タイミングが読めないので、
+   * hidden になった瞬間を visibilitychange で捉えて送る。判定条件そのものを trigger にするので
+   * 待ち時間の見積もりが要らない。
+   */
+  const armBackgroundTest = (): void => {
+    disarmRef.current?.();
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState !== 'hidden') return;
+      disarmRef.current?.();
+      void callServer('test');
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    disarmRef.current = () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      disarmRef.current = null;
+    };
+    setServerStatus('待機中 — アプリを裏に回すと送信します');
+  };
+
   return (
     <div className='min-h-dvh bg-teal-50/50 pb-16'>
       <div className='mx-auto max-w-2xl p-3'>
@@ -234,7 +263,7 @@ const NotifyDebugPage = () => {
           {env.map(([label, value]) => (
             <Row key={label} label={label} value={value} />
           ))}
-          <Row label='fcmToken' value={token} />
+          <Row label='FCMトークン' value={token} />
           <Button
             className='mt-2'
             size='sm'
@@ -253,10 +282,13 @@ const NotifyDebugPage = () => {
         <Section title='Service Worker' hint={`${registrations.length} 件`} defaultOpen>
           {registrations.map(info => (
             <div key={info.scope} className='mb-2 last:mb-0'>
-              <Row label='scope' value={`${new URL(info.scope).pathname}${info.isController ? ' (controller)' : ''}`} />
-              <Row label='script' value={info.scriptURL} />
-              <Row label='states' value={info.states} />
-              <Row label='endpoint' value={info.endpoint} />
+              <Row
+                label='スコープ'
+                value={`${new URL(info.scope).pathname}${info.isController ? ' (controller)' : ''}`}
+              />
+              <Row label='スクリプト' value={info.scriptURL} />
+              <Row label='状態' value={info.states} />
+              <Row label='エンドポイント' value={info.endpoint} />
             </div>
           ))}
         </Section>
@@ -299,8 +331,8 @@ const NotifyDebugPage = () => {
             <Button size='sm' onClick={() => void callServer('test')}>
               テスト送信
             </Button>
-            <Button size='sm' onClick={() => void callServer('test', BACKGROUND_TEST_DELAY_SECONDS)}>
-              {BACKGROUND_TEST_DELAY_SECONDS} 秒後に送信
+            <Button size='sm' onClick={armBackgroundTest}>
+              裏に回したら送信
             </Button>
           </div>
           <Row label='結果' value={serverStatus} />


### PR DESCRIPTION
## サマリ

実機（特に Android PWA）で通知の挙動を切り分けるためのデバッグページを追加する。DevTools を繋げない環境で「今この context がどうなっているか」と「手で通知を撃つ手段」を用意するのが目的。

#233 の調査で必要になって作ったもの。**#233 の原因自体は #218 (`6b4bfc0`) で修正済み・v2026.08.08 で本番反映済み**と判明したため、このPRは調査ツールだけを恒久化する。

<details>
<summary>#233 の原因（参考）</summary>

FCM の SW は可視クライアントが 1 つでもあると自分では表示せずページに postMessage する（`@firebase/messaging` の `onPush`）。`6b4bfc0` 以前の `useForegroundNotificationToast` は `showNotification` に `icon`/`badge` を渡していなかったため、**サイトをブラウザで開いている間だけ**通知が Chrome 既定アイコンで出ていた。バッジ未指定時に Chrome Android が `R.drawable.ic_chrome` にフォールバックするのが「バッジがブラウザのになる」の正体。

本番は 07-31〜08-08 の間このコードで動いており、インストール済み PWA は SW 更新まで古いバンドルを返し続けるため、リリース後もしばらく症状が残る。現在は stg / preview とも再現しないことを実機で確認済み。

</details>

## やったこと

`/debug/notify` に 4 セクション。導線は HomeMenu（3 点リーダ）の「デバッグ > 通知デバッグ」で、**デバッグモード有効時のみ**表示する。

| セクション | 用途 |
|---|---|
| 環境 | display-mode / permission / FCM token / **build ID** |
| Service Worker | 登録ごとの scope / script / state / **push endpoint** |
| ローカル通知 | FCM を経由せず scope 別に `showNotification` |
| サーバ経路 | その context の token だけで購読 / 解除 / テスト送信 |

あわせて `useForegroundNotificationToast` に `debugLog` を 1 行追加した。

## 設計判断

- **導線をメニューに置いた**: PWA はアドレスバーが無く URL 直打ちできないので、導線が無いと PWA 側でページを開けない（実際に踏んだ）。デバッグモード（#217）のフラグにぶら下げて、通常利用では見えないようにしている
- **ログは持たず #217 の診断ロガーに寄せた**: 当初は独自の localStorage ログを持っていたが、develop に汎用ロガーが入ったので破棄。`[FCM] foreground message` の行の有無だけで「ページ経路か SW 経路か」が判るので、これで足りる。build ID も同じ仕組みに乗るので「古い SW が動いたまま」の判別が効く
- **ローカル通知を FCM 非経由にした**: FCM を挟むと「配送」と「表示」のどちらの問題か切り分けられない。`registration.showNotification` を直接叩けば OS 帰属だけを見られる。scope 別に出せるのは、Chrome の WebAPK 委譲が SW の scope だけで決まるため（`NotificationPlatformBridge.getWebApkPackage(scopeUrl)`）
- **画像を絶対 URL にするトグル**: サーバは icon/badge を `_frontend_base()` の絶対 URL で送るため、preview から見るとクロスオリジンになる。ローカル通知は同一オリジンの相対パスなので、そのままだとこの差が試せない
- **遅延テスト送信**: テスト送信は即時配信なので、押した時点では必ず可視クライアントがいて前景経路にしかならない。10 秒待つことで裏に回す猶予を作り、SW 経路を狙える

Refs #233, #217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 通知デバッグ画面を追加しました。環境情報、Service Worker、通知購読、FCMトークンを確認・コピーできます。
  * ローカル通知の表示、購読状態の確認、テスト送信、遅延送信に対応しました。
  * デバッグ設定が有効な場合、ホームメニューからアクセスできます。
  * PWAの表示モードや通知受信状況を確認できるようになりました。

* **ドキュメント**
  * 通知デバッグ画面の利用方法と診断手順を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->